### PR TITLE
feat: add FastMCP v3 compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Skills, commands, and MCP tools for AI coding assistants"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "fastmcp>=2.0.0,<3",
+    "fastmcp>=2.0.0,<4",
     "fastapi>=0.100.0",
 ]
 

--- a/scripts/check_dependabot_coverage.py
+++ b/scripts/check_dependabot_coverage.py
@@ -28,7 +28,7 @@ MANIFEST_ECOSYSTEMS = {
 }
 
 # Directories to skip (node_modules, vendored code, etc.)
-SKIP_DIRS = {"node_modules", ".venv", "venv", "vendor", "__pycache__", ".git"}
+SKIP_DIRS = {"node_modules", ".venv", "venv", "vendor", "__pycache__", ".git", ".claude"}
 
 # Directories whose manifests are covered by a parent directory's entry
 # (e.g. spellbook_mcp/requirements.txt is covered by the root pip entry)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,15 @@ if str(project_root) not in sys.path:
     sys.path.insert(0, str(project_root))
 
 
+def get_tool_fn(tool):
+    """Get the callable function from a FastMCP tool, compatible with both v2 and v3.
+
+    In FastMCP v2, @mcp.tool() returns a FunctionTool object with a .fn attribute.
+    In FastMCP v3, @mcp.tool() returns the original function directly.
+    """
+    return getattr(tool, "fn", tool)
+
+
 def pytest_addoption(parser):
     parser.addoption(
         "--run-docker",

--- a/tests/test_ab_test_mcp.py
+++ b/tests/test_ab_test_mcp.py
@@ -5,15 +5,9 @@ import pytest
 
 def _get_tool_names():
     """Get tool names from the FastMCP server's internal tool registry."""
-    from spellbook_mcp.server import mcp
+    from spellbook_mcp.server import _get_tool_names as server_get_tool_names
 
-    # FastMCP 2.x stores registered tools in _tool_manager._tools dict.
-    # This mirrors the approach used in server.py's own _get_tool_names().
-    try:
-        return list(mcp._tool_manager._tools.keys())
-    except AttributeError:
-        # Fallback: empty list if internal structure changes
-        return []
+    return server_get_tool_names()
 
 
 class TestABTestMCPTools:

--- a/tests/unit/test_update_tools.py
+++ b/tests/unit/test_update_tools.py
@@ -665,14 +665,21 @@ class TestCheckForUpdatesMCPTool:
 
     def test_tool_function_importable(self):
         """Verify spellbook_check_for_updates can be imported from server module."""
-        from fastmcp.tools.tool import FunctionTool
-        from spellbook_mcp.server import spellbook_check_for_updates
-        assert isinstance(spellbook_check_for_updates, FunctionTool)
+        from spellbook_mcp.server import spellbook_check_for_updates, _FASTMCP_MAJOR
+        if _FASTMCP_MAJOR >= 3:
+            # In v3, @mcp.tool() returns the original function (with .fn compat shim)
+            assert callable(spellbook_check_for_updates)
+        else:
+            from fastmcp.tools.tool import FunctionTool
+            assert isinstance(spellbook_check_for_updates, FunctionTool)
         assert callable(spellbook_check_for_updates.fn)
 
     def test_status_tool_function_importable(self):
         """Verify spellbook_get_update_status can be imported from server module."""
-        from fastmcp.tools.tool import FunctionTool
-        from spellbook_mcp.server import spellbook_get_update_status
-        assert isinstance(spellbook_get_update_status, FunctionTool)
+        from spellbook_mcp.server import spellbook_get_update_status, _FASTMCP_MAJOR
+        if _FASTMCP_MAJOR >= 3:
+            assert callable(spellbook_get_update_status)
+        else:
+            from fastmcp.tools.tool import FunctionTool
+            assert isinstance(spellbook_get_update_status, FunctionTool)
         assert callable(spellbook_get_update_status.fn)


### PR DESCRIPTION
## Summary

- Add version detection and compatibility shim for FastMCP v2 and v3
- In v3, `@mcp.tool()` returns the original function instead of `FunctionTool`, and tool storage moved from `_tool_manager._tools` to `_local_provider._components`
- Add `.claude` to `SKIP_DIRS` in `check_dependabot_coverage.py` to prevent worktree directories from triggering false positives
- Supersedes #28 (dependabot fastmcp bump that was failing tests)

## Test plan

- [x] Targeted tests pass locally (121/121)
- [ ] CI passes on all platforms (Ubuntu, macOS, Windows)
- [ ] Verify tools still register correctly with fastmcp v3