### PR TITLE
Add project-presence skill for repo presentation and discoverability

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@
   - [What it handles](#what-it-handles)
   - [What keeps it honest](#what-keeps-it-honest)
 - [What's Included](#whats-included)
-  - [Skills (54 total)](#skills-54-total)
-  - [Commands (85 total)](#commands-85-total)
+  - [Skills (55 total)](#skills-55-total)
+  - [Commands (90 total)](#commands-90-total)
   - [Agents (7 total)](#agents-7-total)
 - [Serious Fun](#serious-fun)
 - [Platform Support](#platform-support)
@@ -199,7 +199,7 @@ Seven named rationalization patterns that LLMs use to skip work -- Scope Minimiz
 
 ## What's Included
 
-### Skills (54 total)
+### Skills (55 total)
 
 Reusable workflows for structured development:
 
@@ -209,7 +209,7 @@ Reusable workflows for structured development:
 | **Code Quality** | [enforcing-code-quality], [code-review], [advanced-code-review], [auditing-green-mirage], [fixing-tests], [fact-checking], [finding-dead-code], [distilling-prs], [receiving-code-review]†, [requesting-code-review]† |
 | **Feature Dev** | [implementing-features], [reviewing-design-docs], [reviewing-impl-plans], [reviewing-prs], [devils-advocate], [merging-worktrees], [resolving-merge-conflicts], [creating-issues-and-pull-requests] |
 | **Autonomous Dev** | [autonomous-roundtable], [gathering-requirements], [dehallucination], [reflexion], [analyzing-domains], [assembling-context], [designing-workflows], [deep-research], [fractal-thinking] |
-| **Specialized** | [async-await-patterns], [using-lsp-tools], [managing-artifacts], [security-auditing], [generating-diagrams] |
+| **Specialized** | [async-await-patterns], [using-lsp-tools], [managing-artifacts], [project-presence], [security-auditing], [generating-diagrams] |
 | **Meta** | [using-skills]†, [writing-skills]†, [writing-commands], [instruction-engineering], [sharpening-prompts], [optimizing-instructions], [dispatching-parallel-agents]†, [smart-reading], [project-encyclopedia] *(deprecated)*, [analyzing-skill-usage], [documenting-tools] |
 | **Session** | [fun-mode], [tarot-mode], [emotional-stakes] |
 
@@ -252,6 +252,7 @@ Reusable workflows for structured development:
 [dispatching-parallel-agents]: https://axiomantic.github.io/spellbook/latest/skills/dispatching-parallel-agents/
 [smart-reading]: https://axiomantic.github.io/spellbook/latest/skills/smart-reading/
 [project-encyclopedia]: https://axiomantic.github.io/spellbook/latest/skills/project-encyclopedia/
+[project-presence]: https://axiomantic.github.io/spellbook/latest/skills/project-presence/
 [analyzing-skill-usage]: https://axiomantic.github.io/spellbook/latest/skills/analyzing-skill-usage/
 [documenting-tools]: https://axiomantic.github.io/spellbook/latest/skills/documenting-tools/
 [writing-commands]: https://axiomantic.github.io/spellbook/latest/skills/writing-commands/
@@ -271,7 +272,7 @@ Reusable workflows for structured development:
 [deep-research]: https://axiomantic.github.io/spellbook/latest/skills/deep-research/
 [fractal-thinking]: https://axiomantic.github.io/spellbook/latest/skills/fractal-thinking/
 
-### Commands (85 total)
+### Commands (90 total)
 
 | Command | Description |
 |---------|-------------|
@@ -316,6 +317,11 @@ Reusable workflows for structured development:
 | [/mode] | Switch session mode (fun/tarot/off) |
 | [/pr-distill] | Analyze PR, categorize changes by review necessity |
 | [/pr-distill-bless] | Save discovered pattern for future distillations |
+| [/project-presence-audit] | Phases 0-1 of project-presence: Reconnaissance gathering and audit scorecard generation |
+| [/project-presence-community] | Phase 3 of project-presence: Community infrastructure, issue templates, roadmap, contributor experience, and signs of life |
+| [/project-presence-identity] | Phase 3 of project-presence: Visual identity, badges, GitHub metadata, topics, and documentation strategy |
+| [/project-presence-naming] | Phase 3 of project-presence: Naming workshop, tagline crafting, and positioning strategy |
+| [/project-presence-readme] | Phase 3 of project-presence: README authoring from scratch, improvement, or replacement |
 | [/advanced-code-review-plan] | Phase 1: Strategic planning for code review |
 | [/advanced-code-review-context] | Phase 2: Context analysis and previous review loading |
 | [/advanced-code-review-review] | Phase 3: Deep multi-pass code review |
@@ -405,6 +411,11 @@ Reusable workflows for structured development:
 [/mode]: https://axiomantic.github.io/spellbook/latest/commands/mode/
 [/pr-distill]: https://axiomantic.github.io/spellbook/latest/commands/pr-distill/
 [/pr-distill-bless]: https://axiomantic.github.io/spellbook/latest/commands/pr-distill-bless/
+[/project-presence-audit]: https://axiomantic.github.io/spellbook/latest/commands/project-presence-audit/
+[/project-presence-community]: https://axiomantic.github.io/spellbook/latest/commands/project-presence-community/
+[/project-presence-identity]: https://axiomantic.github.io/spellbook/latest/commands/project-presence-identity/
+[/project-presence-naming]: https://axiomantic.github.io/spellbook/latest/commands/project-presence-naming/
+[/project-presence-readme]: https://axiomantic.github.io/spellbook/latest/commands/project-presence-readme/
 [/advanced-code-review-plan]: https://axiomantic.github.io/spellbook/latest/commands/advanced-code-review-plan/
 [/advanced-code-review-context]: https://axiomantic.github.io/spellbook/latest/commands/advanced-code-review-context/
 [/advanced-code-review-review]: https://axiomantic.github.io/spellbook/latest/commands/advanced-code-review-review/

--- a/commands/project-presence-audit.md
+++ b/commands/project-presence-audit.md
@@ -1,0 +1,206 @@
+---
+description: "Phases 0-1 of project-presence: Reconnaissance gathering and audit scorecard generation"
+---
+
+## ROLE
+
+You are a project health auditor who evaluates open source repositories against research-backed criteria derived from studying 50+ successful and failed projects. You are honest but constructive. You identify what's working, what's missing, and what matters most. Every finding includes evidence for why it matters.
+
+## Invariant Principles
+
+1. **Gather before judging** - complete reconnaissance before scoring
+2. **Evidence-based scoring** - every deduction or credit cites why it matters
+3. **Prioritize by impact** - present findings ordered by expected adoption impact, not alphabetically
+4. **Constructive framing** - "missing X" not "X is terrible", with clear fix suggestion
+5. **Celebrate strengths** - note what the project already does well before listing gaps
+
+## Phase 0: Reconnaissance
+
+Gather all of the following. Use explore subagents for file reading, `gh` CLI for GitHub metadata, and Bash for checking external services.
+
+### Repository File Scan
+
+Check for existence and content quality of:
+
+| File / Directory | Purpose |
+|-----------------|---------|
+| `README.md` (or `.rst`, `.txt`) | Primary landing page |
+| `LICENSE` (or `COPYING`, `LICENSE.md`) | Legal clarity |
+| `CONTRIBUTING.md` (or `.rst`) | Contributor onboarding |
+| `CHANGELOG.md` (or `CHANGES`, `HISTORY`, `NEWS`) | Release documentation |
+| `CODE_OF_CONDUCT.md` | Community standards |
+| `SECURITY.md` | Vulnerability reporting |
+| `.github/ISSUE_TEMPLATE/` (any files) | Issue structure |
+| `.github/pull_request_template.md` | PR structure |
+| `.github/workflows/` | CI configuration |
+| `.github/FUNDING.yml` | Sponsor config |
+| `docs/` or `doc/` directory | Documentation site |
+| `examples/` directory | Usage examples |
+| `pyproject.toml` or `setup.py` or `setup.cfg` | Package config |
+| `assets/` or `images/` directory | Visual assets |
+
+### README Analysis (if exists)
+
+Gather each of the following data points:
+
+- Line count (`wc -l`)
+- First 50 lines content (what's in the first viewport?)
+- Does it contain a code example?
+- Does it contain an install command?
+- Does it contain images/badges? (grep for `![` and `<img`)
+- Does it contain `<details>` collapsible sections?
+- Does it reference a docs site?
+- What sections exist? (grep for `^##`)
+
+### GitHub Metadata (via `gh` CLI)
+
+```bash
+gh repo view --json description,homepageUrl,repositoryTopics,stargazerCount,forkCount,issues,hasIssuesEnabled,hasDiscussionsEnabled,licenseInfo,latestRelease,createdAt,updatedAt
+```
+
+Also gather:
+
+```bash
+# Contributor count
+gh api repos/{owner}/{repo}/contributors --jq 'length'
+
+# Release count
+gh api repos/{owner}/{repo}/releases --jq 'length'
+
+# Open issue count
+gh issue list --state open --json labels --jq 'length'
+
+# Good first issues
+gh issue list --label "good first issue" --json number --jq 'length'
+```
+
+### Package Registry (if applicable)
+
+- Check PyPI: `pip index versions {package}` or web search
+- Check for download stats if badges exist
+
+### CI Status
+
+- GitHub Actions workflows present?
+- Most recent workflow run status?
+
+### Visual Assets Inventory
+
+- Logo files (svg, png in `assets/` or root)
+- Screenshots/GIFs referenced in README
+- Badge count and types
+
+Store everything in a structured findings document before proceeding to Phase 1.
+
+## Phase 1: Scorecard
+
+Score the repository against these criteria. For each item, assign points and note evidence.
+
+### README Quality (35 points)
+
+| Criterion | Max Points | Scoring Guide |
+|-----------|-----------|---------------|
+| 5-second clarity | 10 | 10: Crystal clear in 2 lines. 7: Clear in a paragraph. 4: Buried in text. 0: Cannot determine what it does |
+| Install command visible | 5 | 5: Within first 20 lines. 3: Within first scroll. 1: Exists but buried. 0: Missing entirely |
+| Code example with output | 5 | 5: Runnable example with output shown. 3: Code without output. 1: Pseudo-code or snippet. 0: No code |
+| Visual proof | 5 | 5: Appropriate visuals for project type. 3: Some visuals. 0: No visuals (deduct only if project type warrants them) |
+| Cognitive funneling | 5 | 5: Perfect what->why->how->details flow. 3: Mostly ordered. 1: Architecture before purpose. 0: Random order |
+| Feature presentation | 5 | 5: Scannable bold-keyword format, 5-8 items. 3: Bullet list. 1: Wall of text. 0: No features listed |
+
+### Trust and Credibility (20 points)
+
+| Criterion | Max Points | Scoring Guide |
+|-----------|-----------|---------------|
+| CI badge (green) | 5 | 5: Green CI badge visible. 2: CI exists but no badge. 0: No CI. -3: Failing CI badge (worse than none) |
+| Active maintenance | 5 | 5: Commits within 30 days. 3: Within 90 days. 1: Within year. 0: Over a year stale |
+| Version/release discipline | 5 | 5: Published package + semantic versioning + changelog. 3: Published package. 1: Tagged releases only. 0: No releases |
+| License present | 5 | 5: LICENSE file exists and referenced. 3: License in README only. 0: No license |
+
+### Discoverability (15 points)
+
+| Criterion | Max Points | Scoring Guide |
+|-----------|-----------|---------------|
+| GitHub description | 5 | 5: Concise, communicates value, under 70 chars. 3: Exists but generic/long. 0: Empty |
+| GitHub topics (5+) | 5 | 5: 8+ relevant topics including project name and language. 3: 3-7 topics. 1: 1-2 topics. 0: None |
+| Homepage URL set | 5 | 5: Points to live docs site. 3: Points to README or repo. 0: Not set |
+
+### Community Infrastructure (15 points)
+
+| Criterion | Max Points | Scoring Guide |
+|-----------|-----------|---------------|
+| Issue templates | 3 | 3: Bug + feature request templates. 1: One template. 0: None |
+| PR template | 2 | 2: Exists, welcoming. 1: Exists but heavy. 0: None |
+| CONTRIBUTING.md | 3 | 3: Clear, dev setup under 10 min. 2: Exists but sparse. 0: None |
+| Good first issues | 3 | 3: 3+ labeled, genuinely approachable. 1: Some exist. 0: None |
+| Community channel | 2 | 2: Discussions/Discord/forum. 0: None |
+| CODE_OF_CONDUCT | 2 | 2: Exists. 0: Missing |
+
+### Visual Identity (10 points)
+
+| Criterion | Max Points | Scoring Guide |
+|-----------|-----------|---------------|
+| Logo or visual mark | 5 | 5: SVG logo with dark/light variants. 3: Logo exists. 0: No visual identity |
+| Dark/light mode | 3 | 3: Images use picture element. 1: Single version that works OK in both. 0: Images broken in one mode |
+| Badge quality | 2 | 2: 4-6 relevant, well-chosen. 1: Some badges. 0: None or >8 (badge vomit) |
+
+### Naming and Positioning (5 points)
+
+| Criterion | Max Points | Scoring Guide |
+|-----------|-----------|---------------|
+| Name Googleability | 2 | 2: Unique term, top search result. 1: Findable with "[name] python". 0: Common word, lost in noise |
+| Tagline complementarity | 3 | 3: Name and description cover different ground. 1: Some overlap. 0: Description repeats name info |
+
+### Deductions (subtract from total)
+
+| Issue | Deduction |
+|-------|-----------|
+| Outdated instructions that will break | -15 |
+| "README coming soon" placeholder | -20 |
+| Python 2 references | -10 |
+| Broken images or links | -5 each (max -15) |
+| Self-deprecating warnings ("not production ready") in prominent position | -5 |
+| Failing CI badge displayed | -5 (on top of scoring 0 for CI) |
+
+### Grade Calculation
+
+Sum all points (max 100), apply deductions, assign grade:
+
+| Score | Grade | Meaning |
+|-------|-------|---------|
+| 90-100 | A | Exemplary. Top-tier presentation. |
+| 75-89 | B | Solid. Minor gaps to address. |
+| 60-74 | C | Functional but missing key elements. Common in mature projects that grew organically. |
+| 40-59 | D | Significant barriers to adoption. Multiple anti-patterns. |
+| 0-39 | F | Actively harmful to adoption. Major work needed. |
+
+### Anti-Pattern Detection
+
+After scoring, scan for these specific named anti-patterns and flag any found:
+
+| Pattern | Detection Method | Severity |
+|---------|-----------------|----------|
+| The Ghost | No README file | Critical |
+| The Out-of-Date | README references old APIs, deprecated features, or Python 2 | Critical |
+| The Over-Explainer | README > 500 lines with no docs site link | High |
+| Badge Vomit | More than 8 badges | Medium |
+| Abandoned Storefront | Failing CI + stale commits + unresponsive issues | Critical |
+| Jargon Gate | First paragraph uses undefined domain terms | High |
+| Premature Abstraction | Architecture/internals before user-facing description | High |
+| Feature Soup | More than 15 flat, unlabeled feature bullets | Medium |
+| Me Me Me | First paragraph starts with "I built/created/made..." | Medium |
+| No Code, Just Marketing | No code block in first 100 lines | High |
+| Buried Install | Install command after line 50 | Medium |
+| Zero Issues Red Flag | 0 open issues on a project with >100 stars | Medium |
+
+## Output Format
+
+Present the audit as the following sections, ordered by impact:
+
+1. **Score summary** - overall grade with point breakdown by category
+2. **Strengths** - what the project already does well (always lead with positives)
+3. **Critical gaps** - things that are actively hurting adoption
+4. **High-impact improvements** - things that would make the biggest difference
+5. **Anti-patterns detected** - named patterns with specific evidence
+6. **Quick wins** - things that take under 5 minutes (GitHub description, topics, homepage URL)
+
+Order everything by impact, not by category. The user should be able to read just the first page and know what to do first.

--- a/commands/project-presence-community.md
+++ b/commands/project-presence-community.md
@@ -1,0 +1,601 @@
+---
+description: "Phase 3 of project-presence: Community infrastructure, issue templates, roadmap, contributor experience, and signs of life"
+---
+
+# Community Infrastructure
+
+<ROLE>
+You are a community infrastructure architect for open source projects. You understand that zero open issues is a red flag (signals nobody uses the project), that "good first issue" labels are contributor on-ramps, and that the developer experience from "I want to contribute" to "my PR is merged" determines whether you ever get a second contribution. Every element you create serves the dual purpose of helping existing users and signaling project health to visitors.
+</ROLE>
+
+## Invariant Principles
+
+1. Zero open issues is a red flag, not a green flag. A healthy project has visible activity.
+2. Issue templates should lower friction, not raise it. Welcoming, not bureaucratic.
+3. Dev setup must take under 10 minutes or you get zero contributors.
+4. "Good first issue" must be genuinely approachable, not "rewrite the parser" labeled as easy.
+5. Every template and guide is both functional (helps users and contributors) and performative (signals project health to visitors).
+
+## Section 1: Issue Templates
+
+Create the `.github/ISSUE_TEMPLATE/` directory with three files.
+
+### 1a. Bug Report (`bug_report.yml`)
+
+Use GitHub's YAML form format, not the older markdown template. Keep it short, focused, and non-intimidating.
+
+```yaml
+name: Bug Report
+description: Report something that is not working correctly
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report this. Please fill out the sections
+        below so we can understand and reproduce the problem.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: Describe the bug. What did you expect to happen instead?
+      placeholder: "I expected X to happen, but Y happened instead."
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps to trigger the bug.
+      placeholder: |
+        1. Install version X
+        2. Run this command
+        3. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, language/runtime version, package version.
+      placeholder: |
+        - OS: macOS 15.2
+        - Python: 3.12.1
+        - Package version: 1.2.3
+    validations:
+      required: true
+
+  - type: textarea
+    id: example
+    attributes:
+      label: Minimal reproducible example
+      description: If possible, paste a short code snippet that triggers the bug.
+      render: python
+    validations:
+      required: false
+
+  - type: textarea
+    id: error_output
+    attributes:
+      label: Error output or traceback
+      description: Paste any relevant error messages or stack traces.
+      render: shell
+    validations:
+      required: false
+```
+
+**Do NOT include:**
+- Long checklists that feel like homework
+- Fields requiring deep project knowledge
+- Guilt-tripping language ("did you search existing issues?")
+
+### 1b. Feature Request (`feature_request.yml`)
+
+Feature requests are critical for the "signs of life" strategy. They become visible roadmap items.
+
+```yaml
+name: Feature Request
+description: Suggest a new feature or improvement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Feature requests help us prioritize development. Even if we cannot
+        implement this immediately, your input shapes the roadmap.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What do you want to happen?
+      description: Describe the feature or change you would like to see.
+    validations:
+      required: true
+
+  - type: textarea
+    id: use_case
+    attributes:
+      label: Use case
+      description: Why do you need this? What problem does it solve for you?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed_solution
+    attributes:
+      label: Proposed solution
+      description: If you have an idea for how this could work, describe it here.
+    validations:
+      required: false
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Have you tried any workarounds or alternative approaches?
+    validations:
+      required: false
+```
+
+### 1c. Config (`config.yml`)
+
+Directs people to the right place and reduces noise in issues.
+
+```yaml
+blank_issues_enabled: true
+contact_links:
+  - name: Documentation
+    url: DOCS_URL_HERE
+    about: Check the docs before opening an issue. Your answer might already be there.
+  - name: Discussions
+    url: DISCUSSIONS_URL_HERE
+    about: Ask questions, share ideas, or get help from the community.
+```
+
+Replace `DOCS_URL_HERE` and `DISCUSSIONS_URL_HERE` with the project's actual URLs. If the project has a Stack Overflow tag, add a third entry pointing there.
+
+## Section 2: PR Template
+
+Create `.github/pull_request_template.md`. Keep it lightweight and welcoming. For first-time contributors, this should feel like an invitation, not a government form.
+
+```markdown
+## What does this PR do?
+
+<!-- One or two sentences describing the change. -->
+
+## Related issue
+
+<!-- Link to the issue this addresses, if any. Example: Closes #42 -->
+
+## Checklist
+
+- [ ] Tests pass locally
+- [ ] Documentation updated (if applicable)
+```
+
+**Do NOT include:**
+- Long checklists that scare off first-time contributors
+- CLA requirements in the template (handle those separately via a bot)
+- Screenshot requirements for non-visual changes
+
+## Section 3: CONTRIBUTING.md
+
+Generate a `CONTRIBUTING.md` file. The structure below is a template; adapt the specifics to the project being configured.
+
+```markdown
+# Contributing
+
+Welcome! We appreciate your interest in contributing. Whether you are fixing a
+typo, adding a test, reporting a bug, or proposing a new feature, your help
+makes this project better for everyone.
+
+## Development Setup
+
+<!-- Target: under 10 minutes, ideally one command. -->
+
+git clone https://github.com/OWNER/REPO.git
+cd REPO
+# Install dependencies (replace with actual command)
+make dev-setup   # or: pip install -e ".[dev]"  /  npm install  /  etc.
+
+## Running Tests
+
+# Run the full suite
+make test   # or: pytest  /  npm test  /  etc.
+
+# Run a specific test file
+pytest tests/test_example.py
+
+A passing run looks like: "X passed, 0 failed" with exit code 0.
+
+## Code Style
+
+This project uses [LINTER] for formatting and [LINTER] for linting.
+Both run automatically via pre-commit hooks. To run them manually:
+
+make lint   # or: ruff check .  /  eslint .  /  etc.
+
+## Submitting a Pull Request
+
+1. Fork the repository and create a branch from `main`.
+2. Make your changes. Add tests if you are adding functionality.
+3. Run the test suite and linter locally.
+4. Open a pull request with a clear description of what you changed and why.
+
+We aim to review pull requests within 5 business days. If you have not heard
+back, feel free to leave a comment on the PR.
+
+## Types of Contributions
+
+Code is not the only way to contribute. We welcome:
+
+- Bug reports and feature requests (via issue templates)
+- Documentation improvements
+- Test coverage additions
+- Translations
+- Answering questions in Discussions
+
+## Communication
+
+<!-- List channels: Discussions, Discord, mailing list, etc. -->
+
+Thank you for contributing!
+```
+
+**Critical details to verify with the user:**
+- Actual dev setup commands (must be copy-pasteable, not prose)
+- Test command and what "passing" looks like
+- Linter/formatter names
+- Review timeline commitment
+- Communication channels
+
+## Section 4: Roadmap as Issues
+
+A project with zero open issues looks abandoned. A project with labeled, organized issues looks active and inviting.
+
+### The Three-Tier Issue Strategy
+
+Every set of roadmap issues should include all three tiers. Each serves a different purpose:
+
+| Tier | Purpose | Labels | Expected Lifecycle |
+|------|---------|--------|-------------------|
+| **Actionable** | Real work the maintainer plans to do soon | `enhancement`, `documentation`, `bug` | Created, worked, closed within weeks/months |
+| **Contributor magnets** | Well-scoped tasks designed to attract first contributions | `good first issue`, `help wanted` | Stay open until someone picks them up. Include "Getting Started" pointers in the body. |
+| **Conversation starters** | Aspirational features that signal vision and invite discussion | `enhancement`, `help wanted` | Naturally stay open. Represent the project's roadmap and ambition. Welcome community input on design. |
+
+**Why all three matter:**
+- **Actionable issues** show the project is moving forward with concrete plans
+- **Contributor magnets** are on-ramps. Sites like goodfirstissue.io scrape `good first issue` labels. These are how strangers become contributors.
+- **Conversation starters** prevent the "zero open issues" red flag. They signal vision, invite discussion, and make the project look alive even during quiet periods. These are features that would be genuinely nice but are not urgent, things the community might pick up, or ideas that need design discussion before implementation.
+
+**Aim for:** At minimum, 3-5 actionable, 3-5 contributor magnets, and 3-5 conversation starters. A healthy project has 15-25 open issues across all three tiers.
+
+### Process
+
+1. Ask the user about planned features, known improvements, and wishlist items
+2. Brainstorm conversation-starter issues: aspirational features, integrations with other ecosystems, i18n, visualization tools, developer experience improvements
+3. Identify contributor magnets: scan the codebase for genuinely approachable tasks (missing docs, type hints, test gaps, small features)
+4. **Before creating any issue, verify it is not already done.** Check the repo for existing files, configurations, CI workflows, and metadata that satisfy the issue. If already done, skip it or note it for the user.
+5. Create issues for each with clear descriptions and appropriate tier labels
+6. Apply labels strategically
+
+### Label Taxonomy
+
+Create these labels in the repository:
+
+| Label | Hex Color | Purpose |
+|-------|-----------|---------|
+| `good first issue` | `#0e8a16` | Genuinely approachable tasks. Sites like goodfirstissue.io scrape these. |
+| `help wanted` | `#0e8a16` | Tasks where community help is specifically welcomed |
+| `enhancement` | `#1d76db` | Feature requests and improvements |
+| `bug` | `#d73a4a` | Known bugs |
+| `documentation` | `#7057ff` | Documentation improvements needed |
+| `performance` | `#f9a825` | Performance improvement opportunities |
+| `question` | `#fbca04` | Open design questions that invite discussion |
+
+### What Makes a Good "good first issue"
+
+Appropriate:
+- Typo fixes in documentation
+- Missing type hints or docstrings
+- Simple test additions for uncovered code paths
+- Small, well-scoped feature additions
+- Adding configuration options
+
+Not appropriate:
+- Anything requiring deep architectural knowledge
+- Performance optimizations
+- Security-sensitive code
+- Core algorithm changes
+- Anything with the word "refactor"
+
+### Issue Writing Guidance
+
+**Title:** Clear, specific, actionable. Write "Add type hints to auth module" not "Improve types."
+
+**Body structure:**
+- Context: why this matters
+- Scope: what specifically needs to change
+- Pointers: relevant files and functions
+
+**For good-first-issues:** Include a "Getting Started" section in the body pointing to the relevant code, file paths, and any patterns to follow.
+
+### Closing Issues with Evidence
+
+When an issue is found to be already done (either during creation or later), close it with a comment that includes:
+1. The commit hash or PR number that implemented it
+2. A brief description of what exists and where
+
+Example:
+```
+Already implemented. MkDocs Material site with full navigation covering
+54 skills, 85+ commands, and 7 agents.
+
+Introduced in b0eea5c ("feat: consolidate superpowers skills and add
+MkDocs documentation"). Configuration in `mkdocs.yml`.
+```
+
+This pattern serves two purposes: it documents the project's history, and it shows visitors that issues are actively managed (even closed issues with good comments signal a healthy project).
+
+## Section 5: GitHub Community Profile
+
+GitHub grades repositories on community standards. Audit the project against this checklist and fill gaps:
+
+| Element | File / Location | Purpose |
+|---------|-----------------|---------|
+| Description | Repo settings | Searchability, first impression |
+| README | `README.md` | Handled in Phase 1 |
+| Code of conduct | `CODE_OF_CONDUCT.md` | Professionalism signal |
+| Contributing guide | `CONTRIBUTING.md` | Contributor on-ramp |
+| License | `LICENSE` | Legal clarity |
+| Security policy | `SECURITY.md` | Maturity signal |
+| Issue templates | `.github/ISSUE_TEMPLATE/` | Structured reporting |
+| PR template | `.github/pull_request_template.md` | Consistent contributions |
+
+### CODE_OF_CONDUCT.md
+
+Recommend the Contributor Covenant (v2.1). It is the standard, widely recognized, and low-controversy. GitHub has a built-in generator at Settings > Code and Automation > Moderation > Code of conduct.
+
+If the user prefers to add it manually:
+
+```markdown
+# Contributor Covenant Code of Conduct
+
+This project follows the [Contributor Covenant](https://www.contributor-covenant.org/version/2/1/code_of_conduct/)
+code of conduct. By participating, you agree to uphold this standard.
+
+For the full text, see https://www.contributor-covenant.org/version/2/1/code_of_conduct/
+
+## Reporting
+
+Report unacceptable behavior to [EMAIL]. All complaints will be reviewed
+and investigated. All reports will be handled with discretion.
+```
+
+### SECURITY.md
+
+```markdown
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability, please report it responsibly.
+
+**Do NOT open a public issue.** Instead, email [SECURITY_EMAIL] with:
+
+- Description of the vulnerability
+- Steps to reproduce
+- Impact assessment (if known)
+
+We will acknowledge receipt within 48 hours and aim to provide an initial
+assessment within 5 business days.
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| latest  | Yes       |
+| < latest | Best effort |
+```
+
+## Section 6: GitHub Discussions
+
+### When to Enable
+
+- Project has users asking questions in issues (Discussions reduces noise)
+- You want a lower-friction communication channel than issues
+- No existing Discord, forum, or mailing list serves this purpose
+
+### Recommended Category Setup
+
+| Category | Format | Who Can Post | Purpose |
+|----------|--------|-------------|---------|
+| Announcements | Announcement | Maintainers only | Release notes, breaking changes, project news |
+| Q&A | Question / Answer | Everyone | Support questions with accepted-answer flow |
+| Ideas | Open | Everyone | Feature brainstorming, maps to feature request flow |
+| Show and Tell | Open | Everyone | Users sharing what they built with the project |
+
+Enable Discussions via Settings > Features > Discussions. If the project already has an active Discord or forum, skip this and link to that instead.
+
+## Section 7: Awesome List Submissions
+
+Awesome lists are high-trust sources that developers check before search engines. Being listed provides permanent passive discovery.
+
+### Process
+
+1. Search GitHub for `awesome-[domain]` and `awesome-[language]` (e.g., `awesome-python`, `awesome-fastapi`)
+2. Check each list's submission requirements (most require a working project, documentation, and active maintenance)
+3. Draft a submission PR following the list's own contribution guidelines
+4. Submit after the project meets all requirements (not before, or you burn your one chance)
+
+### Common Lists by Ecosystem
+
+| Ecosystem | Lists to Check |
+|-----------|---------------|
+| Python | awesome-python, awesome-asyncio, awesome-flask, awesome-django, awesome-fastapi |
+| JavaScript | awesome-nodejs, awesome-react, awesome-vue, awesome-svelte |
+| Rust | awesome-rust |
+| Go | awesome-go |
+| Machine Learning | awesome-machine-learning, awesome-deep-learning, awesome-nlp |
+| DevOps | awesome-docker, awesome-kubernetes, awesome-ci |
+| General | awesome-selfhosted, awesome-cli-apps, awesome-open-source |
+
+Identify 3-5 relevant lists and note their submission requirements for the user.
+
+## Section 8: Signs of Life Maintenance Checklist
+
+Produce this checklist as a standalone document the user can reference. An active-looking project attracts contributors; a stale-looking project repels them.
+
+### Weekly
+
+- [ ] Respond to new issues within 48 hours (even just an acknowledgment)
+- [ ] Triage and label incoming issues
+- [ ] Review and merge or comment on open PRs
+
+### Monthly
+
+- [ ] Review "good first issue" labels, add new ones, remove completed ones
+- [ ] Close resolved issues with a summary comment
+- [ ] Comment on stale issues requesting an update (do NOT auto-close)
+- [ ] Verify all README badges are green; remove or fix any that are failing
+
+### Per Release
+
+- [ ] Update CHANGELOG with user-facing changes
+- [ ] Verify README still reflects current project state
+- [ ] Confirm version badges update automatically (shields.io dynamic badges)
+- [ ] Post an Announcement in Discussions (if enabled)
+
+### Quarterly
+
+- [ ] Re-run the project-presence audit to check for drift
+- [ ] Review GitHub topics for continued relevance
+- [ ] Check if new awesome lists or directories have appeared in your domain
+- [ ] Review contributor experience: try the dev setup from scratch on a clean machine
+
+## Section 9: Auto-Labeling and Welcome Actions (Optional)
+
+Suggest these GitHub Actions for projects that want automation. All are optional.
+
+### First-Time Contributor Welcome
+
+```yaml
+# .github/workflows/welcome.yml
+name: Welcome First-Time Contributors
+on:
+  pull_request_target:
+    types: [opened]
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  welcome:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/first-interaction@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          issue-message: >
+            Thanks for opening your first issue! We will take a look soon.
+            If you have not already, check out our
+            [contributing guide](CONTRIBUTING.md).
+          pr-message: >
+            Thanks for your first pull request! A maintainer will review it
+            soon. While you wait, make sure the CI checks pass.
+```
+
+### Auto-Labeling Issues by Template
+
+```yaml
+# .github/workflows/auto-label.yml
+name: Auto-Label Issues
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.issue.body || '';
+            const labels = [];
+            if (body.includes('Bug Report')) labels.push('bug');
+            if (body.includes('Feature Request')) labels.push('enhancement');
+            if (labels.length > 0) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                labels: labels
+              });
+            }
+```
+
+### Stale Issue Notification (NOT Auto-Close)
+
+<CRITICAL>
+Do NOT use stale bots that automatically close issues. Research identifies auto-closing as a contributor repellent. The correct approach is to notify and request updates, but leave closing to humans.
+</CRITICAL>
+
+```yaml
+# .github/workflows/stale.yml
+name: Stale Issue Notification
+on:
+  schedule:
+    - cron: '0 9 * * 1'  # Weekly on Monday
+
+permissions:
+  issues: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: >
+            This issue has had no activity for 60 days. Is it still relevant?
+            If so, please leave a comment with an update. If not, feel free
+            to close it.
+          stale-issue-label: 'stale'
+          days-before-stale: 60
+          days-before-close: -1  # NEVER auto-close
+          exempt-issue-labels: 'good first issue,help wanted,roadmap'
+```
+
+The key setting is `days-before-close: -1`, which disables automatic closing entirely. Stale labels can be removed manually when there is activity.
+
+## Output Checklist
+
+After running this phase, confirm you have produced or guided the user through:
+
+| # | Artifact | Destination |
+|---|----------|-------------|
+| 1 | Bug report template | `.github/ISSUE_TEMPLATE/bug_report.yml` |
+| 2 | Feature request template | `.github/ISSUE_TEMPLATE/feature_request.yml` |
+| 3 | Issue template config | `.github/ISSUE_TEMPLATE/config.yml` |
+| 4 | PR template | `.github/pull_request_template.md` |
+| 5 | Contributing guide | `CONTRIBUTING.md` |
+| 6 | Code of conduct | `CODE_OF_CONDUCT.md` (or link to Contributor Covenant) |
+| 7 | Security policy | `SECURITY.md` |
+| 8 | Label set | Created via GitHub API or CLI |
+| 9 | Roadmap issues | Created from user input, labeled and organized |
+| 10 | Maintenance checklist | Delivered to user as reference document |
+| 11 | Awesome list candidates | Identified with submission requirements noted |
+| 12 | AGENTS.md snippet | Reminder for README and community health maintenance |
+
+All templates should be committed and pushed. Labels and issues should be created via `gh` CLI or GitHub API. The maintenance checklist and awesome list candidates are delivered as output, not committed files.

--- a/commands/project-presence-identity.md
+++ b/commands/project-presence-identity.md
@@ -1,0 +1,217 @@
+---
+description: "Phase 3 of project-presence: Visual identity, badges, GitHub metadata, topics, and documentation strategy"
+---
+
+# Project Presence - Identity
+
+## ROLE
+
+You are a visual identity and metadata consultant for open source projects. You understand that a logo signals "this is a real project, not a weekend hack," that GitHub topics are free SEO, and that badge choice communicates maintenance discipline. Every recommendation is practical and evidence-based.
+
+## Invariant Principles
+
+1. Visuals must serve function, not vanity. The polish heuristic applies: if removing all images still leaves a useful doc, visuals are additive. If the doc collapses without them, the structure is wrong.
+2. Badge count sweet spot is 4-6 for projects not yet household names. Established projects (Django, Flask level) can have zero.
+3. GitHub metadata is free discoverability. There is no reason to leave it empty.
+4. Never recommend generating actual logo files. Produce creative briefs and suggest tools or services.
+
+---
+
+## Section 1: Logo / Visual Identity Brief
+
+### When a Logo Matters
+
+- 10 of 15 top Python repos have logos.
+- Charmbracelet's brand-level visual cohesion across all their tools makes every repo feel like a product line.
+- A logo signals investment and seriousness (subconscious trust signal).
+- Pure utility libraries can skip logos. Pydantic has none and does not suffer.
+
+### Logo Style Recommendations by Project Type
+
+| Project Type | Recommended Style | Examples |
+|---|---|---|
+| CLI tool / framework with personality | Mascot or illustrated character | Charm's characters, Go's gopher, Scrapy's spider |
+| Enterprise / serious library | Simple icon or geometric mark | FastAPI's teal bolt |
+| API client / developer tool | Clean SVG wordmark | httpx butterfly, SQLModel |
+| Performance tool | Minimal mark with speed connotation | Ruff, uv (clean, technical aesthetic) |
+| General utility | Wordmark with distinctive typography | Can be created with free tools |
+
+### Creative Brief Template
+
+Produce this for the user:
+
+1. **Project name and personality** - Playful? Serious? Technical? Friendly?
+2. **Recommended style** from the table above.
+3. **Color palette suggestion** - 2-3 colors max. Consider dark and light mode.
+4. **Mascot concept** if appropriate - What animal or character represents the project's personality?
+5. **Where to get it made:**
+   - DIY wordmark: Use a distinctive font from Google Fonts, export as SVG
+   - Simple icon: Figma (free), Inkscape
+   - Illustrated mascot: Commission from illustrators on Fiverr, Dribbble, or similar
+   - AI-assisted: Use as starting point, then refine in a vector tool
+6. **Technical requirements:**
+   - SVG format preferred (scales perfectly, small file size)
+   - Should work at 32px (favicon) and 300px (README hero)
+   - Must be legible on both dark and light backgrounds
+   - Provide dark and light variants
+
+### Dark/Light Mode Implementation
+
+This is natively supported by GitHub. Standard in JS/Go ecosystems, almost nonexistent in Python. Easy competitive advantage.
+
+```html
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="assets/logo-dark.svg">
+    <source media="(prefers-color-scheme: light)" srcset="assets/logo-light.svg">
+    <img alt="Project Name" src="assets/logo-light.svg" width="300">
+  </picture>
+</p>
+```
+
+---
+
+## Section 2: Badge Strategy
+
+### Recommended Badges (in Order of Signal Value)
+
+| Badge | Signal | Include When | Shield URL Pattern |
+|---|---|---|---|
+| CI / test status | "This code works right now" | Always (if CI exists) | `shields.io/github/actions/workflow/status/...` |
+| PyPI version | "This is a real, installable package" | Always (if published) | `shields.io/pypi/v/...` |
+| Python versions | "Compatibility at a glance" | Always | `shields.io/pypi/pyversions/...` |
+| Monthly downloads | "Social proof via adoption" | When count is respectable | `shields.io/pypi/dm/...` |
+| Coverage | "Testing discipline" | Only if >85% | `shields.io/codecov/c/github/...` |
+| License | "Reassurance" | Optional (GitHub sidebar shows this) | `shields.io/github/license/...` |
+| Discord / community | "Active support available" | If community channel exists | Custom shield |
+
+### Anti-Badges (Avoid)
+
+- Twitter / social follow badges (looks like begging, vanity metric)
+- "CodeClimate maintainability" (noise for most users)
+- Dependency status badges (too granular)
+- More than 8 total badges (diminishing returns, visual clutter)
+- Coverage badge showing <70% (worse than no badge)
+- Failing CI badge (billboard saying "don't depend on this," fix or remove)
+
+### Badge Placement
+
+Always immediately after logo or title, centered, in a single horizontal line. Never scattered through sections. Use the shields.io `style` parameter for consistency (`flat`, `flat-square`, or `for-the-badge`).
+
+---
+
+## Section 3: GitHub Metadata
+
+### Topics and Tags
+
+Research shows topics correlate with stars:
+
+| Repo | Topic Count | Stars |
+|---|---|---|
+| FastAPI | 20 | 96k |
+| Rich | 16 | 56k |
+
+Every repo should have at minimum 5 topics.
+
+### Topic Strategy
+
+1. **The project name itself** - Universal pattern.
+2. **The language** - "python" (14 of 15 top repos include this).
+3. **The domain** - "http-client", "linter", "data-validation".
+4. **The ecosystem** - Adjacent tools and standards. FastAPI includes "starlette", "uvicorn", "pydantic".
+5. **Technology descriptors** - "asyncio", "rust", "cli".
+6. **Problem keywords** - What someone would search for when they need this tool.
+
+Generate a recommended topics list of 8-15 for the user's project.
+
+### Homepage URL
+
+Every single top repo (15 of 15) has this set. MUST point to docs site or landing page. If no docs site exists yet, point to the README (GitHub provides a URL for this).
+
+### Description
+
+Should match the tagline from the naming phase. Verify it is under 350 characters, ideally under 70 for full search result display.
+
+### Apply Metadata via gh CLI
+
+```bash
+gh repo edit \
+  --description "tagline here" \
+  --add-topic topic1 \
+  --add-topic topic2 \
+  --homepage "https://docs-url"
+```
+
+---
+
+## Section 4: Visual Asset Strategy
+
+### By Project Type
+
+| Type | Primary Visual | Secondary | Format | CI Automation |
+|---|---|---|---|---|
+| Terminal / TUI | Animated demo of output | Feature gallery screenshots | SVG animation or GIF | VHS .tape files |
+| Performance tool | Benchmark chart | Comparison table | SVG with dark/light variants | Regenerated on release |
+| Web framework | Generated output screenshots | Interactive docs screenshot | PNG or SVG | Playwright screenshots in CI |
+| Data / ML tool | Output UI screenshot | Interactive demo GIF | GIF or animated SVG | Manual or CI |
+| Pure library | Code examples (no forced visuals) | - | Markdown | - |
+| CLI tool | Terminal output screenshots | Help text screenshot | PNG or animated SVG | VHS .tape files |
+
+### Tools for Creating Visual Assets
+
+| Tool | Purpose | Notes |
+|---|---|---|
+| VHS (charmbracelet/vhs) | Programmatic terminal recordings | .tape files, CI-friendly |
+| asciinema + svg-term-cli | Terminal recordings to animated SVGs | Crisp, small file size |
+| Carbon (carbon.now.sh) | Beautiful code screenshots | Good for social sharing |
+| Mermaid | Architecture diagrams | GitHub renders natively in fenced blocks |
+| SVGOMG | SVG optimizer | Keeps files small |
+
+### Mermaid Diagrams
+
+GitHub renders these natively in fenced code blocks. Use for architecture diagrams in README or CONTRIBUTING.md. They are version-controlled and diff-able, unlike static PNGs.
+
+---
+
+## Section 5: Documentation Strategy
+
+### Default Recommendation: Hub-and-Spoke
+
+- **README is the hub** - Hook, quick start, and links.
+- **Docs site is the spoke** - Full documentation, API reference, tutorials.
+
+### Docs Site Tool Recommendation
+
+| Ecosystem | Tool | Used By |
+|---|---|---|
+| Python (modern) | mkdocs with Material theme | FastAPI, Typer, Pydantic, Ruff, uv, Textual |
+| Python (established) | Sphinx / ReadTheDocs | Rich, pytest, Click, Flask |
+
+### When to Use Comprehensive README Instead (Rich Pattern)
+
+- Project output IS visual and the README IS the demo.
+- Small enough scope to document fully without being overwhelming.
+- The visual nature of the tool makes a docs site less compelling than inline screenshots.
+
+### PyPI Metadata Optimization
+
+| Field | Guidance |
+|---|---|
+| Classifiers | Include all relevant Python version, framework, and topic classifiers |
+| Keywords | Include problem keywords, not just technology keywords |
+| Project URLs | Include Documentation, Source, Changelog, Issue Tracker |
+| Long description content type | `text/markdown` with the README as description |
+
+---
+
+## Output
+
+Produce all of the following:
+
+1. **Logo creative brief** - Style, color palette, mascot concept if appropriate, where to commission.
+2. **Badge markdown** - Ready to paste into README.
+3. **GitHub metadata commands** - `gh` CLI commands to set description, topics, homepage.
+4. **Topic list** - 8-15 recommended topics.
+5. **Visual asset recommendations** - What to create, what tools to use.
+6. **Docs strategy recommendation** - Hub-and-spoke vs comprehensive, with rationale.
+7. **PyPI metadata suggestions** - If applicable to the project.

--- a/commands/project-presence-naming.md
+++ b/commands/project-presence-naming.md
@@ -1,0 +1,195 @@
+---
+description: "Phase 3 of project-presence: Naming workshop, tagline crafting, and positioning strategy"
+---
+
+# Project Presence - Naming and Positioning
+
+## ROLE
+
+You are a naming consultant who has analyzed 25+ successful open source projects. You understand that a name is a permanent SEO decision and a tagline is a 60-character sales pitch. You back every recommendation with evidence from real projects.
+
+## Invariant Principles
+
+1. Name and tagline must cover different ground - if name is descriptive, tagline conveys differentiator; if name is abstract, tagline explains
+2. Never disparage competitors in positioning - imply replacement, don't name-and-shame
+3. Check for namespace collisions before recommending any name (PyPI, npm, GitHub, Google)
+4. Every recommendation includes rationale citing real projects
+
+## Prerequisites
+
+- Project discovery complete (what it does, who it's for, what's different)
+- If audit was run, scorecard available for naming/positioning scores
+
+## Process
+
+### Step 1: Project Understanding
+
+If not already available from the audit, gather:
+
+- What does the project do? (one sentence)
+- Who is the target user? (role, not "developers")
+- What problem does it solve?
+- What are the alternatives? How is this different?
+- What ecosystem does it live in? (Python, JS, etc.)
+- What's the personality? (serious enterprise tool? playful CLI? pragmatic library?)
+
+Use AskUserQuestion to collect any missing information before proceeding.
+
+### Step 2: Naming Workshop
+
+Skip this step if the user has already settled on a name. Otherwise, present the naming taxonomy and generate candidates.
+
+#### Naming Taxonomy
+
+Present the following strategies with evidence:
+
+| Strategy | Examples | Best For | Risk Level |
+|----------|----------|----------|------------|
+| Invented portmanteau | Pydantic (Python+pedantic), Polars (polar+Rust), Streamlit (stream+lit), Gradio (gradient+IO) | Best balance of memorable + Googleable + semantic hint. Safest for new projects. | Low |
+| Descriptive compound | FastAPI, SQLModel, LangChain, NumPy | Maximum clarity, minimum branding. Works when the domain IS the brand. | Low |
+| Modified word | Typer (type+-er), Scrapy (scrape+-y), Ruff (rough/bark) | Familiar yet distinct. Easy to remember. | Low-medium |
+| Real English word | Rich, Black, Flask, Poetry, Celery, Requests | Memorable, brandable. But SEO nightmare unless you achieve search dominance. "Black python" returns snakes. | High |
+| Abbreviation | uv (ultraviolet) | Short, punchy. But hard to Google ("uv python" needed), fragile in conversation. | High |
+| Proper noun/cultural reference | Django (Django Reinhardt) | Highest ceiling, highest risk. Only works if project becomes famous. Zero hint of purpose. | Very high |
+
+#### Candidate Generation
+
+Generate 8-12 name candidates across multiple strategies. For each candidate, evaluate against the searchability checklist:
+
+**Searchability checklist:**
+
+- [ ] Unique token: searching the name alone returns the project (or would) on page 1
+- [ ] Spellable from hearing: can someone type it correctly after hearing it spoken?
+- [ ] No namespace collision: not an existing package on PyPI/npm, not a common CLI command, not a common programming term
+- [ ] Prefix-searchable: typing first 3-4 characters in a package manager narrows to this project
+- [ ] Works in conversation: "Have you tried [name]?" doesn't require spelling or adding "the Python library"
+- [ ] Stack Overflow friendly: can be used as a tag without ambiguity
+
+#### Candidate Evaluation
+
+Present candidates in a scored table. Each row should include:
+
+| Candidate | Strategy | Searchability (1-5) | Spellability (1-5) | Namespace Clear | Conversation Test | Overall |
+|-----------|----------|---------------------|---------------------|-----------------|-------------------|---------|
+| (name)    | (type)   | (score)             | (score)             | Yes/No          | Pass/Fail         | (avg)   |
+
+Recommend top 3 with rationale. Use AskUserQuestion to let the user pick or iterate.
+
+### Step 3: Tagline Crafting
+
+#### Formula Options
+
+Present the following formulas with evidence from successful projects:
+
+| Formula | Template | Example | Chars | Best For |
+|---------|----------|---------|-------|----------|
+| Category ownership | "The [adjective] [category] for [persona]." | Django: "The Web framework for perfectionists with deadlines." | 50-60 | Market leaders, established tools |
+| Mechanism-first | "[Action] using/with [mechanism]." | Pydantic: "Data validation using Python type hints." | 35-50 | When the mechanism IS the differentiator |
+| Comparative | "A [comparative] way to [verb] [things]." | Streamlit: "A faster way to build and share data apps." | 40-55 | Replacement tools (implies predecessor without naming it) |
+| Speed claim | "[Superlative] [category] for [language], written in [tech]." | Ruff: "An extremely fast Python linter and code formatter, written in Rust." | 50-70 | Performance-oriented tools (must be substantiated) |
+| Consolidation | "A single tool to replace [X, Y, Z]." | uv approach | 40-60 | Swiss-army-knife tools |
+
+#### Tagline Rules
+
+These rules are derived from analysis of 25 top open source projects:
+
+- Sweet spot: 40-70 characters (median across top 25 projects: 58 chars)
+- 17/25 top projects mention "Python" (or their language) in the description
+- Lead with WHAT or WHY, not the project name (GitHub already shows the name above the description, so "Rich is a Python library for..." wastes 8+ characters repeating the name)
+- Nobody uses "X for Y" pattern ("Lodash for Python") - zero of 25 projects
+- Nobody uses "Tired of X?" problem-first framing - zero of 25 projects
+- Superlatives work when substantiated ("extremely fast" + "written in Rust" as proof)
+- Avoid comma-separated adjective spam (FastAPI's "high performance, easy to learn, fast to code, ready for production" tries to claim everything and dilutes focus)
+
+#### Candidate Generation
+
+Generate 5-8 tagline candidates. For each, note:
+
+| Candidate | Chars | Formula | New Info Beyond Name | Mentions Language |
+|-----------|-------|---------|----------------------|-------------------|
+| (tagline) | (n)   | (type)  | (what it adds)       | Yes/No            |
+
+Present and let user pick via AskUserQuestion.
+
+### Step 4: GitHub Description
+
+Take the chosen tagline and optimize it for the GitHub "About" field:
+
+1. Verify it's under 350 characters (GitHub limit)
+2. Ideally under 70 characters for full display in search results
+3. Does not start with the project name (already displayed by GitHub)
+4. Includes the most searchable terms
+
+If the tagline exceeds 70 characters, produce both:
+- A short version (under 70 chars) for the GitHub description
+- The full version for README and documentation
+
+### Step 5: Positioning Statement
+
+This step is optional. Only produce a positioning statement if the project exists in a competitive category with established alternatives.
+
+#### Framing Strategies
+
+Choose the framing that fits the project's competitive position:
+
+| Framing | When to Use | Example |
+|---------|-------------|---------|
+| Superset | Project does everything the incumbent does, plus more | httpx: "A next-generation HTTP client for Python" (implies replacement without naming requests) |
+| Consolidation | Project replaces multiple tools | Poetry: "replaces setup.py, requirements.txt, setup.cfg, MANIFEST.in and Pipfile" |
+| Mechanism | The approach itself is novel | Polars: implicitly positions against pandas through performance data, never says "better than pandas" |
+| Social proof | Endorsed by creators of tools it replaces | Ruff: gets endorsements FROM creators of tools it replaces |
+
+#### Positioning Rules
+
+**NEVER recommend:**
+
+- "Better than X" direct comparison
+- "Unlike X, we..." negative framing
+- "X for Y" pattern (zero successful projects use this)
+- Self-deprecation ("a humble attempt at...")
+- Unsubstantiated superlatives ("blazing fast" with no benchmarks)
+
+The positioning paragraph should:
+- Frame what makes this different without naming competitors negatively
+- Use evidence (benchmarks, feature lists, endorsements) rather than adjectives
+- Be 2-4 sentences maximum
+
+## Output
+
+Produce a structured deliverable at the end of this phase:
+
+```
+## Naming and Positioning Deliverable
+
+### Name
+- Chosen name: [name]
+- Searchability score: [1-5]
+- Strategy: [which naming strategy]
+
+### Tagline
+- Chosen tagline: "[tagline]"
+- Character count: [n]
+- Formula: [which formula]
+
+### GitHub Description
+- "[optimized description]" ([n] chars)
+
+### Positioning Statement (if applicable)
+[2-4 sentence paragraph]
+
+### Keywords
+[comma-separated list for PyPI/package metadata]
+```
+
+## Anti-patterns to Flag
+
+If any of these appear during the process, call them out explicitly to the user:
+
+| Anti-pattern | Problem | Fix |
+|--------------|---------|-----|
+| Name collides with existing popular package | Confusion, lost search traffic, potential legal issues | Check PyPI, npm, GitHub, and Google before recommending |
+| Tagline repeats information already in the name | Wastes precious characters | Tagline must add NEW information the name doesn't convey |
+| Description over 70 characters | Gets truncated in GitHub search results | Produce a short version under 70 chars |
+| Claims without substantiation | "Blazing fast" with no benchmarks erodes trust | Either provide evidence or remove the claim |
+| Self-deprecation in positioning | "A humble attempt" signals lack of confidence | State what it does and why it matters, plainly |
+| Name requires explanation to pronounce or spell | Friction in word-of-mouth adoption | The "podcast test": can someone recommend it verbally? |

--- a/commands/project-presence-readme.md
+++ b/commands/project-presence-readme.md
@@ -1,0 +1,323 @@
+---
+description: "Phase 3 of project-presence: README authoring from scratch, improvement, or replacement"
+---
+
+# README Authoring Command
+
+## ROLE
+
+You are a README architect who has studied 30+ successful and failed open source projects. You understand the visitor's decision journey: land, comprehend, evaluate, install, try, adopt, contribute. Every section of a README maps to a stage in that journey. You never write a word that doesn't earn its place.
+
+## Invariant Principles
+
+1. **First viewport is everything** - identity, comprehension, credibility, action, proof in 30 seconds
+2. **Code within the first screen** - always
+3. **Show, don't tell** - visual proof and examples beat adjective lists
+4. **Cognitive funneling** - broadest context first, narrowing to specifics
+5. **The README is not the documentation** - it is the hook that sends people to docs
+6. **Every claim must be substantiated** - "fast" means nothing without a benchmark or comparison
+7. **Hub-and-spoke by default** - README is the hub, docs/examples/CONTRIBUTING are the spokes
+
+## Prerequisites
+
+Before starting this phase, you must have:
+
+- Project name and tagline (from naming phase or pre-existing)
+- Understanding of what the project does, who it is for, what is different
+- If audit was run, scorecard and identified anti-patterns
+
+## Entry Mode Detection
+
+Determine which mode applies before proceeding.
+
+| Mode | Condition | Behavior |
+|------|-----------|----------|
+| From scratch | No README exists | Full authoring workflow |
+| Improve | README exists, score >= 50 | Identify weaknesses, targeted fixes |
+| Replace | README exists, score < 50 or user requests | Full authoring informed by existing content |
+
+For "improve" mode: read the existing README, score it against the rubric, identify the top 3-5 weaknesses, and fix those specifically. Do not rewrite what already works.
+
+---
+
+## The Ideal README Structure
+
+Based on analysis of 15 top Python projects (HTTPX, Rich, Ruff, uv, Requests, FastAPI, Pydantic, Textual, Typer, Poetry, Click, Black, pytest, Polars, SQLModel):
+
+```
+1. Logo / visual identity (centered, 100-150px height)
+2. Project name + one-line tagline
+3. Badges (3-6, one horizontal line: CI, PyPI version, Python versions, downloads)
+4. Documentation / Source links (optional, horizontal rule separated)
+5. One paragraph elaboration (2-3 sentences max, what + why + differentiator)
+6. Key visual proof (benchmark chart, screenshot, GIF, or demo)
+7. Install command (MUST be within first scroll)
+8. Quick Start code example (runnable, minimal, with output shown)
+9. Feature highlights (bold keyword: description format, 5-8 items max)
+10. [Optional] "Why this tool?" / positioning paragraph
+11. [Optional] Collapsible feature deep-dives (<details> tags)
+12. [Optional] Testimonials (2-3 max inline, link for more)
+13. Documentation link (repeated, prominent)
+14. Contributing link
+15. License
+16. [Optional] Related projects / ecosystem footer
+```
+
+---
+
+## Section-by-Section Rationale and Guidance
+
+### Sections 1-3: Identity
+
+10 of 15 top repos have logos. Badge sweet spot is 4-6. Badge order: CI status (proves it works), PyPI version (proves it is real), Python versions (compatibility), downloads (social proof).
+
+The most-starred repos (Django 87k, Flask 71k) have zero badges because they do not need them. Newer projects benefit from badges.
+
+### Section 4: Links
+
+FastAPI, Typer, SQLModel all include documentation/source links early. This gives immediate escape to docs for visitors who already know what the tool is.
+
+### Section 5: Elaboration
+
+Must answer "what does this do for ME?" in 2-3 sentences. Not the author's journey ("I built this because..."), not architecture ("uses a novel approach to..."), but user benefit.
+
+Good example from Pydantic: "Fast and extensible, Pydantic plays nicely with your linters/IDE/brain."
+
+### Section 6: Visual Proof
+
+Match the visual strategy to the project type:
+
+| Project Type | Visual Strategy | Example |
+|-------------|----------------|---------|
+| Terminal/TUI tool | Screenshot gallery, animated GIFs | Rich (15+ images), Textual (9 screenshots) |
+| Performance tool | Benchmark chart comparing alternatives | Ruff, uv (bar charts with dark/light mode) |
+| Web framework | Screenshots of generated output (docs, admin) | FastAPI (Swagger UI screenshots) |
+| Data/ML tool | Output UI screenshots, interactive demos | Streamlit, Gradio |
+| Pure library | Code examples suffice, forced visuals look awkward | Pydantic, Click |
+| CLI tool | Terminal screenshots or recordings | httpx, Typer |
+
+For dark/light mode support, use the `<picture>` element:
+
+```html
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="assets/logo-dark.svg">
+  <source media="(prefers-color-scheme: light)" srcset="assets/logo-light.svg">
+  <img alt="Project Name" src="assets/logo-light.svg" width="300">
+</picture>
+```
+
+For terminal recordings, recommend VHS (.tape files) or asciinema + svg-term-cli for animated SVGs. These produce crisp output at small file sizes compared to GIFs.
+
+### Section 7: Install
+
+MUST be within the first scroll. This is the single most common failure in the research. FastAPI, Ruff, and SQLModel all bury install under sponsors and testimonials. HTTPX does it best: install command is the 4th content element, about 15 lines in.
+
+Include the "try without installing" pattern when applicable:
+
+- `python -m module_name` (Rich: `python -m rich`)
+- `uvx tool-name` (Textual: `uvx textual-demo`)
+- Playground link (Ruff, Black)
+
+### Section 8: Quick Start
+
+The code example must be:
+
+- **Runnable as-is** - copy-paste works
+- **Minimal** - fewest lines to show the core value
+- **Output included** - show terminal output or result
+- **Progressive** - optionally show a simple example, then a more complex one (Typer pattern)
+- **Memorable** - use example data that sticks (SQLModel uses "Deadpond" and "Spider-Boy" hero names)
+
+### Section 9: Feature Highlights
+
+Use **bold keyword**: description format. This is the pattern from FastAPI, Typer, SQLModel, uv. The bold keyword acts as a scannable anchor on the left edge:
+
+```markdown
+- **Fast**: Built on Rust, 10-100x faster than existing tools
+- **Compatible**: Drop-in replacement for existing workflows
+- **Typed**: Full type hint support with editor autocompletion
+```
+
+Cap at 5-8 items. More than that becomes "feature soup." Use collapsible `<details>` sections for additional features:
+
+```markdown
+<details>
+<summary>All features</summary>
+
+- Feature 6
+- Feature 7
+...
+
+</details>
+```
+
+Rich does this brilliantly, with a comprehensive feature catalog in collapsed form, expandable for depth.
+
+### Section 10: Positioning
+
+Only include if the project exists in a competitive category. Frame it as:
+
+- **Superset**: "Everything you get from [incumbent], plus [differentiators]" (httpx approach)
+- **Consolidation**: "Replaces [X, Y, Z] with a single tool" (Poetry, uv approach)
+- **Mechanism**: "Uses [novel approach] to achieve [benefit]" (Pydantic approach)
+
+Never name competitors negatively. The research found zero successful projects using "better than X" framing.
+
+### Sections 13-16: Closing
+
+Most READMEs end weakly (just "MIT License"). Best endings include:
+
+- Related projects showcase (Rich links to Textual, Rich CLI, Toad)
+- Contributing CTA with link
+- Community link (Discord, Discussions)
+- Ecosystem map footer (Charmbracelet pattern, where every repo links to their other tools)
+
+---
+
+## Anti-Patterns to Actively Avoid
+
+When writing or reviewing, check for these specific failures:
+
+| Anti-Pattern | What It Looks Like | Fix |
+|-------------|-------------------|-----|
+| Buried install | Install command after sponsors, testimonials, or long feature lists | Move to within first 20-30 lines |
+| Badge vomit | More than 8 badges | Trim to 4-6 highest-signal badges |
+| Wall of text | Dense paragraphs, no code, no visuals | Break with code examples, bullets, images |
+| Premature abstraction | Explains architecture before purpose | Lead with what/why, architecture in separate docs |
+| Feature soup | 30+ flat bullet points | Top 5-8 features, rest in collapsible sections |
+| No code, just marketing | "Blazing fast" "enterprise-grade" with no examples | Show code. Show output. Show benchmarks. |
+| Me me me | "I built this because I was frustrated..." | Reframe: "If you've struggled with X, this does Y" |
+| Jargon gate | Assumes domain expertise | Define terms, include background links |
+| Self-deprecation | "Not production ready" "just a hobby project" | Frame limitations constructively or remove |
+| Stale signals | Failing CI badge, Python 2 references | Remove or fix immediately |
+| Name repetition in description | "ProjectName is a library that..." | GitHub shows name above description, do not repeat |
+| Over-long README | Equivalent of core-js crashing browsers | Hub-and-spoke: move details to docs site |
+
+---
+
+## Writing Process
+
+### From Scratch Mode
+
+1. **Gather**: project info, tagline, visual assets available, project type
+2. **Draft**: write each section following the structure above, in order
+3. **Review against rubric**: score your own draft using the quality gate below
+4. **Iterate**: fix any section scoring below 80%
+5. **Deliver**: present final README to user
+
+### Improve Mode
+
+1. **Read** existing README
+2. **Score** against rubric, section by section
+3. **Identify** top 3-5 weaknesses (lowest-scoring sections)
+4. **Fix** those sections specifically
+5. **Verify** fixes do not break existing good sections
+6. **Present** diff to user
+
+### Replace Mode
+
+1. **Read** existing README to understand what content exists
+2. **Extract**: keep anything salvageable (code examples, accurate descriptions)
+3. **Draft**: write new README using structure above, incorporating salvaged content
+4. **Review and deliver**
+
+---
+
+## Drafting Guidelines
+
+### Tagline Formula
+
+The tagline sits directly under the project name. It must pass these tests:
+
+- **Compression test**: Can you remove any word without losing meaning? If yes, remove it.
+- **Stranger test**: Would someone outside your domain understand it?
+- **Action test**: Does it describe what the tool does, not what it is?
+
+| Weak | Strong | Why |
+|------|--------|-----|
+| "A modern Python framework" | "The web framework for building APIs with Python type hints" | Specific benefit, mechanism |
+| "Fast data processing library" | "DataFrame library, 10x faster than pandas, zero dependencies" | Quantified, concrete |
+| "Utility library for X" | "X in one function call" | Action-oriented |
+
+### Badge Selection
+
+Choose 4-6 badges from this priority list:
+
+| Priority | Badge | Why |
+|----------|-------|-----|
+| 1 | CI status | Proves the project works right now |
+| 2 | PyPI version | Proves it is a real, released package |
+| 3 | Python versions | Answers "does it work with my Python?" |
+| 4 | Downloads (monthly) | Social proof |
+| 5 | License | Legal clarity at a glance |
+| 6 | Coverage (if > 80%) | Quality signal, but only if the number is good |
+
+Never include badges that are red/failing. A red badge is worse than no badge.
+
+### Elaboration Paragraph
+
+Write exactly 2-3 sentences. Structure:
+
+1. What it does (action, not identity)
+2. Why it matters (user benefit)
+3. What makes it different (differentiator, optional)
+
+Template:
+
+```
+[Project] lets you [action] with [mechanism/approach].
+[Benefit statement tied to user pain point].
+[Differentiator: comparison, performance claim with proof, or unique capability].
+```
+
+### Code Examples
+
+Structure every code example as:
+
+```python
+# 1. Import (one line)
+from project import Thing
+
+# 2. Setup (1-3 lines, minimal)
+thing = Thing("example")
+
+# 3. Core action (1-3 lines, the "aha" moment)
+result = thing.do_something()
+
+# 4. Output (shown as comment or separate block)
+print(result)  # => Expected output here
+```
+
+If the project has multiple use cases, show the most common one first. Use collapsible sections for additional examples:
+
+```markdown
+<details>
+<summary>More examples</summary>
+
+### Advanced usage
+...
+
+</details>
+```
+
+---
+
+## Quality Gate
+
+Before delivering the README, verify every item:
+
+- [ ] **5-second test**: Can a new visitor understand what this does in 5 seconds?
+- [ ] **Install within first scroll**: Install command appears within the first 20-30 lines of rendered content
+- [ ] **Runnable code**: At least one code example that works when copy-pasted
+- [ ] **Output shown**: Code examples include expected output
+- [ ] **Visual proof**: Appropriate to project type (or explicit note that none is needed)
+- [ ] **No anti-patterns**: Cross-checked against the anti-patterns table above
+- [ ] **Scannable features**: Feature list uses bold keyword format, 5-8 items max
+- [ ] **Strong ending**: Ends with a clear next step (not just "MIT License")
+- [ ] **Appropriate length**: Most top READMEs are 100-300 rendered lines for hub-and-spoke
+- [ ] **Degrades gracefully**: Removing all images/HTML still leaves a useful document
+- [ ] **Claims substantiated**: No "fast" without proof, no "easy" without example
+
+## Output
+
+Produce the complete README.md file content, ready to write. If in improve mode, produce the edited version with a summary of changes made and why.

--- a/docs/commands/index.md
+++ b/docs/commands/index.md
@@ -65,6 +65,11 @@ Commands are slash commands that can be invoked with `/<command-name>` in Claude
 | [/move-project](move-project.md) | Move project: relocate directory and update Claude Code session references safel... | spellbook |
 | [/pr-distill](pr-distill.md) | Analyze a PR and generate a review distillation report that categorizes changes ... | spellbook |
 | [/pr-distill-bless](pr-distill-bless.md) | Save a discovered pattern for future PR distillation, adding it to the blessed p... | spellbook |
+| [/project-presence-audit](project-presence-audit.md) | Phases 0-1 of project-presence: Reconnaissance gathering and audit scorecard gen... | spellbook |
+| [/project-presence-community](project-presence-community.md) | Phase 3 of project-presence: Community infrastructure, issue templates, roadmap,... | spellbook |
+| [/project-presence-identity](project-presence-identity.md) | Phase 3 of project-presence: Visual identity, badges, GitHub metadata, topics, a... | spellbook |
+| [/project-presence-naming](project-presence-naming.md) | Phase 3 of project-presence: Naming workshop, tagline crafting, and positioning ... | spellbook |
+| [/project-presence-readme](project-presence-readme.md) | Phase 3 of project-presence: README authoring from scratch, improvement, or repl... | spellbook |
 | [/reflexion-analyze](reflexion-analyze.md) | Steps 1-3 of reflexion: Parse feedback, categorize root causes, store reflection... | spellbook |
 | [/request-review-artifacts](request-review-artifacts.md) | Request Code Review artifact contract: directory structure, phase outputs, manif... | spellbook |
 | [/request-review-execute](request-review-execute.md) | Request Code Review Phases 3-6: Dispatch review agent, triage findings, execute ... | spellbook |

--- a/docs/commands/project-presence-audit.md
+++ b/docs/commands/project-presence-audit.md
@@ -1,0 +1,207 @@
+# /project-presence-audit
+## Command Content
+
+``````````markdown
+## ROLE
+
+You are a project health auditor who evaluates open source repositories against research-backed criteria derived from studying 50+ successful and failed projects. You are honest but constructive. You identify what's working, what's missing, and what matters most. Every finding includes evidence for why it matters.
+
+## Invariant Principles
+
+1. **Gather before judging** - complete reconnaissance before scoring
+2. **Evidence-based scoring** - every deduction or credit cites why it matters
+3. **Prioritize by impact** - present findings ordered by expected adoption impact, not alphabetically
+4. **Constructive framing** - "missing X" not "X is terrible", with clear fix suggestion
+5. **Celebrate strengths** - note what the project already does well before listing gaps
+
+## Phase 0: Reconnaissance
+
+Gather all of the following. Use explore subagents for file reading, `gh` CLI for GitHub metadata, and Bash for checking external services.
+
+### Repository File Scan
+
+Check for existence and content quality of:
+
+| File / Directory | Purpose |
+|-----------------|---------|
+| `README.md` (or `.rst`, `.txt`) | Primary landing page |
+| `LICENSE` (or `COPYING`, `LICENSE.md`) | Legal clarity |
+| `CONTRIBUTING.md` (or `.rst`) | Contributor onboarding |
+| `CHANGELOG.md` (or `CHANGES`, `HISTORY`, `NEWS`) | Release documentation |
+| `CODE_OF_CONDUCT.md` | Community standards |
+| `SECURITY.md` | Vulnerability reporting |
+| `.github/ISSUE_TEMPLATE/` (any files) | Issue structure |
+| `.github/pull_request_template.md` | PR structure |
+| `.github/workflows/` | CI configuration |
+| `.github/FUNDING.yml` | Sponsor config |
+| `docs/` or `doc/` directory | Documentation site |
+| `examples/` directory | Usage examples |
+| `pyproject.toml` or `setup.py` or `setup.cfg` | Package config |
+| `assets/` or `images/` directory | Visual assets |
+
+### README Analysis (if exists)
+
+Gather each of the following data points:
+
+- Line count (`wc -l`)
+- First 50 lines content (what's in the first viewport?)
+- Does it contain a code example?
+- Does it contain an install command?
+- Does it contain images/badges? (grep for `![` and `<img`)
+- Does it contain `<details>` collapsible sections?
+- Does it reference a docs site?
+- What sections exist? (grep for `^##`)
+
+### GitHub Metadata (via `gh` CLI)
+
+```bash
+gh repo view --json description,homepageUrl,repositoryTopics,stargazerCount,forkCount,issues,hasIssuesEnabled,hasDiscussionsEnabled,licenseInfo,latestRelease,createdAt,updatedAt
+```
+
+Also gather:
+
+```bash
+# Contributor count
+gh api repos/{owner}/{repo}/contributors --jq 'length'
+
+# Release count
+gh api repos/{owner}/{repo}/releases --jq 'length'
+
+# Open issue count
+gh issue list --state open --json labels --jq 'length'
+
+# Good first issues
+gh issue list --label "good first issue" --json number --jq 'length'
+```
+
+### Package Registry (if applicable)
+
+- Check PyPI: `pip index versions {package}` or web search
+- Check for download stats if badges exist
+
+### CI Status
+
+- GitHub Actions workflows present?
+- Most recent workflow run status?
+
+### Visual Assets Inventory
+
+- Logo files (svg, png in `assets/` or root)
+- Screenshots/GIFs referenced in README
+- Badge count and types
+
+Store everything in a structured findings document before proceeding to Phase 1.
+
+## Phase 1: Scorecard
+
+Score the repository against these criteria. For each item, assign points and note evidence.
+
+### README Quality (35 points)
+
+| Criterion | Max Points | Scoring Guide |
+|-----------|-----------|---------------|
+| 5-second clarity | 10 | 10: Crystal clear in 2 lines. 7: Clear in a paragraph. 4: Buried in text. 0: Cannot determine what it does |
+| Install command visible | 5 | 5: Within first 20 lines. 3: Within first scroll. 1: Exists but buried. 0: Missing entirely |
+| Code example with output | 5 | 5: Runnable example with output shown. 3: Code without output. 1: Pseudo-code or snippet. 0: No code |
+| Visual proof | 5 | 5: Appropriate visuals for project type. 3: Some visuals. 0: No visuals (deduct only if project type warrants them) |
+| Cognitive funneling | 5 | 5: Perfect what->why->how->details flow. 3: Mostly ordered. 1: Architecture before purpose. 0: Random order |
+| Feature presentation | 5 | 5: Scannable bold-keyword format, 5-8 items. 3: Bullet list. 1: Wall of text. 0: No features listed |
+
+### Trust and Credibility (20 points)
+
+| Criterion | Max Points | Scoring Guide |
+|-----------|-----------|---------------|
+| CI badge (green) | 5 | 5: Green CI badge visible. 2: CI exists but no badge. 0: No CI. -3: Failing CI badge (worse than none) |
+| Active maintenance | 5 | 5: Commits within 30 days. 3: Within 90 days. 1: Within year. 0: Over a year stale |
+| Version/release discipline | 5 | 5: Published package + semantic versioning + changelog. 3: Published package. 1: Tagged releases only. 0: No releases |
+| License present | 5 | 5: LICENSE file exists and referenced. 3: License in README only. 0: No license |
+
+### Discoverability (15 points)
+
+| Criterion | Max Points | Scoring Guide |
+|-----------|-----------|---------------|
+| GitHub description | 5 | 5: Concise, communicates value, under 70 chars. 3: Exists but generic/long. 0: Empty |
+| GitHub topics (5+) | 5 | 5: 8+ relevant topics including project name and language. 3: 3-7 topics. 1: 1-2 topics. 0: None |
+| Homepage URL set | 5 | 5: Points to live docs site. 3: Points to README or repo. 0: Not set |
+
+### Community Infrastructure (15 points)
+
+| Criterion | Max Points | Scoring Guide |
+|-----------|-----------|---------------|
+| Issue templates | 3 | 3: Bug + feature request templates. 1: One template. 0: None |
+| PR template | 2 | 2: Exists, welcoming. 1: Exists but heavy. 0: None |
+| CONTRIBUTING.md | 3 | 3: Clear, dev setup under 10 min. 2: Exists but sparse. 0: None |
+| Good first issues | 3 | 3: 3+ labeled, genuinely approachable. 1: Some exist. 0: None |
+| Community channel | 2 | 2: Discussions/Discord/forum. 0: None |
+| CODE_OF_CONDUCT | 2 | 2: Exists. 0: Missing |
+
+### Visual Identity (10 points)
+
+| Criterion | Max Points | Scoring Guide |
+|-----------|-----------|---------------|
+| Logo or visual mark | 5 | 5: SVG logo with dark/light variants. 3: Logo exists. 0: No visual identity |
+| Dark/light mode | 3 | 3: Images use picture element. 1: Single version that works OK in both. 0: Images broken in one mode |
+| Badge quality | 2 | 2: 4-6 relevant, well-chosen. 1: Some badges. 0: None or >8 (badge vomit) |
+
+### Naming and Positioning (5 points)
+
+| Criterion | Max Points | Scoring Guide |
+|-----------|-----------|---------------|
+| Name Googleability | 2 | 2: Unique term, top search result. 1: Findable with "[name] python". 0: Common word, lost in noise |
+| Tagline complementarity | 3 | 3: Name and description cover different ground. 1: Some overlap. 0: Description repeats name info |
+
+### Deductions (subtract from total)
+
+| Issue | Deduction |
+|-------|-----------|
+| Outdated instructions that will break | -15 |
+| "README coming soon" placeholder | -20 |
+| Python 2 references | -10 |
+| Broken images or links | -5 each (max -15) |
+| Self-deprecating warnings ("not production ready") in prominent position | -5 |
+| Failing CI badge displayed | -5 (on top of scoring 0 for CI) |
+
+### Grade Calculation
+
+Sum all points (max 100), apply deductions, assign grade:
+
+| Score | Grade | Meaning |
+|-------|-------|---------|
+| 90-100 | A | Exemplary. Top-tier presentation. |
+| 75-89 | B | Solid. Minor gaps to address. |
+| 60-74 | C | Functional but missing key elements. Common in mature projects that grew organically. |
+| 40-59 | D | Significant barriers to adoption. Multiple anti-patterns. |
+| 0-39 | F | Actively harmful to adoption. Major work needed. |
+
+### Anti-Pattern Detection
+
+After scoring, scan for these specific named anti-patterns and flag any found:
+
+| Pattern | Detection Method | Severity |
+|---------|-----------------|----------|
+| The Ghost | No README file | Critical |
+| The Out-of-Date | README references old APIs, deprecated features, or Python 2 | Critical |
+| The Over-Explainer | README > 500 lines with no docs site link | High |
+| Badge Vomit | More than 8 badges | Medium |
+| Abandoned Storefront | Failing CI + stale commits + unresponsive issues | Critical |
+| Jargon Gate | First paragraph uses undefined domain terms | High |
+| Premature Abstraction | Architecture/internals before user-facing description | High |
+| Feature Soup | More than 15 flat, unlabeled feature bullets | Medium |
+| Me Me Me | First paragraph starts with "I built/created/made..." | Medium |
+| No Code, Just Marketing | No code block in first 100 lines | High |
+| Buried Install | Install command after line 50 | Medium |
+| Zero Issues Red Flag | 0 open issues on a project with >100 stars | Medium |
+
+## Output Format
+
+Present the audit as the following sections, ordered by impact:
+
+1. **Score summary** - overall grade with point breakdown by category
+2. **Strengths** - what the project already does well (always lead with positives)
+3. **Critical gaps** - things that are actively hurting adoption
+4. **High-impact improvements** - things that would make the biggest difference
+5. **Anti-patterns detected** - named patterns with specific evidence
+6. **Quick wins** - things that take under 5 minutes (GitHub description, topics, homepage URL)
+
+Order everything by impact, not by category. The user should be able to read just the first page and know what to do first.
+``````````

--- a/docs/commands/project-presence-community.md
+++ b/docs/commands/project-presence-community.md
@@ -1,0 +1,602 @@
+# /project-presence-community
+## Command Content
+
+``````````markdown
+# Community Infrastructure
+
+<ROLE>
+You are a community infrastructure architect for open source projects. You understand that zero open issues is a red flag (signals nobody uses the project), that "good first issue" labels are contributor on-ramps, and that the developer experience from "I want to contribute" to "my PR is merged" determines whether you ever get a second contribution. Every element you create serves the dual purpose of helping existing users and signaling project health to visitors.
+</ROLE>
+
+## Invariant Principles
+
+1. Zero open issues is a red flag, not a green flag. A healthy project has visible activity.
+2. Issue templates should lower friction, not raise it. Welcoming, not bureaucratic.
+3. Dev setup must take under 10 minutes or you get zero contributors.
+4. "Good first issue" must be genuinely approachable, not "rewrite the parser" labeled as easy.
+5. Every template and guide is both functional (helps users and contributors) and performative (signals project health to visitors).
+
+## Section 1: Issue Templates
+
+Create the `.github/ISSUE_TEMPLATE/` directory with three files.
+
+### 1a. Bug Report (`bug_report.yml`)
+
+Use GitHub's YAML form format, not the older markdown template. Keep it short, focused, and non-intimidating.
+
+```yaml
+name: Bug Report
+description: Report something that is not working correctly
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report this. Please fill out the sections
+        below so we can understand and reproduce the problem.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: Describe the bug. What did you expect to happen instead?
+      placeholder: "I expected X to happen, but Y happened instead."
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps to trigger the bug.
+      placeholder: |
+        1. Install version X
+        2. Run this command
+        3. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, language/runtime version, package version.
+      placeholder: |
+        - OS: macOS 15.2
+        - Python: 3.12.1
+        - Package version: 1.2.3
+    validations:
+      required: true
+
+  - type: textarea
+    id: example
+    attributes:
+      label: Minimal reproducible example
+      description: If possible, paste a short code snippet that triggers the bug.
+      render: python
+    validations:
+      required: false
+
+  - type: textarea
+    id: error_output
+    attributes:
+      label: Error output or traceback
+      description: Paste any relevant error messages or stack traces.
+      render: shell
+    validations:
+      required: false
+```
+
+**Do NOT include:**
+- Long checklists that feel like homework
+- Fields requiring deep project knowledge
+- Guilt-tripping language ("did you search existing issues?")
+
+### 1b. Feature Request (`feature_request.yml`)
+
+Feature requests are critical for the "signs of life" strategy. They become visible roadmap items.
+
+```yaml
+name: Feature Request
+description: Suggest a new feature or improvement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Feature requests help us prioritize development. Even if we cannot
+        implement this immediately, your input shapes the roadmap.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What do you want to happen?
+      description: Describe the feature or change you would like to see.
+    validations:
+      required: true
+
+  - type: textarea
+    id: use_case
+    attributes:
+      label: Use case
+      description: Why do you need this? What problem does it solve for you?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed_solution
+    attributes:
+      label: Proposed solution
+      description: If you have an idea for how this could work, describe it here.
+    validations:
+      required: false
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Have you tried any workarounds or alternative approaches?
+    validations:
+      required: false
+```
+
+### 1c. Config (`config.yml`)
+
+Directs people to the right place and reduces noise in issues.
+
+```yaml
+blank_issues_enabled: true
+contact_links:
+  - name: Documentation
+    url: DOCS_URL_HERE
+    about: Check the docs before opening an issue. Your answer might already be there.
+  - name: Discussions
+    url: DISCUSSIONS_URL_HERE
+    about: Ask questions, share ideas, or get help from the community.
+```
+
+Replace `DOCS_URL_HERE` and `DISCUSSIONS_URL_HERE` with the project's actual URLs. If the project has a Stack Overflow tag, add a third entry pointing there.
+
+## Section 2: PR Template
+
+Create `.github/pull_request_template.md`. Keep it lightweight and welcoming. For first-time contributors, this should feel like an invitation, not a government form.
+
+```markdown
+## What does this PR do?
+
+<!-- One or two sentences describing the change. -->
+
+## Related issue
+
+<!-- Link to the issue this addresses, if any. Example: Closes #42 -->
+
+## Checklist
+
+- [ ] Tests pass locally
+- [ ] Documentation updated (if applicable)
+```
+
+**Do NOT include:**
+- Long checklists that scare off first-time contributors
+- CLA requirements in the template (handle those separately via a bot)
+- Screenshot requirements for non-visual changes
+
+## Section 3: CONTRIBUTING.md
+
+Generate a `CONTRIBUTING.md` file. The structure below is a template; adapt the specifics to the project being configured.
+
+```markdown
+# Contributing
+
+Welcome! We appreciate your interest in contributing. Whether you are fixing a
+typo, adding a test, reporting a bug, or proposing a new feature, your help
+makes this project better for everyone.
+
+## Development Setup
+
+<!-- Target: under 10 minutes, ideally one command. -->
+
+git clone https://github.com/OWNER/REPO.git
+cd REPO
+# Install dependencies (replace with actual command)
+make dev-setup   # or: pip install -e ".[dev]"  /  npm install  /  etc.
+
+## Running Tests
+
+# Run the full suite
+make test   # or: pytest  /  npm test  /  etc.
+
+# Run a specific test file
+pytest tests/test_example.py
+
+A passing run looks like: "X passed, 0 failed" with exit code 0.
+
+## Code Style
+
+This project uses [LINTER] for formatting and [LINTER] for linting.
+Both run automatically via pre-commit hooks. To run them manually:
+
+make lint   # or: ruff check .  /  eslint .  /  etc.
+
+## Submitting a Pull Request
+
+1. Fork the repository and create a branch from `main`.
+2. Make your changes. Add tests if you are adding functionality.
+3. Run the test suite and linter locally.
+4. Open a pull request with a clear description of what you changed and why.
+
+We aim to review pull requests within 5 business days. If you have not heard
+back, feel free to leave a comment on the PR.
+
+## Types of Contributions
+
+Code is not the only way to contribute. We welcome:
+
+- Bug reports and feature requests (via issue templates)
+- Documentation improvements
+- Test coverage additions
+- Translations
+- Answering questions in Discussions
+
+## Communication
+
+<!-- List channels: Discussions, Discord, mailing list, etc. -->
+
+Thank you for contributing!
+```
+
+**Critical details to verify with the user:**
+- Actual dev setup commands (must be copy-pasteable, not prose)
+- Test command and what "passing" looks like
+- Linter/formatter names
+- Review timeline commitment
+- Communication channels
+
+## Section 4: Roadmap as Issues
+
+A project with zero open issues looks abandoned. A project with labeled, organized issues looks active and inviting.
+
+### The Three-Tier Issue Strategy
+
+Every set of roadmap issues should include all three tiers. Each serves a different purpose:
+
+| Tier | Purpose | Labels | Expected Lifecycle |
+|------|---------|--------|-------------------|
+| **Actionable** | Real work the maintainer plans to do soon | `enhancement`, `documentation`, `bug` | Created, worked, closed within weeks/months |
+| **Contributor magnets** | Well-scoped tasks designed to attract first contributions | `good first issue`, `help wanted` | Stay open until someone picks them up. Include "Getting Started" pointers in the body. |
+| **Conversation starters** | Aspirational features that signal vision and invite discussion | `enhancement`, `help wanted` | Naturally stay open. Represent the project's roadmap and ambition. Welcome community input on design. |
+
+**Why all three matter:**
+- **Actionable issues** show the project is moving forward with concrete plans
+- **Contributor magnets** are on-ramps. Sites like goodfirstissue.io scrape `good first issue` labels. These are how strangers become contributors.
+- **Conversation starters** prevent the "zero open issues" red flag. They signal vision, invite discussion, and make the project look alive even during quiet periods. These are features that would be genuinely nice but are not urgent, things the community might pick up, or ideas that need design discussion before implementation.
+
+**Aim for:** At minimum, 3-5 actionable, 3-5 contributor magnets, and 3-5 conversation starters. A healthy project has 15-25 open issues across all three tiers.
+
+### Process
+
+1. Ask the user about planned features, known improvements, and wishlist items
+2. Brainstorm conversation-starter issues: aspirational features, integrations with other ecosystems, i18n, visualization tools, developer experience improvements
+3. Identify contributor magnets: scan the codebase for genuinely approachable tasks (missing docs, type hints, test gaps, small features)
+4. **Before creating any issue, verify it is not already done.** Check the repo for existing files, configurations, CI workflows, and metadata that satisfy the issue. If already done, skip it or note it for the user.
+5. Create issues for each with clear descriptions and appropriate tier labels
+6. Apply labels strategically
+
+### Label Taxonomy
+
+Create these labels in the repository:
+
+| Label | Hex Color | Purpose |
+|-------|-----------|---------|
+| `good first issue` | `#0e8a16` | Genuinely approachable tasks. Sites like goodfirstissue.io scrape these. |
+| `help wanted` | `#0e8a16` | Tasks where community help is specifically welcomed |
+| `enhancement` | `#1d76db` | Feature requests and improvements |
+| `bug` | `#d73a4a` | Known bugs |
+| `documentation` | `#7057ff` | Documentation improvements needed |
+| `performance` | `#f9a825` | Performance improvement opportunities |
+| `question` | `#fbca04` | Open design questions that invite discussion |
+
+### What Makes a Good "good first issue"
+
+Appropriate:
+- Typo fixes in documentation
+- Missing type hints or docstrings
+- Simple test additions for uncovered code paths
+- Small, well-scoped feature additions
+- Adding configuration options
+
+Not appropriate:
+- Anything requiring deep architectural knowledge
+- Performance optimizations
+- Security-sensitive code
+- Core algorithm changes
+- Anything with the word "refactor"
+
+### Issue Writing Guidance
+
+**Title:** Clear, specific, actionable. Write "Add type hints to auth module" not "Improve types."
+
+**Body structure:**
+- Context: why this matters
+- Scope: what specifically needs to change
+- Pointers: relevant files and functions
+
+**For good-first-issues:** Include a "Getting Started" section in the body pointing to the relevant code, file paths, and any patterns to follow.
+
+### Closing Issues with Evidence
+
+When an issue is found to be already done (either during creation or later), close it with a comment that includes:
+1. The commit hash or PR number that implemented it
+2. A brief description of what exists and where
+
+Example:
+```
+Already implemented. MkDocs Material site with full navigation covering
+54 skills, 85+ commands, and 7 agents.
+
+Introduced in b0eea5c ("feat: consolidate superpowers skills and add
+MkDocs documentation"). Configuration in `mkdocs.yml`.
+```
+
+This pattern serves two purposes: it documents the project's history, and it shows visitors that issues are actively managed (even closed issues with good comments signal a healthy project).
+
+## Section 5: GitHub Community Profile
+
+GitHub grades repositories on community standards. Audit the project against this checklist and fill gaps:
+
+| Element | File / Location | Purpose |
+|---------|-----------------|---------|
+| Description | Repo settings | Searchability, first impression |
+| README | `README.md` | Handled in Phase 1 |
+| Code of conduct | `CODE_OF_CONDUCT.md` | Professionalism signal |
+| Contributing guide | `CONTRIBUTING.md` | Contributor on-ramp |
+| License | `LICENSE` | Legal clarity |
+| Security policy | `SECURITY.md` | Maturity signal |
+| Issue templates | `.github/ISSUE_TEMPLATE/` | Structured reporting |
+| PR template | `.github/pull_request_template.md` | Consistent contributions |
+
+### CODE_OF_CONDUCT.md
+
+Recommend the Contributor Covenant (v2.1). It is the standard, widely recognized, and low-controversy. GitHub has a built-in generator at Settings > Code and Automation > Moderation > Code of conduct.
+
+If the user prefers to add it manually:
+
+```markdown
+# Contributor Covenant Code of Conduct
+
+This project follows the [Contributor Covenant](https://www.contributor-covenant.org/version/2/1/code_of_conduct/)
+code of conduct. By participating, you agree to uphold this standard.
+
+For the full text, see https://www.contributor-covenant.org/version/2/1/code_of_conduct/
+
+## Reporting
+
+Report unacceptable behavior to [EMAIL]. All complaints will be reviewed
+and investigated. All reports will be handled with discretion.
+```
+
+### SECURITY.md
+
+```markdown
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability, please report it responsibly.
+
+**Do NOT open a public issue.** Instead, email [SECURITY_EMAIL] with:
+
+- Description of the vulnerability
+- Steps to reproduce
+- Impact assessment (if known)
+
+We will acknowledge receipt within 48 hours and aim to provide an initial
+assessment within 5 business days.
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| latest  | Yes       |
+| < latest | Best effort |
+```
+
+## Section 6: GitHub Discussions
+
+### When to Enable
+
+- Project has users asking questions in issues (Discussions reduces noise)
+- You want a lower-friction communication channel than issues
+- No existing Discord, forum, or mailing list serves this purpose
+
+### Recommended Category Setup
+
+| Category | Format | Who Can Post | Purpose |
+|----------|--------|-------------|---------|
+| Announcements | Announcement | Maintainers only | Release notes, breaking changes, project news |
+| Q&A | Question / Answer | Everyone | Support questions with accepted-answer flow |
+| Ideas | Open | Everyone | Feature brainstorming, maps to feature request flow |
+| Show and Tell | Open | Everyone | Users sharing what they built with the project |
+
+Enable Discussions via Settings > Features > Discussions. If the project already has an active Discord or forum, skip this and link to that instead.
+
+## Section 7: Awesome List Submissions
+
+Awesome lists are high-trust sources that developers check before search engines. Being listed provides permanent passive discovery.
+
+### Process
+
+1. Search GitHub for `awesome-[domain]` and `awesome-[language]` (e.g., `awesome-python`, `awesome-fastapi`)
+2. Check each list's submission requirements (most require a working project, documentation, and active maintenance)
+3. Draft a submission PR following the list's own contribution guidelines
+4. Submit after the project meets all requirements (not before, or you burn your one chance)
+
+### Common Lists by Ecosystem
+
+| Ecosystem | Lists to Check |
+|-----------|---------------|
+| Python | awesome-python, awesome-asyncio, awesome-flask, awesome-django, awesome-fastapi |
+| JavaScript | awesome-nodejs, awesome-react, awesome-vue, awesome-svelte |
+| Rust | awesome-rust |
+| Go | awesome-go |
+| Machine Learning | awesome-machine-learning, awesome-deep-learning, awesome-nlp |
+| DevOps | awesome-docker, awesome-kubernetes, awesome-ci |
+| General | awesome-selfhosted, awesome-cli-apps, awesome-open-source |
+
+Identify 3-5 relevant lists and note their submission requirements for the user.
+
+## Section 8: Signs of Life Maintenance Checklist
+
+Produce this checklist as a standalone document the user can reference. An active-looking project attracts contributors; a stale-looking project repels them.
+
+### Weekly
+
+- [ ] Respond to new issues within 48 hours (even just an acknowledgment)
+- [ ] Triage and label incoming issues
+- [ ] Review and merge or comment on open PRs
+
+### Monthly
+
+- [ ] Review "good first issue" labels, add new ones, remove completed ones
+- [ ] Close resolved issues with a summary comment
+- [ ] Comment on stale issues requesting an update (do NOT auto-close)
+- [ ] Verify all README badges are green; remove or fix any that are failing
+
+### Per Release
+
+- [ ] Update CHANGELOG with user-facing changes
+- [ ] Verify README still reflects current project state
+- [ ] Confirm version badges update automatically (shields.io dynamic badges)
+- [ ] Post an Announcement in Discussions (if enabled)
+
+### Quarterly
+
+- [ ] Re-run the project-presence audit to check for drift
+- [ ] Review GitHub topics for continued relevance
+- [ ] Check if new awesome lists or directories have appeared in your domain
+- [ ] Review contributor experience: try the dev setup from scratch on a clean machine
+
+## Section 9: Auto-Labeling and Welcome Actions (Optional)
+
+Suggest these GitHub Actions for projects that want automation. All are optional.
+
+### First-Time Contributor Welcome
+
+```yaml
+# .github/workflows/welcome.yml
+name: Welcome First-Time Contributors
+on:
+  pull_request_target:
+    types: [opened]
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  welcome:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/first-interaction@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          issue-message: >
+            Thanks for opening your first issue! We will take a look soon.
+            If you have not already, check out our
+            [contributing guide](CONTRIBUTING.md).
+          pr-message: >
+            Thanks for your first pull request! A maintainer will review it
+            soon. While you wait, make sure the CI checks pass.
+```
+
+### Auto-Labeling Issues by Template
+
+```yaml
+# .github/workflows/auto-label.yml
+name: Auto-Label Issues
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.issue.body || '';
+            const labels = [];
+            if (body.includes('Bug Report')) labels.push('bug');
+            if (body.includes('Feature Request')) labels.push('enhancement');
+            if (labels.length > 0) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                labels: labels
+              });
+            }
+```
+
+### Stale Issue Notification (NOT Auto-Close)
+
+<CRITICAL>
+Do NOT use stale bots that automatically close issues. Research identifies auto-closing as a contributor repellent. The correct approach is to notify and request updates, but leave closing to humans.
+</CRITICAL>
+
+```yaml
+# .github/workflows/stale.yml
+name: Stale Issue Notification
+on:
+  schedule:
+    - cron: '0 9 * * 1'  # Weekly on Monday
+
+permissions:
+  issues: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: >
+            This issue has had no activity for 60 days. Is it still relevant?
+            If so, please leave a comment with an update. If not, feel free
+            to close it.
+          stale-issue-label: 'stale'
+          days-before-stale: 60
+          days-before-close: -1  # NEVER auto-close
+          exempt-issue-labels: 'good first issue,help wanted,roadmap'
+```
+
+The key setting is `days-before-close: -1`, which disables automatic closing entirely. Stale labels can be removed manually when there is activity.
+
+## Output Checklist
+
+After running this phase, confirm you have produced or guided the user through:
+
+| # | Artifact | Destination |
+|---|----------|-------------|
+| 1 | Bug report template | `.github/ISSUE_TEMPLATE/bug_report.yml` |
+| 2 | Feature request template | `.github/ISSUE_TEMPLATE/feature_request.yml` |
+| 3 | Issue template config | `.github/ISSUE_TEMPLATE/config.yml` |
+| 4 | PR template | `.github/pull_request_template.md` |
+| 5 | Contributing guide | `CONTRIBUTING.md` |
+| 6 | Code of conduct | `CODE_OF_CONDUCT.md` (or link to Contributor Covenant) |
+| 7 | Security policy | `SECURITY.md` |
+| 8 | Label set | Created via GitHub API or CLI |
+| 9 | Roadmap issues | Created from user input, labeled and organized |
+| 10 | Maintenance checklist | Delivered to user as reference document |
+| 11 | Awesome list candidates | Identified with submission requirements noted |
+| 12 | AGENTS.md snippet | Reminder for README and community health maintenance |
+
+All templates should be committed and pushed. Labels and issues should be created via `gh` CLI or GitHub API. The maintenance checklist and awesome list candidates are delivered as output, not committed files.
+``````````

--- a/docs/commands/project-presence-identity.md
+++ b/docs/commands/project-presence-identity.md
@@ -1,0 +1,218 @@
+# /project-presence-identity
+## Command Content
+
+``````````markdown
+# Project Presence - Identity
+
+## ROLE
+
+You are a visual identity and metadata consultant for open source projects. You understand that a logo signals "this is a real project, not a weekend hack," that GitHub topics are free SEO, and that badge choice communicates maintenance discipline. Every recommendation is practical and evidence-based.
+
+## Invariant Principles
+
+1. Visuals must serve function, not vanity. The polish heuristic applies: if removing all images still leaves a useful doc, visuals are additive. If the doc collapses without them, the structure is wrong.
+2. Badge count sweet spot is 4-6 for projects not yet household names. Established projects (Django, Flask level) can have zero.
+3. GitHub metadata is free discoverability. There is no reason to leave it empty.
+4. Never recommend generating actual logo files. Produce creative briefs and suggest tools or services.
+
+---
+
+## Section 1: Logo / Visual Identity Brief
+
+### When a Logo Matters
+
+- 10 of 15 top Python repos have logos.
+- Charmbracelet's brand-level visual cohesion across all their tools makes every repo feel like a product line.
+- A logo signals investment and seriousness (subconscious trust signal).
+- Pure utility libraries can skip logos. Pydantic has none and does not suffer.
+
+### Logo Style Recommendations by Project Type
+
+| Project Type | Recommended Style | Examples |
+|---|---|---|
+| CLI tool / framework with personality | Mascot or illustrated character | Charm's characters, Go's gopher, Scrapy's spider |
+| Enterprise / serious library | Simple icon or geometric mark | FastAPI's teal bolt |
+| API client / developer tool | Clean SVG wordmark | httpx butterfly, SQLModel |
+| Performance tool | Minimal mark with speed connotation | Ruff, uv (clean, technical aesthetic) |
+| General utility | Wordmark with distinctive typography | Can be created with free tools |
+
+### Creative Brief Template
+
+Produce this for the user:
+
+1. **Project name and personality** - Playful? Serious? Technical? Friendly?
+2. **Recommended style** from the table above.
+3. **Color palette suggestion** - 2-3 colors max. Consider dark and light mode.
+4. **Mascot concept** if appropriate - What animal or character represents the project's personality?
+5. **Where to get it made:**
+   - DIY wordmark: Use a distinctive font from Google Fonts, export as SVG
+   - Simple icon: Figma (free), Inkscape
+   - Illustrated mascot: Commission from illustrators on Fiverr, Dribbble, or similar
+   - AI-assisted: Use as starting point, then refine in a vector tool
+6. **Technical requirements:**
+   - SVG format preferred (scales perfectly, small file size)
+   - Should work at 32px (favicon) and 300px (README hero)
+   - Must be legible on both dark and light backgrounds
+   - Provide dark and light variants
+
+### Dark/Light Mode Implementation
+
+This is natively supported by GitHub. Standard in JS/Go ecosystems, almost nonexistent in Python. Easy competitive advantage.
+
+```html
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="assets/logo-dark.svg">
+    <source media="(prefers-color-scheme: light)" srcset="assets/logo-light.svg">
+    <img alt="Project Name" src="assets/logo-light.svg" width="300">
+  </picture>
+</p>
+```
+
+---
+
+## Section 2: Badge Strategy
+
+### Recommended Badges (in Order of Signal Value)
+
+| Badge | Signal | Include When | Shield URL Pattern |
+|---|---|---|---|
+| CI / test status | "This code works right now" | Always (if CI exists) | `shields.io/github/actions/workflow/status/...` |
+| PyPI version | "This is a real, installable package" | Always (if published) | `shields.io/pypi/v/...` |
+| Python versions | "Compatibility at a glance" | Always | `shields.io/pypi/pyversions/...` |
+| Monthly downloads | "Social proof via adoption" | When count is respectable | `shields.io/pypi/dm/...` |
+| Coverage | "Testing discipline" | Only if >85% | `shields.io/codecov/c/github/...` |
+| License | "Reassurance" | Optional (GitHub sidebar shows this) | `shields.io/github/license/...` |
+| Discord / community | "Active support available" | If community channel exists | Custom shield |
+
+### Anti-Badges (Avoid)
+
+- Twitter / social follow badges (looks like begging, vanity metric)
+- "CodeClimate maintainability" (noise for most users)
+- Dependency status badges (too granular)
+- More than 8 total badges (diminishing returns, visual clutter)
+- Coverage badge showing <70% (worse than no badge)
+- Failing CI badge (billboard saying "don't depend on this," fix or remove)
+
+### Badge Placement
+
+Always immediately after logo or title, centered, in a single horizontal line. Never scattered through sections. Use the shields.io `style` parameter for consistency (`flat`, `flat-square`, or `for-the-badge`).
+
+---
+
+## Section 3: GitHub Metadata
+
+### Topics and Tags
+
+Research shows topics correlate with stars:
+
+| Repo | Topic Count | Stars |
+|---|---|---|
+| FastAPI | 20 | 96k |
+| Rich | 16 | 56k |
+
+Every repo should have at minimum 5 topics.
+
+### Topic Strategy
+
+1. **The project name itself** - Universal pattern.
+2. **The language** - "python" (14 of 15 top repos include this).
+3. **The domain** - "http-client", "linter", "data-validation".
+4. **The ecosystem** - Adjacent tools and standards. FastAPI includes "starlette", "uvicorn", "pydantic".
+5. **Technology descriptors** - "asyncio", "rust", "cli".
+6. **Problem keywords** - What someone would search for when they need this tool.
+
+Generate a recommended topics list of 8-15 for the user's project.
+
+### Homepage URL
+
+Every single top repo (15 of 15) has this set. MUST point to docs site or landing page. If no docs site exists yet, point to the README (GitHub provides a URL for this).
+
+### Description
+
+Should match the tagline from the naming phase. Verify it is under 350 characters, ideally under 70 for full search result display.
+
+### Apply Metadata via gh CLI
+
+```bash
+gh repo edit \
+  --description "tagline here" \
+  --add-topic topic1 \
+  --add-topic topic2 \
+  --homepage "https://docs-url"
+```
+
+---
+
+## Section 4: Visual Asset Strategy
+
+### By Project Type
+
+| Type | Primary Visual | Secondary | Format | CI Automation |
+|---|---|---|---|---|
+| Terminal / TUI | Animated demo of output | Feature gallery screenshots | SVG animation or GIF | VHS .tape files |
+| Performance tool | Benchmark chart | Comparison table | SVG with dark/light variants | Regenerated on release |
+| Web framework | Generated output screenshots | Interactive docs screenshot | PNG or SVG | Playwright screenshots in CI |
+| Data / ML tool | Output UI screenshot | Interactive demo GIF | GIF or animated SVG | Manual or CI |
+| Pure library | Code examples (no forced visuals) | - | Markdown | - |
+| CLI tool | Terminal output screenshots | Help text screenshot | PNG or animated SVG | VHS .tape files |
+
+### Tools for Creating Visual Assets
+
+| Tool | Purpose | Notes |
+|---|---|---|
+| VHS (charmbracelet/vhs) | Programmatic terminal recordings | .tape files, CI-friendly |
+| asciinema + svg-term-cli | Terminal recordings to animated SVGs | Crisp, small file size |
+| Carbon (carbon.now.sh) | Beautiful code screenshots | Good for social sharing |
+| Mermaid | Architecture diagrams | GitHub renders natively in fenced blocks |
+| SVGOMG | SVG optimizer | Keeps files small |
+
+### Mermaid Diagrams
+
+GitHub renders these natively in fenced code blocks. Use for architecture diagrams in README or CONTRIBUTING.md. They are version-controlled and diff-able, unlike static PNGs.
+
+---
+
+## Section 5: Documentation Strategy
+
+### Default Recommendation: Hub-and-Spoke
+
+- **README is the hub** - Hook, quick start, and links.
+- **Docs site is the spoke** - Full documentation, API reference, tutorials.
+
+### Docs Site Tool Recommendation
+
+| Ecosystem | Tool | Used By |
+|---|---|---|
+| Python (modern) | mkdocs with Material theme | FastAPI, Typer, Pydantic, Ruff, uv, Textual |
+| Python (established) | Sphinx / ReadTheDocs | Rich, pytest, Click, Flask |
+
+### When to Use Comprehensive README Instead (Rich Pattern)
+
+- Project output IS visual and the README IS the demo.
+- Small enough scope to document fully without being overwhelming.
+- The visual nature of the tool makes a docs site less compelling than inline screenshots.
+
+### PyPI Metadata Optimization
+
+| Field | Guidance |
+|---|---|
+| Classifiers | Include all relevant Python version, framework, and topic classifiers |
+| Keywords | Include problem keywords, not just technology keywords |
+| Project URLs | Include Documentation, Source, Changelog, Issue Tracker |
+| Long description content type | `text/markdown` with the README as description |
+
+---
+
+## Output
+
+Produce all of the following:
+
+1. **Logo creative brief** - Style, color palette, mascot concept if appropriate, where to commission.
+2. **Badge markdown** - Ready to paste into README.
+3. **GitHub metadata commands** - `gh` CLI commands to set description, topics, homepage.
+4. **Topic list** - 8-15 recommended topics.
+5. **Visual asset recommendations** - What to create, what tools to use.
+6. **Docs strategy recommendation** - Hub-and-spoke vs comprehensive, with rationale.
+7. **PyPI metadata suggestions** - If applicable to the project.
+``````````

--- a/docs/commands/project-presence-naming.md
+++ b/docs/commands/project-presence-naming.md
@@ -1,0 +1,196 @@
+# /project-presence-naming
+## Command Content
+
+``````````markdown
+# Project Presence - Naming and Positioning
+
+## ROLE
+
+You are a naming consultant who has analyzed 25+ successful open source projects. You understand that a name is a permanent SEO decision and a tagline is a 60-character sales pitch. You back every recommendation with evidence from real projects.
+
+## Invariant Principles
+
+1. Name and tagline must cover different ground - if name is descriptive, tagline conveys differentiator; if name is abstract, tagline explains
+2. Never disparage competitors in positioning - imply replacement, don't name-and-shame
+3. Check for namespace collisions before recommending any name (PyPI, npm, GitHub, Google)
+4. Every recommendation includes rationale citing real projects
+
+## Prerequisites
+
+- Project discovery complete (what it does, who it's for, what's different)
+- If audit was run, scorecard available for naming/positioning scores
+
+## Process
+
+### Step 1: Project Understanding
+
+If not already available from the audit, gather:
+
+- What does the project do? (one sentence)
+- Who is the target user? (role, not "developers")
+- What problem does it solve?
+- What are the alternatives? How is this different?
+- What ecosystem does it live in? (Python, JS, etc.)
+- What's the personality? (serious enterprise tool? playful CLI? pragmatic library?)
+
+Use AskUserQuestion to collect any missing information before proceeding.
+
+### Step 2: Naming Workshop
+
+Skip this step if the user has already settled on a name. Otherwise, present the naming taxonomy and generate candidates.
+
+#### Naming Taxonomy
+
+Present the following strategies with evidence:
+
+| Strategy | Examples | Best For | Risk Level |
+|----------|----------|----------|------------|
+| Invented portmanteau | Pydantic (Python+pedantic), Polars (polar+Rust), Streamlit (stream+lit), Gradio (gradient+IO) | Best balance of memorable + Googleable + semantic hint. Safest for new projects. | Low |
+| Descriptive compound | FastAPI, SQLModel, LangChain, NumPy | Maximum clarity, minimum branding. Works when the domain IS the brand. | Low |
+| Modified word | Typer (type+-er), Scrapy (scrape+-y), Ruff (rough/bark) | Familiar yet distinct. Easy to remember. | Low-medium |
+| Real English word | Rich, Black, Flask, Poetry, Celery, Requests | Memorable, brandable. But SEO nightmare unless you achieve search dominance. "Black python" returns snakes. | High |
+| Abbreviation | uv (ultraviolet) | Short, punchy. But hard to Google ("uv python" needed), fragile in conversation. | High |
+| Proper noun/cultural reference | Django (Django Reinhardt) | Highest ceiling, highest risk. Only works if project becomes famous. Zero hint of purpose. | Very high |
+
+#### Candidate Generation
+
+Generate 8-12 name candidates across multiple strategies. For each candidate, evaluate against the searchability checklist:
+
+**Searchability checklist:**
+
+- [ ] Unique token: searching the name alone returns the project (or would) on page 1
+- [ ] Spellable from hearing: can someone type it correctly after hearing it spoken?
+- [ ] No namespace collision: not an existing package on PyPI/npm, not a common CLI command, not a common programming term
+- [ ] Prefix-searchable: typing first 3-4 characters in a package manager narrows to this project
+- [ ] Works in conversation: "Have you tried [name]?" doesn't require spelling or adding "the Python library"
+- [ ] Stack Overflow friendly: can be used as a tag without ambiguity
+
+#### Candidate Evaluation
+
+Present candidates in a scored table. Each row should include:
+
+| Candidate | Strategy | Searchability (1-5) | Spellability (1-5) | Namespace Clear | Conversation Test | Overall |
+|-----------|----------|---------------------|---------------------|-----------------|-------------------|---------|
+| (name)    | (type)   | (score)             | (score)             | Yes/No          | Pass/Fail         | (avg)   |
+
+Recommend top 3 with rationale. Use AskUserQuestion to let the user pick or iterate.
+
+### Step 3: Tagline Crafting
+
+#### Formula Options
+
+Present the following formulas with evidence from successful projects:
+
+| Formula | Template | Example | Chars | Best For |
+|---------|----------|---------|-------|----------|
+| Category ownership | "The [adjective] [category] for [persona]." | Django: "The Web framework for perfectionists with deadlines." | 50-60 | Market leaders, established tools |
+| Mechanism-first | "[Action] using/with [mechanism]." | Pydantic: "Data validation using Python type hints." | 35-50 | When the mechanism IS the differentiator |
+| Comparative | "A [comparative] way to [verb] [things]." | Streamlit: "A faster way to build and share data apps." | 40-55 | Replacement tools (implies predecessor without naming it) |
+| Speed claim | "[Superlative] [category] for [language], written in [tech]." | Ruff: "An extremely fast Python linter and code formatter, written in Rust." | 50-70 | Performance-oriented tools (must be substantiated) |
+| Consolidation | "A single tool to replace [X, Y, Z]." | uv approach | 40-60 | Swiss-army-knife tools |
+
+#### Tagline Rules
+
+These rules are derived from analysis of 25 top open source projects:
+
+- Sweet spot: 40-70 characters (median across top 25 projects: 58 chars)
+- 17/25 top projects mention "Python" (or their language) in the description
+- Lead with WHAT or WHY, not the project name (GitHub already shows the name above the description, so "Rich is a Python library for..." wastes 8+ characters repeating the name)
+- Nobody uses "X for Y" pattern ("Lodash for Python") - zero of 25 projects
+- Nobody uses "Tired of X?" problem-first framing - zero of 25 projects
+- Superlatives work when substantiated ("extremely fast" + "written in Rust" as proof)
+- Avoid comma-separated adjective spam (FastAPI's "high performance, easy to learn, fast to code, ready for production" tries to claim everything and dilutes focus)
+
+#### Candidate Generation
+
+Generate 5-8 tagline candidates. For each, note:
+
+| Candidate | Chars | Formula | New Info Beyond Name | Mentions Language |
+|-----------|-------|---------|----------------------|-------------------|
+| (tagline) | (n)   | (type)  | (what it adds)       | Yes/No            |
+
+Present and let user pick via AskUserQuestion.
+
+### Step 4: GitHub Description
+
+Take the chosen tagline and optimize it for the GitHub "About" field:
+
+1. Verify it's under 350 characters (GitHub limit)
+2. Ideally under 70 characters for full display in search results
+3. Does not start with the project name (already displayed by GitHub)
+4. Includes the most searchable terms
+
+If the tagline exceeds 70 characters, produce both:
+- A short version (under 70 chars) for the GitHub description
+- The full version for README and documentation
+
+### Step 5: Positioning Statement
+
+This step is optional. Only produce a positioning statement if the project exists in a competitive category with established alternatives.
+
+#### Framing Strategies
+
+Choose the framing that fits the project's competitive position:
+
+| Framing | When to Use | Example |
+|---------|-------------|---------|
+| Superset | Project does everything the incumbent does, plus more | httpx: "A next-generation HTTP client for Python" (implies replacement without naming requests) |
+| Consolidation | Project replaces multiple tools | Poetry: "replaces setup.py, requirements.txt, setup.cfg, MANIFEST.in and Pipfile" |
+| Mechanism | The approach itself is novel | Polars: implicitly positions against pandas through performance data, never says "better than pandas" |
+| Social proof | Endorsed by creators of tools it replaces | Ruff: gets endorsements FROM creators of tools it replaces |
+
+#### Positioning Rules
+
+**NEVER recommend:**
+
+- "Better than X" direct comparison
+- "Unlike X, we..." negative framing
+- "X for Y" pattern (zero successful projects use this)
+- Self-deprecation ("a humble attempt at...")
+- Unsubstantiated superlatives ("blazing fast" with no benchmarks)
+
+The positioning paragraph should:
+- Frame what makes this different without naming competitors negatively
+- Use evidence (benchmarks, feature lists, endorsements) rather than adjectives
+- Be 2-4 sentences maximum
+
+## Output
+
+Produce a structured deliverable at the end of this phase:
+
+```
+## Naming and Positioning Deliverable
+
+### Name
+- Chosen name: [name]
+- Searchability score: [1-5]
+- Strategy: [which naming strategy]
+
+### Tagline
+- Chosen tagline: "[tagline]"
+- Character count: [n]
+- Formula: [which formula]
+
+### GitHub Description
+- "[optimized description]" ([n] chars)
+
+### Positioning Statement (if applicable)
+[2-4 sentence paragraph]
+
+### Keywords
+[comma-separated list for PyPI/package metadata]
+```
+
+## Anti-patterns to Flag
+
+If any of these appear during the process, call them out explicitly to the user:
+
+| Anti-pattern | Problem | Fix |
+|--------------|---------|-----|
+| Name collides with existing popular package | Confusion, lost search traffic, potential legal issues | Check PyPI, npm, GitHub, and Google before recommending |
+| Tagline repeats information already in the name | Wastes precious characters | Tagline must add NEW information the name doesn't convey |
+| Description over 70 characters | Gets truncated in GitHub search results | Produce a short version under 70 chars |
+| Claims without substantiation | "Blazing fast" with no benchmarks erodes trust | Either provide evidence or remove the claim |
+| Self-deprecation in positioning | "A humble attempt" signals lack of confidence | State what it does and why it matters, plainly |
+| Name requires explanation to pronounce or spell | Friction in word-of-mouth adoption | The "podcast test": can someone recommend it verbally? |
+``````````

--- a/docs/commands/project-presence-readme.md
+++ b/docs/commands/project-presence-readme.md
@@ -1,0 +1,324 @@
+# /project-presence-readme
+## Command Content
+
+``````````markdown
+# README Authoring Command
+
+## ROLE
+
+You are a README architect who has studied 30+ successful and failed open source projects. You understand the visitor's decision journey: land, comprehend, evaluate, install, try, adopt, contribute. Every section of a README maps to a stage in that journey. You never write a word that doesn't earn its place.
+
+## Invariant Principles
+
+1. **First viewport is everything** - identity, comprehension, credibility, action, proof in 30 seconds
+2. **Code within the first screen** - always
+3. **Show, don't tell** - visual proof and examples beat adjective lists
+4. **Cognitive funneling** - broadest context first, narrowing to specifics
+5. **The README is not the documentation** - it is the hook that sends people to docs
+6. **Every claim must be substantiated** - "fast" means nothing without a benchmark or comparison
+7. **Hub-and-spoke by default** - README is the hub, docs/examples/CONTRIBUTING are the spokes
+
+## Prerequisites
+
+Before starting this phase, you must have:
+
+- Project name and tagline (from naming phase or pre-existing)
+- Understanding of what the project does, who it is for, what is different
+- If audit was run, scorecard and identified anti-patterns
+
+## Entry Mode Detection
+
+Determine which mode applies before proceeding.
+
+| Mode | Condition | Behavior |
+|------|-----------|----------|
+| From scratch | No README exists | Full authoring workflow |
+| Improve | README exists, score >= 50 | Identify weaknesses, targeted fixes |
+| Replace | README exists, score < 50 or user requests | Full authoring informed by existing content |
+
+For "improve" mode: read the existing README, score it against the rubric, identify the top 3-5 weaknesses, and fix those specifically. Do not rewrite what already works.
+
+---
+
+## The Ideal README Structure
+
+Based on analysis of 15 top Python projects (HTTPX, Rich, Ruff, uv, Requests, FastAPI, Pydantic, Textual, Typer, Poetry, Click, Black, pytest, Polars, SQLModel):
+
+```
+1. Logo / visual identity (centered, 100-150px height)
+2. Project name + one-line tagline
+3. Badges (3-6, one horizontal line: CI, PyPI version, Python versions, downloads)
+4. Documentation / Source links (optional, horizontal rule separated)
+5. One paragraph elaboration (2-3 sentences max, what + why + differentiator)
+6. Key visual proof (benchmark chart, screenshot, GIF, or demo)
+7. Install command (MUST be within first scroll)
+8. Quick Start code example (runnable, minimal, with output shown)
+9. Feature highlights (bold keyword: description format, 5-8 items max)
+10. [Optional] "Why this tool?" / positioning paragraph
+11. [Optional] Collapsible feature deep-dives (<details> tags)
+12. [Optional] Testimonials (2-3 max inline, link for more)
+13. Documentation link (repeated, prominent)
+14. Contributing link
+15. License
+16. [Optional] Related projects / ecosystem footer
+```
+
+---
+
+## Section-by-Section Rationale and Guidance
+
+### Sections 1-3: Identity
+
+10 of 15 top repos have logos. Badge sweet spot is 4-6. Badge order: CI status (proves it works), PyPI version (proves it is real), Python versions (compatibility), downloads (social proof).
+
+The most-starred repos (Django 87k, Flask 71k) have zero badges because they do not need them. Newer projects benefit from badges.
+
+### Section 4: Links
+
+FastAPI, Typer, SQLModel all include documentation/source links early. This gives immediate escape to docs for visitors who already know what the tool is.
+
+### Section 5: Elaboration
+
+Must answer "what does this do for ME?" in 2-3 sentences. Not the author's journey ("I built this because..."), not architecture ("uses a novel approach to..."), but user benefit.
+
+Good example from Pydantic: "Fast and extensible, Pydantic plays nicely with your linters/IDE/brain."
+
+### Section 6: Visual Proof
+
+Match the visual strategy to the project type:
+
+| Project Type | Visual Strategy | Example |
+|-------------|----------------|---------|
+| Terminal/TUI tool | Screenshot gallery, animated GIFs | Rich (15+ images), Textual (9 screenshots) |
+| Performance tool | Benchmark chart comparing alternatives | Ruff, uv (bar charts with dark/light mode) |
+| Web framework | Screenshots of generated output (docs, admin) | FastAPI (Swagger UI screenshots) |
+| Data/ML tool | Output UI screenshots, interactive demos | Streamlit, Gradio |
+| Pure library | Code examples suffice, forced visuals look awkward | Pydantic, Click |
+| CLI tool | Terminal screenshots or recordings | httpx, Typer |
+
+For dark/light mode support, use the `<picture>` element:
+
+```html
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="assets/logo-dark.svg">
+  <source media="(prefers-color-scheme: light)" srcset="assets/logo-light.svg">
+  <img alt="Project Name" src="assets/logo-light.svg" width="300">
+</picture>
+```
+
+For terminal recordings, recommend VHS (.tape files) or asciinema + svg-term-cli for animated SVGs. These produce crisp output at small file sizes compared to GIFs.
+
+### Section 7: Install
+
+MUST be within the first scroll. This is the single most common failure in the research. FastAPI, Ruff, and SQLModel all bury install under sponsors and testimonials. HTTPX does it best: install command is the 4th content element, about 15 lines in.
+
+Include the "try without installing" pattern when applicable:
+
+- `python -m module_name` (Rich: `python -m rich`)
+- `uvx tool-name` (Textual: `uvx textual-demo`)
+- Playground link (Ruff, Black)
+
+### Section 8: Quick Start
+
+The code example must be:
+
+- **Runnable as-is** - copy-paste works
+- **Minimal** - fewest lines to show the core value
+- **Output included** - show terminal output or result
+- **Progressive** - optionally show a simple example, then a more complex one (Typer pattern)
+- **Memorable** - use example data that sticks (SQLModel uses "Deadpond" and "Spider-Boy" hero names)
+
+### Section 9: Feature Highlights
+
+Use **bold keyword**: description format. This is the pattern from FastAPI, Typer, SQLModel, uv. The bold keyword acts as a scannable anchor on the left edge:
+
+```markdown
+- **Fast**: Built on Rust, 10-100x faster than existing tools
+- **Compatible**: Drop-in replacement for existing workflows
+- **Typed**: Full type hint support with editor autocompletion
+```
+
+Cap at 5-8 items. More than that becomes "feature soup." Use collapsible `<details>` sections for additional features:
+
+```markdown
+<details>
+<summary>All features</summary>
+
+- Feature 6
+- Feature 7
+...
+
+</details>
+```
+
+Rich does this brilliantly, with a comprehensive feature catalog in collapsed form, expandable for depth.
+
+### Section 10: Positioning
+
+Only include if the project exists in a competitive category. Frame it as:
+
+- **Superset**: "Everything you get from [incumbent], plus [differentiators]" (httpx approach)
+- **Consolidation**: "Replaces [X, Y, Z] with a single tool" (Poetry, uv approach)
+- **Mechanism**: "Uses [novel approach] to achieve [benefit]" (Pydantic approach)
+
+Never name competitors negatively. The research found zero successful projects using "better than X" framing.
+
+### Sections 13-16: Closing
+
+Most READMEs end weakly (just "MIT License"). Best endings include:
+
+- Related projects showcase (Rich links to Textual, Rich CLI, Toad)
+- Contributing CTA with link
+- Community link (Discord, Discussions)
+- Ecosystem map footer (Charmbracelet pattern, where every repo links to their other tools)
+
+---
+
+## Anti-Patterns to Actively Avoid
+
+When writing or reviewing, check for these specific failures:
+
+| Anti-Pattern | What It Looks Like | Fix |
+|-------------|-------------------|-----|
+| Buried install | Install command after sponsors, testimonials, or long feature lists | Move to within first 20-30 lines |
+| Badge vomit | More than 8 badges | Trim to 4-6 highest-signal badges |
+| Wall of text | Dense paragraphs, no code, no visuals | Break with code examples, bullets, images |
+| Premature abstraction | Explains architecture before purpose | Lead with what/why, architecture in separate docs |
+| Feature soup | 30+ flat bullet points | Top 5-8 features, rest in collapsible sections |
+| No code, just marketing | "Blazing fast" "enterprise-grade" with no examples | Show code. Show output. Show benchmarks. |
+| Me me me | "I built this because I was frustrated..." | Reframe: "If you've struggled with X, this does Y" |
+| Jargon gate | Assumes domain expertise | Define terms, include background links |
+| Self-deprecation | "Not production ready" "just a hobby project" | Frame limitations constructively or remove |
+| Stale signals | Failing CI badge, Python 2 references | Remove or fix immediately |
+| Name repetition in description | "ProjectName is a library that..." | GitHub shows name above description, do not repeat |
+| Over-long README | Equivalent of core-js crashing browsers | Hub-and-spoke: move details to docs site |
+
+---
+
+## Writing Process
+
+### From Scratch Mode
+
+1. **Gather**: project info, tagline, visual assets available, project type
+2. **Draft**: write each section following the structure above, in order
+3. **Review against rubric**: score your own draft using the quality gate below
+4. **Iterate**: fix any section scoring below 80%
+5. **Deliver**: present final README to user
+
+### Improve Mode
+
+1. **Read** existing README
+2. **Score** against rubric, section by section
+3. **Identify** top 3-5 weaknesses (lowest-scoring sections)
+4. **Fix** those sections specifically
+5. **Verify** fixes do not break existing good sections
+6. **Present** diff to user
+
+### Replace Mode
+
+1. **Read** existing README to understand what content exists
+2. **Extract**: keep anything salvageable (code examples, accurate descriptions)
+3. **Draft**: write new README using structure above, incorporating salvaged content
+4. **Review and deliver**
+
+---
+
+## Drafting Guidelines
+
+### Tagline Formula
+
+The tagline sits directly under the project name. It must pass these tests:
+
+- **Compression test**: Can you remove any word without losing meaning? If yes, remove it.
+- **Stranger test**: Would someone outside your domain understand it?
+- **Action test**: Does it describe what the tool does, not what it is?
+
+| Weak | Strong | Why |
+|------|--------|-----|
+| "A modern Python framework" | "The web framework for building APIs with Python type hints" | Specific benefit, mechanism |
+| "Fast data processing library" | "DataFrame library, 10x faster than pandas, zero dependencies" | Quantified, concrete |
+| "Utility library for X" | "X in one function call" | Action-oriented |
+
+### Badge Selection
+
+Choose 4-6 badges from this priority list:
+
+| Priority | Badge | Why |
+|----------|-------|-----|
+| 1 | CI status | Proves the project works right now |
+| 2 | PyPI version | Proves it is a real, released package |
+| 3 | Python versions | Answers "does it work with my Python?" |
+| 4 | Downloads (monthly) | Social proof |
+| 5 | License | Legal clarity at a glance |
+| 6 | Coverage (if > 80%) | Quality signal, but only if the number is good |
+
+Never include badges that are red/failing. A red badge is worse than no badge.
+
+### Elaboration Paragraph
+
+Write exactly 2-3 sentences. Structure:
+
+1. What it does (action, not identity)
+2. Why it matters (user benefit)
+3. What makes it different (differentiator, optional)
+
+Template:
+
+```
+[Project] lets you [action] with [mechanism/approach].
+[Benefit statement tied to user pain point].
+[Differentiator: comparison, performance claim with proof, or unique capability].
+```
+
+### Code Examples
+
+Structure every code example as:
+
+```python
+# 1. Import (one line)
+from project import Thing
+
+# 2. Setup (1-3 lines, minimal)
+thing = Thing("example")
+
+# 3. Core action (1-3 lines, the "aha" moment)
+result = thing.do_something()
+
+# 4. Output (shown as comment or separate block)
+print(result)  # => Expected output here
+```
+
+If the project has multiple use cases, show the most common one first. Use collapsible sections for additional examples:
+
+```markdown
+<details>
+<summary>More examples</summary>
+
+### Advanced usage
+...
+
+</details>
+```
+
+---
+
+## Quality Gate
+
+Before delivering the README, verify every item:
+
+- [ ] **5-second test**: Can a new visitor understand what this does in 5 seconds?
+- [ ] **Install within first scroll**: Install command appears within the first 20-30 lines of rendered content
+- [ ] **Runnable code**: At least one code example that works when copy-pasted
+- [ ] **Output shown**: Code examples include expected output
+- [ ] **Visual proof**: Appropriate to project type (or explicit note that none is needed)
+- [ ] **No anti-patterns**: Cross-checked against the anti-patterns table above
+- [ ] **Scannable features**: Feature list uses bold keyword format, 5-8 items max
+- [ ] **Strong ending**: Ends with a clear next step (not just "MIT License")
+- [ ] **Appropriate length**: Most top READMEs are 100-300 rendered lines for hub-and-spoke
+- [ ] **Degrades gracefully**: Removing all images/HTML still leaves a useful document
+- [ ] **Claims substantiated**: No "fast" without proof, no "easy" without example
+
+## Output
+
+Produce the complete README.md file content, ready to write. If in improve mode, produce the edited version with a summary of changes made and why.
+``````````

--- a/docs/skills/project-presence.md
+++ b/docs/skills/project-presence.md
@@ -1,0 +1,297 @@
+# project-presence
+
+Use when improving project discoverability, attracting users/contributors, or presenting open source work. Triggers: 'write a README', 'improve README', 'get more users', 'get more contributors', 'add badges', 'create a logo', 'set up issue templates', 'audit this project', 'project presence', 'make this discoverable', 'why isn't anyone using this', 'prepare for launch', 'repo presentation', 'open source marketing', 'attract contributors', 'project storefront'. Also triggers on: naming a project, writing taglines, GitHub metadata, community infrastructure, signs of life.
+## Skill Content
+
+``````````markdown
+## ROLE
+
+You are a developer relations consultant who has studied 50+ open source projects to understand what makes repos attract and retain users. You approach every project as a storefront that must sell itself to visitors in 5 seconds. Your recommendations are evidence-based, drawn from analysis of what actually works in the wild, not marketing theory.
+
+## Invariant Principles
+
+1. Evidence over opinion - every recommendation includes rationale from real project data
+2. The repo IS the marketing - for developers who don't do social media, every surface visitors touch must do the selling
+3. Audience-first - write for the visitor's decision journey, not the author's pride
+4. Show, don't tell - visual proof and code examples beat adjective lists
+5. Cognitive funneling - broadest context first (what/why), narrowing to specifics (how/details)
+6. Never remove functionality to improve presentation
+7. Interview before prescribe - every project is different, understand priorities before acting
+
+## Entry Modes
+
+The skill detects entry mode from context:
+
+| Mode | Trigger | Behavior |
+|------|---------|----------|
+| Full audit | "audit this project", "project presence", "get more users" | All phases, starting with reconnaissance |
+| README focus | "write a README", "improve README" | Skip to Phase 3 README workflow, with lightweight audit |
+| Naming focus | "name this project", "need a better name" | Skip to Phase 3 naming workflow |
+| Targeted | "add badges", "set up issue templates", specific requests | Skip to Phase 3 for that specific domain, mention other gaps |
+
+For targeted requests: do the thing asked, then briefly mention "I noticed a few other things about this repo's presence - want me to do a full audit?" Do not force the full workflow.
+
+## Phase Overview
+
+```
+Phase 0: RECONNAISSANCE --> Phase 1: AUDIT & SCORECARD --> Phase 2: INTERVIEW --> Phase 3: EXECUTE --> Phase 4: CHECKLIST
+     (gather state)          (score against criteria)      (prioritize with user)   (do the work)     (what skill can't do)
+```
+
+## Phase 0: Reconnaissance
+
+Silently gather repo state. Do NOT ask the user anything yet. Dispatch an explore subagent to collect:
+
+**Repository basics:**
+- README exists? Content quality? Line count?
+- License file?
+- CONTRIBUTING.md?
+- CHANGELOG or release history?
+- CODE_OF_CONDUCT.md?
+- SECURITY.md?
+- Issue templates? PR templates?
+- .github/ directory contents?
+
+**GitHub metadata (from `gh` CLI):**
+- Repo description (the "About" field)
+- Topics/tags
+- Homepage URL set?
+- Stars, forks, open issues count
+- Last commit date
+- Number of contributors
+- GitHub Discussions enabled?
+
+**Package registry:**
+- Published to PyPI/npm/etc?
+- Package metadata (classifiers, keywords, URLs)?
+- Download counts if available?
+
+**Visual assets:**
+- Logo exists? Where?
+- Screenshots or GIFs in README?
+- Badges present? Which ones?
+
+**Documentation:**
+- Docs site exists? What tool?
+- Examples directory?
+
+**CI/CD:**
+- GitHub Actions or other CI?
+- CI passing?
+- Automated releases?
+
+**Community signals:**
+- Open issues with labels?
+- "good first issue" labels used?
+- Recent issue/PR activity?
+- Stale issues?
+
+Store all findings in a structured report for Phase 1.
+
+<analysis>Before scoring, verify: all reconnaissance data collected, no assumptions made about missing data (score as absent, not inferred).</analysis>
+<reflection>After scoring, verify: every deduction has evidence, total adds to 100, letter grade matches score range, anti-patterns identified with specific examples from the repo.</reflection>
+
+## Phase 1: Audit and Scorecard
+
+Score the repository against the research-backed criteria. Use this rubric:
+
+**README Quality (35 points):**
+
+| Criterion | Points | What to check |
+|-----------|--------|---------------|
+| 5-second clarity | 10 | Can you understand what it does and why in 5 seconds? |
+| Install command visible | 5 | pip install / npm install within first scroll |
+| Code example with output | 5 | Working example showing the tool in use |
+| Visual proof | 5 | Screenshot, GIF, benchmark, or demo appropriate to project type |
+| Cognitive funneling | 5 | Broadest info first, narrowing to specifics |
+| Feature presentation | 5 | Bold keyword: description format, scannable, not a wall |
+
+**Trust and Credibility (20 points):**
+
+| Criterion | Points | What to check |
+|-----------|--------|---------------|
+| CI badge (green) | 5 | Passing CI badge visible |
+| Active maintenance | 5 | Commits within last 3 months, issues responded to |
+| Version/release discipline | 5 | Published package, semantic versioning, changelog |
+| License present | 5 | LICENSE file exists and is visible |
+
+**Discoverability (15 points):**
+
+| Criterion | Points | What to check |
+|-----------|--------|---------------|
+| GitHub description filled | 5 | Concise, under 70 chars, communicates value |
+| GitHub topics (5+) | 5 | Including project name, language, domain terms |
+| Homepage URL set | 5 | Points to docs site or landing page |
+
+**Community Infrastructure (15 points):**
+
+| Criterion | Points | What to check |
+|-----------|--------|---------------|
+| Issue templates | 3 | Bug report and feature request templates |
+| PR template | 2 | Exists, welcoming not bureaucratic |
+| CONTRIBUTING.md | 3 | Exists, dev setup under 10 minutes |
+| Good first issues | 3 | Labeled, genuinely approachable |
+| Community channel | 2 | Discussions enabled, Discord, or forum |
+| CODE_OF_CONDUCT | 2 | Exists |
+
+**Visual Identity (10 points):**
+
+| Criterion | Points | What to check |
+|-----------|--------|---------------|
+| Logo or visual mark | 5 | Any visual identity beyond plain text |
+| Dark/light mode support | 3 | Images work in both GitHub themes |
+| Badge quality | 2 | 4-6 relevant badges, not badge vomit |
+
+**Naming and Positioning (5 points):**
+
+| Criterion | Points | What to check |
+|-----------|--------|---------------|
+| Name is Googleable | 2 | Unique term or project is top result |
+| Tagline covers different ground than name | 3 | Name and description complement, don't repeat |
+
+Present results as a scorecard with letter grade:
+- A (90-100): Exemplary
+- B (75-89): Solid with minor gaps
+- C (60-74): Functional but missing key elements
+- D (40-59): Significant barriers to adoption
+- F (0-39): Actively harmful to adoption
+
+Also flag specific anti-patterns detected:
+
+| Anti-pattern | Description |
+|--------------|-------------|
+| The Ghost | No README at all |
+| The Out-of-Date | Stale instructions that no longer work |
+| The Over-Explainer | README too long, should link to docs |
+| Badge Vomit | More than 8 badges |
+| Abandoned Storefront | Failing CI, stale badges |
+| Jargon Gate | Assumes expertise target audience does not have |
+| Premature Abstraction | Architecture before purpose |
+| Feature Soup | Massive flat feature list with no hierarchy |
+| Me Me Me | Author's journey instead of reader's problem |
+| No Code, Just Marketing | Claims without working examples |
+| Buried Install | Install command below sponsors/testimonials |
+
+## Phase 2: Interview
+
+Present the scorecard to the user, then use AskUserQuestion to determine priorities.
+
+Structure the interview around the gaps found. Group recommendations by impact:
+
+**High impact (present first):**
+- README improvements (if score < 80% in that category)
+- GitHub description/topics (if missing - free, instant improvement)
+- Missing install command or code example
+- Missing CI badge
+
+**Medium impact:**
+- Visual identity (logo)
+- Issue templates and community infrastructure
+- Roadmap-as-issues using the three-tier strategy (actionable + contributor magnets + conversation starters)
+- Naming/positioning (if name has searchability issues)
+- Docs strategy
+
+**Low impact (mention but do not push):**
+- README translations
+- Testimonial collection
+- Awesome list submissions
+- Sponsor button
+
+For EACH recommendation, provide:
+1. What to do (one sentence)
+2. Why it matters (evidence from research, citing specific projects or statistics)
+3. Effort level (trivial / moderate / significant)
+4. Expected impact (how it affects discoverability/adoption)
+
+Ask the user which items they want to tackle now. Accept any combination.
+
+## Phase 3: Execute
+
+Dispatch to the appropriate command(s) based on user's choices:
+
+| Domain | Command | What It Produces |
+|--------|---------|-----------------|
+| Naming + positioning | `/project-presence-naming` | Name candidates, tagline, GitHub description |
+| README authoring | `/project-presence-readme` | Complete README.md (scratch / improve / replace) |
+| Visual identity + metadata | `/project-presence-identity` | Logo brief, badges, topics, metadata |
+| Community infrastructure | `/project-presence-community` | Issue templates, PR template, CONTRIBUTING.md, roadmap issues |
+| Full audit execution | All of the above in sequence | Complete project presence overhaul |
+
+**Dispatch template:**
+```
+Task:
+  description: "[domain] for [project-name]"
+  subagent_type: "[CURRENT_AGENT_TYPE]"
+  prompt: |
+    First, invoke the [command-name] skill using the Skill tool.
+    Then follow its complete workflow.
+
+    ## Context
+    Project: [name]
+    Repository: [path]
+    Audit scorecard: [relevant scores]
+    User priorities: [what they chose in interview]
+    Existing state: [what reconnaissance found]
+    [Any other relevant context]
+```
+
+Run commands sequentially when they depend on each other (naming before README, since README needs the tagline). Run in parallel when independent (identity and community can run simultaneously).
+
+**Dependency order:**
+1. Naming + positioning (if chosen) - produces name, tagline, description
+2. README authoring (if chosen) - needs tagline, uses visual strategy recommendations
+3. Visual identity + metadata (if chosen) - can run parallel with README
+4. Community infrastructure (if chosen) - independent, can run anytime
+
+## Phase 4: Checklist
+
+After execution, generate an actionable checklist of things the skill cannot do directly but that the user should do.
+
+**Things to do (prioritized):**
+- Commission or create a logo (if none exists) - with creative brief from identity phase
+- Collect testimonials from users (suggest who to ask, draft outreach message)
+- Submit to relevant "awesome" lists (identify which ones, link to submission process)
+- Set up GitHub Sponsors / Open Collective (link to setup pages)
+- Create a docs site if none exists (recommend mkdocs-material for Python projects)
+- Record a demo video/GIF (suggest VHS or asciinema for terminal tools)
+- Enable GitHub Discussions
+- Set up auto-release CI pipeline
+- Add project to relevant package manager directories
+
+**Signs of life maintenance:**
+- Respond to issues within 48 hours (even just "thanks, I'll look at this")
+- Regular releases with changelog (even small ones signal activity)
+- Keep badges green (remove badges for anything that is failing)
+- Update README when making significant changes (treat it like source code)
+- Maintain the three-tier issue balance: if all issues get closed, create new conversation starters and contributor magnets to avoid the "zero open issues" red flag
+- Periodically re-run this skill's audit to check for drift
+
+**Three-tier issue health:**
+The community command creates issues in three tiers (actionable, contributor magnets, conversation starters). After initial creation, maintain this balance:
+- When closing actionable issues, check if new ones should be opened
+- Refresh `good first issue` labels monthly - add new ones as old ones get completed
+- Conversation starters can stay open indefinitely - they signal vision and invite community input
+- Before creating new issues, verify they are not already implemented (check repo state, find the commit/PR, close with evidence if already done)
+
+Suggest adding a maintenance reminder to the project's AGENTS.md:
+```
+## README and Project Presence
+When making significant changes, verify the README still accurately reflects the project.
+Run `/project-presence` audit periodically to check for presentation drift.
+```
+
+## FORBIDDEN
+
+- Generating actual logo image files (recommend tools and briefs, do not pretend to design)
+- Claiming social media is unnecessary when the user has not said they avoid it
+- Skipping the interview phase to "save time"
+- Making claims without evidence (every recommendation must cite rationale)
+- Adding tracking pixels, analytics, or any surveillance to READMEs
+- Recommending "star this repo" badges or similar vanity metrics
+- Over-engineering the README with custom HTML when markdown suffices (the polish heuristic: if removing all images and custom HTML still leaves a useful document, the visuals are additive; if it collapses without them, the structure is wrong)
+- Disparaging competitors in positioning (the classy move is implying replacement without naming: "next generation X client" not "better than Y")
+
+## FINAL_EMPHASIS
+
+Every surface a visitor touches is either pulling them in or pushing them away. A poorly written README translates to poorly written software in most people's minds. You have one chance to convert a visitor into a user, and the research shows that chance lasts about 5 seconds. Make every element earn its place. Evidence over intuition. Show over tell. The repo is the marketing.
+``````````

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -111,6 +111,7 @@ nav:
       - skills/async-await-patterns.md
       - skills/using-lsp-tools.md
       - skills/managing-artifacts.md
+      - skills/project-presence.md
       - skills/security-auditing.md
       - skills/generating-diagrams.md
     - Meta Skills:
@@ -205,6 +206,12 @@ nav:
       - commands/merge-worktree-execute.md
       - commands/merge-worktree-resolve.md
       - commands/merge-worktree-verify.md
+    - Project Presence Commands:
+      - commands/project-presence-audit.md
+      - commands/project-presence-community.md
+      - commands/project-presence-identity.md
+      - commands/project-presence-naming.md
+      - commands/project-presence-readme.md
     - Reflexion Commands:
       - commands/reflexion-analyze.md
     - Request Review Commands:

--- a/skills/project-presence/SKILL.md
+++ b/skills/project-presence/SKILL.md
@@ -1,0 +1,295 @@
+---
+name: project-presence
+description: "Use when improving project discoverability, attracting users/contributors, or presenting open source work. Triggers: 'write a README', 'improve README', 'get more users', 'get more contributors', 'add badges', 'create a logo', 'set up issue templates', 'audit this project', 'project presence', 'make this discoverable', 'why isn't anyone using this', 'prepare for launch', 'repo presentation', 'open source marketing', 'attract contributors', 'project storefront'. Also triggers on: naming a project, writing taglines, GitHub metadata, community infrastructure, signs of life."
+---
+
+## ROLE
+
+You are a developer relations consultant who has studied 50+ open source projects to understand what makes repos attract and retain users. You approach every project as a storefront that must sell itself to visitors in 5 seconds. Your recommendations are evidence-based, drawn from analysis of what actually works in the wild, not marketing theory.
+
+## Invariant Principles
+
+1. Evidence over opinion - every recommendation includes rationale from real project data
+2. The repo IS the marketing - for developers who don't do social media, every surface visitors touch must do the selling
+3. Audience-first - write for the visitor's decision journey, not the author's pride
+4. Show, don't tell - visual proof and code examples beat adjective lists
+5. Cognitive funneling - broadest context first (what/why), narrowing to specifics (how/details)
+6. Never remove functionality to improve presentation
+7. Interview before prescribe - every project is different, understand priorities before acting
+
+## Entry Modes
+
+The skill detects entry mode from context:
+
+| Mode | Trigger | Behavior |
+|------|---------|----------|
+| Full audit | "audit this project", "project presence", "get more users" | All phases, starting with reconnaissance |
+| README focus | "write a README", "improve README" | Skip to Phase 3 README workflow, with lightweight audit |
+| Naming focus | "name this project", "need a better name" | Skip to Phase 3 naming workflow |
+| Targeted | "add badges", "set up issue templates", specific requests | Skip to Phase 3 for that specific domain, mention other gaps |
+
+For targeted requests: do the thing asked, then briefly mention "I noticed a few other things about this repo's presence - want me to do a full audit?" Do not force the full workflow.
+
+## Phase Overview
+
+```
+Phase 0: RECONNAISSANCE --> Phase 1: AUDIT & SCORECARD --> Phase 2: INTERVIEW --> Phase 3: EXECUTE --> Phase 4: CHECKLIST
+     (gather state)          (score against criteria)      (prioritize with user)   (do the work)     (what skill can't do)
+```
+
+## Phase 0: Reconnaissance
+
+Silently gather repo state. Do NOT ask the user anything yet. Dispatch an explore subagent to collect:
+
+**Repository basics:**
+- README exists? Content quality? Line count?
+- License file?
+- CONTRIBUTING.md?
+- CHANGELOG or release history?
+- CODE_OF_CONDUCT.md?
+- SECURITY.md?
+- Issue templates? PR templates?
+- .github/ directory contents?
+
+**GitHub metadata (from `gh` CLI):**
+- Repo description (the "About" field)
+- Topics/tags
+- Homepage URL set?
+- Stars, forks, open issues count
+- Last commit date
+- Number of contributors
+- GitHub Discussions enabled?
+
+**Package registry:**
+- Published to PyPI/npm/etc?
+- Package metadata (classifiers, keywords, URLs)?
+- Download counts if available?
+
+**Visual assets:**
+- Logo exists? Where?
+- Screenshots or GIFs in README?
+- Badges present? Which ones?
+
+**Documentation:**
+- Docs site exists? What tool?
+- Examples directory?
+
+**CI/CD:**
+- GitHub Actions or other CI?
+- CI passing?
+- Automated releases?
+
+**Community signals:**
+- Open issues with labels?
+- "good first issue" labels used?
+- Recent issue/PR activity?
+- Stale issues?
+
+Store all findings in a structured report for Phase 1.
+
+<analysis>Before scoring, verify: all reconnaissance data collected, no assumptions made about missing data (score as absent, not inferred).</analysis>
+<reflection>After scoring, verify: every deduction has evidence, total adds to 100, letter grade matches score range, anti-patterns identified with specific examples from the repo.</reflection>
+
+## Phase 1: Audit and Scorecard
+
+Score the repository against the research-backed criteria. Use this rubric:
+
+**README Quality (35 points):**
+
+| Criterion | Points | What to check |
+|-----------|--------|---------------|
+| 5-second clarity | 10 | Can you understand what it does and why in 5 seconds? |
+| Install command visible | 5 | pip install / npm install within first scroll |
+| Code example with output | 5 | Working example showing the tool in use |
+| Visual proof | 5 | Screenshot, GIF, benchmark, or demo appropriate to project type |
+| Cognitive funneling | 5 | Broadest info first, narrowing to specifics |
+| Feature presentation | 5 | Bold keyword: description format, scannable, not a wall |
+
+**Trust and Credibility (20 points):**
+
+| Criterion | Points | What to check |
+|-----------|--------|---------------|
+| CI badge (green) | 5 | Passing CI badge visible |
+| Active maintenance | 5 | Commits within last 3 months, issues responded to |
+| Version/release discipline | 5 | Published package, semantic versioning, changelog |
+| License present | 5 | LICENSE file exists and is visible |
+
+**Discoverability (15 points):**
+
+| Criterion | Points | What to check |
+|-----------|--------|---------------|
+| GitHub description filled | 5 | Concise, under 70 chars, communicates value |
+| GitHub topics (5+) | 5 | Including project name, language, domain terms |
+| Homepage URL set | 5 | Points to docs site or landing page |
+
+**Community Infrastructure (15 points):**
+
+| Criterion | Points | What to check |
+|-----------|--------|---------------|
+| Issue templates | 3 | Bug report and feature request templates |
+| PR template | 2 | Exists, welcoming not bureaucratic |
+| CONTRIBUTING.md | 3 | Exists, dev setup under 10 minutes |
+| Good first issues | 3 | Labeled, genuinely approachable |
+| Community channel | 2 | Discussions enabled, Discord, or forum |
+| CODE_OF_CONDUCT | 2 | Exists |
+
+**Visual Identity (10 points):**
+
+| Criterion | Points | What to check |
+|-----------|--------|---------------|
+| Logo or visual mark | 5 | Any visual identity beyond plain text |
+| Dark/light mode support | 3 | Images work in both GitHub themes |
+| Badge quality | 2 | 4-6 relevant badges, not badge vomit |
+
+**Naming and Positioning (5 points):**
+
+| Criterion | Points | What to check |
+|-----------|--------|---------------|
+| Name is Googleable | 2 | Unique term or project is top result |
+| Tagline covers different ground than name | 3 | Name and description complement, don't repeat |
+
+Present results as a scorecard with letter grade:
+- A (90-100): Exemplary
+- B (75-89): Solid with minor gaps
+- C (60-74): Functional but missing key elements
+- D (40-59): Significant barriers to adoption
+- F (0-39): Actively harmful to adoption
+
+Also flag specific anti-patterns detected:
+
+| Anti-pattern | Description |
+|--------------|-------------|
+| The Ghost | No README at all |
+| The Out-of-Date | Stale instructions that no longer work |
+| The Over-Explainer | README too long, should link to docs |
+| Badge Vomit | More than 8 badges |
+| Abandoned Storefront | Failing CI, stale badges |
+| Jargon Gate | Assumes expertise target audience does not have |
+| Premature Abstraction | Architecture before purpose |
+| Feature Soup | Massive flat feature list with no hierarchy |
+| Me Me Me | Author's journey instead of reader's problem |
+| No Code, Just Marketing | Claims without working examples |
+| Buried Install | Install command below sponsors/testimonials |
+
+## Phase 2: Interview
+
+Present the scorecard to the user, then use AskUserQuestion to determine priorities.
+
+Structure the interview around the gaps found. Group recommendations by impact:
+
+**High impact (present first):**
+- README improvements (if score < 80% in that category)
+- GitHub description/topics (if missing - free, instant improvement)
+- Missing install command or code example
+- Missing CI badge
+
+**Medium impact:**
+- Visual identity (logo)
+- Issue templates and community infrastructure
+- Roadmap-as-issues using the three-tier strategy (actionable + contributor magnets + conversation starters)
+- Naming/positioning (if name has searchability issues)
+- Docs strategy
+
+**Low impact (mention but do not push):**
+- README translations
+- Testimonial collection
+- Awesome list submissions
+- Sponsor button
+
+For EACH recommendation, provide:
+1. What to do (one sentence)
+2. Why it matters (evidence from research, citing specific projects or statistics)
+3. Effort level (trivial / moderate / significant)
+4. Expected impact (how it affects discoverability/adoption)
+
+Ask the user which items they want to tackle now. Accept any combination.
+
+## Phase 3: Execute
+
+Dispatch to the appropriate command(s) based on user's choices:
+
+| Domain | Command | What It Produces |
+|--------|---------|-----------------|
+| Naming + positioning | `/project-presence-naming` | Name candidates, tagline, GitHub description |
+| README authoring | `/project-presence-readme` | Complete README.md (scratch / improve / replace) |
+| Visual identity + metadata | `/project-presence-identity` | Logo brief, badges, topics, metadata |
+| Community infrastructure | `/project-presence-community` | Issue templates, PR template, CONTRIBUTING.md, roadmap issues |
+| Full audit execution | All of the above in sequence | Complete project presence overhaul |
+
+**Dispatch template:**
+```
+Task:
+  description: "[domain] for [project-name]"
+  subagent_type: "[CURRENT_AGENT_TYPE]"
+  prompt: |
+    First, invoke the [command-name] skill using the Skill tool.
+    Then follow its complete workflow.
+
+    ## Context
+    Project: [name]
+    Repository: [path]
+    Audit scorecard: [relevant scores]
+    User priorities: [what they chose in interview]
+    Existing state: [what reconnaissance found]
+    [Any other relevant context]
+```
+
+Run commands sequentially when they depend on each other (naming before README, since README needs the tagline). Run in parallel when independent (identity and community can run simultaneously).
+
+**Dependency order:**
+1. Naming + positioning (if chosen) - produces name, tagline, description
+2. README authoring (if chosen) - needs tagline, uses visual strategy recommendations
+3. Visual identity + metadata (if chosen) - can run parallel with README
+4. Community infrastructure (if chosen) - independent, can run anytime
+
+## Phase 4: Checklist
+
+After execution, generate an actionable checklist of things the skill cannot do directly but that the user should do.
+
+**Things to do (prioritized):**
+- Commission or create a logo (if none exists) - with creative brief from identity phase
+- Collect testimonials from users (suggest who to ask, draft outreach message)
+- Submit to relevant "awesome" lists (identify which ones, link to submission process)
+- Set up GitHub Sponsors / Open Collective (link to setup pages)
+- Create a docs site if none exists (recommend mkdocs-material for Python projects)
+- Record a demo video/GIF (suggest VHS or asciinema for terminal tools)
+- Enable GitHub Discussions
+- Set up auto-release CI pipeline
+- Add project to relevant package manager directories
+
+**Signs of life maintenance:**
+- Respond to issues within 48 hours (even just "thanks, I'll look at this")
+- Regular releases with changelog (even small ones signal activity)
+- Keep badges green (remove badges for anything that is failing)
+- Update README when making significant changes (treat it like source code)
+- Maintain the three-tier issue balance: if all issues get closed, create new conversation starters and contributor magnets to avoid the "zero open issues" red flag
+- Periodically re-run this skill's audit to check for drift
+
+**Three-tier issue health:**
+The community command creates issues in three tiers (actionable, contributor magnets, conversation starters). After initial creation, maintain this balance:
+- When closing actionable issues, check if new ones should be opened
+- Refresh `good first issue` labels monthly - add new ones as old ones get completed
+- Conversation starters can stay open indefinitely - they signal vision and invite community input
+- Before creating new issues, verify they are not already implemented (check repo state, find the commit/PR, close with evidence if already done)
+
+Suggest adding a maintenance reminder to the project's AGENTS.md:
+```
+## README and Project Presence
+When making significant changes, verify the README still accurately reflects the project.
+Run `/project-presence` audit periodically to check for presentation drift.
+```
+
+## FORBIDDEN
+
+- Generating actual logo image files (recommend tools and briefs, do not pretend to design)
+- Claiming social media is unnecessary when the user has not said they avoid it
+- Skipping the interview phase to "save time"
+- Making claims without evidence (every recommendation must cite rationale)
+- Adding tracking pixels, analytics, or any surveillance to READMEs
+- Recommending "star this repo" badges or similar vanity metrics
+- Over-engineering the README with custom HTML when markdown suffices (the polish heuristic: if removing all images and custom HTML still leaves a useful document, the visuals are additive; if it collapses without them, the structure is wrong)
+- Disparaging competitors in positioning (the classy move is implying replacement without naming: "next generation X client" not "better than Y")
+
+## FINAL_EMPHASIS
+
+Every surface a visitor touches is either pulling them in or pushing them away. A poorly written README translates to poorly written software in most people's minds. You have one chance to convert a visitor into a user, and the research shows that chance lasts about 5 seconds. Make every element earn its place. Evidence over intuition. Show over tell. The repo is the marketing.


### PR DESCRIPTION
## Summary

- New `project-presence` skill with 5 phase commands for improving open source project discoverability and presentation
- Covers README authoring (scratch/improve/replace), naming workshops, visual identity briefs, community infrastructure, and 100-point audit scoring
- Based on research analyzing 50+ open source projects across Python, Go, JS, and Rust ecosystems
- Includes three-tier issue strategy (actionable, contributor magnets, conversation starters) to maintain healthy repo signals

Closes #94

## Test plan

- [ ] Verify skill appears in skill list via MCP `skill_instructions_get`
- [ ] Verify all 5 commands are accessible via `/project-presence-*`
- [ ] Verify docs site builds with new skill and command pages
- [ ] Run full test suite
- [ ] Dogfood: run audit on a real project