### PR TITLE
Add community infrastructure: templates, contributing guide, security policy, welcome bot

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,61 @@
+name: Bug Report
+description: Report something that is not working correctly
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report this. Please fill out the sections
+        below so we can understand and reproduce the problem.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: Describe the bug. What did you expect to happen instead?
+      placeholder: "I expected X to happen, but Y happened instead."
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps to trigger the bug.
+      placeholder: |
+        1. Install version X
+        2. Run this command
+        3. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, Python version, spellbook version, platform (Claude Code, OpenCode, etc.)
+      placeholder: |
+        - OS: macOS 15.2
+        - Python: 3.12.1
+        - Spellbook: 0.23.0
+        - Platform: Claude Code
+    validations:
+      required: true
+
+  - type: textarea
+    id: example
+    attributes:
+      label: Minimal reproducible example
+      description: If possible, paste a short snippet or sequence of steps that triggers the bug.
+      render: python
+    validations:
+      required: false
+
+  - type: textarea
+    id: error_output
+    attributes:
+      label: Error output or traceback
+      description: Paste any relevant error messages or stack traces.
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Documentation
+    url: https://axiomantic.github.io/spellbook/latest/
+    about: Check the docs before opening an issue. Your answer might already be there.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,41 @@
+name: Feature Request
+description: Suggest a new feature or improvement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Feature requests help us prioritize development. Even if we cannot
+        implement this immediately, your input shapes the roadmap.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What do you want to happen?
+      description: Describe the feature or change you would like to see.
+    validations:
+      required: true
+
+  - type: textarea
+    id: use_case
+    attributes:
+      label: Use case
+      description: Why do you need this? What problem does it solve for you?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed_solution
+    attributes:
+      label: Proposed solution
+      description: If you have an idea for how this could work, describe it here.
+    validations:
+      required: false
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Have you tried any workarounds or alternative approaches?
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+## What does this PR do?
+
+<!-- One or two sentences describing the change. -->
+
+## Related issue
+
+<!-- Link to the issue this addresses, if any. Example: Closes #42 -->
+
+## Checklist
+
+- [ ] Tests pass locally
+- [ ] Documentation updated (if applicable)

--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -1,0 +1,28 @@
+name: Welcome First-Time Contributors
+on:
+  pull_request_target:
+    types: [opened]
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  welcome:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/first-interaction@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          issue-message: >
+            Thanks for opening your first issue! We will take a look soon.
+            If you have not already, check out our
+            [contributing guide](https://github.com/axiomantic/spellbook/blob/main/CONTRIBUTING.md)
+            and [documentation](https://axiomantic.github.io/spellbook/latest/).
+          pr-message: >
+            Thanks for your first pull request! A maintainer will review it
+            soon. While you wait, make sure the CI checks pass. If you have
+            questions, check our
+            [contributing guide](https://github.com/axiomantic/spellbook/blob/main/CONTRIBUTING.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,106 @@
+# Contributing
+
+Welcome! Whether you are fixing a typo, adding a test, reporting a bug,
+writing a new skill, or proposing a feature, your help makes spellbook
+better for everyone.
+
+## Development Setup
+
+```bash
+git clone https://github.com/axiomantic/spellbook.git
+cd spellbook
+uv pip install -e ".[dev,test,tts]"
+```
+
+Install pre-commit hooks:
+
+```bash
+./scripts/install-hooks.sh
+```
+
+## Running Tests
+
+```bash
+# Run the full suite
+uv run pytest tests/ -x --timeout=30
+
+# Run a specific test file
+uv run pytest tests/test_specific_file.py -x
+
+# Run linting
+uv run ruff check .
+```
+
+A passing run shows something like `X passed` with exit code 0.
+
+## Adding a Skill
+
+1. Create `skills/<your-skill-name>/SKILL.md` with YAML frontmatter:
+   ```yaml
+   ---
+   name: your-skill-name
+   description: "Use when [trigger conditions]. Triggers: 'phrase1', 'phrase2'."
+   ---
+   ```
+2. Write the skill body following existing skills as examples
+3. Run `python3 scripts/generate_docs.py` to generate the docs page
+4. Pre-commit hooks will validate the schema and update documentation
+
+## Adding a Command
+
+1. Create `commands/<your-command-name>.md` with YAML frontmatter:
+   ```yaml
+   ---
+   description: "Brief description of the command"
+   ---
+   ```
+2. Pre-commit hooks will generate docs and update the index
+
+## Code Style
+
+This project uses [Ruff](https://github.com/astral-sh/ruff) for Python
+linting and formatting. Pre-commit hooks run these automatically. To run
+manually:
+
+```bash
+uv run ruff check .
+uv run ruff format .
+```
+
+## Submitting a Pull Request
+
+1. Fork the repository and create a branch from `main`
+2. Make your changes and add tests if adding functionality
+3. Run the test suite and linter locally
+4. Verify the installer works: `uv run install.py --dry-run`
+5. Open a pull request with a clear description of what you changed and why
+
+We aim to review pull requests within 5 business days. If you have not
+heard back, feel free to leave a comment on the PR.
+
+## Types of Contributions
+
+Code is not the only way to contribute. We welcome:
+
+- **Bug reports and feature requests** via issue templates
+- **New skills and commands** for common development workflows
+- **Documentation improvements** and typo fixes
+- **Test coverage additions**
+- **Translations** of the README
+
+## Pre-commit Hooks
+
+Pre-commit hooks auto-generate documentation files. If a hook fails:
+
+1. Check the output for which files were modified
+2. Stage the generated files with `git add`
+3. Commit again
+
+This is normal and expected when adding new skills or commands.
+
+## Communication
+
+- [GitHub Issues](https://github.com/axiomantic/spellbook/issues) for bugs and feature requests
+- [GitHub Discussions](https://github.com/axiomantic/spellbook/discussions) for questions and ideas (when enabled)
+
+Thank you for contributing!

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,33 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability, please report it responsibly.
+
+**Do NOT open a public issue.** Instead, use [GitHub's private vulnerability reporting](https://github.com/axiomantic/spellbook/security/advisories/new) or email the maintainer directly.
+
+Please include:
+
+- Description of the vulnerability
+- Steps to reproduce
+- Impact assessment (if known)
+
+We will acknowledge receipt within 48 hours and aim to provide an initial
+assessment within 5 business days.
+
+## Scope
+
+Security issues for spellbook include but are not limited to:
+
+- **Prompt injection** in skills, commands, or agent definitions
+- **MCP tool vulnerabilities** that could leak data or escalate privileges
+- **Credential exposure** through hooks, scripts, or configuration
+- **Path traversal** in file-handling operations
+- **Arbitrary code execution** through skill or hook injection
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| latest  | Yes       |
+| < latest | Best effort |


### PR DESCRIPTION
## Summary

- Issue templates (bug report + feature request) using GitHub YAML form format
- PR template (lightweight, welcoming)
- CONTRIBUTING.md with dev setup, testing, skill/command authoring guide
- SECURITY.md with vulnerability reporting scope specific to MCP/prompt injection surface
- Welcome bot GitHub Action for first-time contributors

Closes #79, closes #82, closes #85, closes #88, closes #72

## Test plan

- [ ] Verify issue templates appear when creating a new issue on GitHub
- [ ] Verify PR template populates when creating a new PR
- [ ] Verify welcome workflow syntax is valid (CI will check)
- [ ] Review CONTRIBUTING.md dev setup commands match AGENTS.md
- [ ] Review SECURITY.md scope covers spellbook-specific concerns