### PR TITLE
Clarify circuit breaker budget wording in crystallize command

### DIFF
--- a/commands/crystallize.md
+++ b/commands/crystallize.md
@@ -597,7 +597,7 @@ IF verify_iterations == max_verify_iterations AND verdict != PASS:
     DO NOT deliver until user resolves
 ```
 
-**Total circuit breaker budget:** The process includes two iterative review phases. Phase 4.5 (self-review) runs for up to 3 iterations. If it passes, the Pre-Delivery Adversarial Review runs for up to 3 iterations. This results in a total of 1 to 6 loop executions before delivery or HALT.
+**Total circuit breaker budget:** The process includes two iterative review phases. Phase 4.5 (self-review) runs for up to 3 iterations. If it passes, the Pre-Delivery Adversarial Review runs for up to 3 iterations. This results in a total of 2 to 6 loop executions before delivery or HALT.
 
 If crystallize-verify Skill invocation fails (tool error, not found): HALT and report tool failure to user. Do NOT skip. This is a delivery gate, not optional.
 

--- a/docs/commands/crystallize.md
+++ b/docs/commands/crystallize.md
@@ -675,7 +675,7 @@ IF verify_iterations == max_verify_iterations AND verdict != PASS:
     DO NOT deliver until user resolves
 ```
 
-**Total circuit breaker budget:** The process includes two iterative review phases. Phase 4.5 (self-review) runs for up to 3 iterations. If it passes, the Pre-Delivery Adversarial Review runs for up to 3 iterations. This results in a total of 1 to 6 loop executions before delivery or HALT.
+**Total circuit breaker budget:** The process includes two iterative review phases. Phase 4.5 (self-review) runs for up to 3 iterations. If it passes, the Pre-Delivery Adversarial Review runs for up to 3 iterations. This results in a total of 2 to 6 loop executions before delivery or HALT.
 
 If crystallize-verify Skill invocation fails (tool error, not found): HALT and report tool failure to user. Do NOT skip. This is a delivery gate, not optional.
 


### PR DESCRIPTION
## Summary

- Reword the total circuit breaker budget description in `commands/crystallize.md` to clearly explain the two-phase structure (Phase 4.5 self-review + Pre-Delivery Adversarial Review) and the range of 1 to 6 total loop executions

## Context

Addresses unresolved Gemini feedback from PR #56 (two medium-severity comments on circuit breaker budget wording).

## Test plan

- [ ] Verify wording is clear and accurate
- [ ] Confirm docs auto-generated correctly