### PR TITLE
fix(develop): prevent Phase 4 gate bypass via implicit instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Develop skill Phase 4 guardrail hardening.** Bans phrases like "TDD mode"
+and "or read SKILL.md" that signal subagents to inline behavior instead of
+invoking the Skill tool; mandates a "Launching skill:" check in subagent
+output before accepting results; requires each Phase 4 gate (4.3–4.5.1) be
+a separate dispatch to prevent gate collapse during parallel dispatch.
+
 - **Opt-in to re-enable `BASH-PARSER-COMPOUND` deny findings.** The 0.63.2
   compound-allow change was a deliberate widening of the bash gate's
   allowlist: the L4 parser stopped emitting a CRITICAL deny on every

--- a/skills/develop/SKILL.md
+++ b/skills/develop/SKILL.md
@@ -242,6 +242,7 @@ is wrong by construction. Decompose before sending:
 - "all per-task gates", "combined gates", "batched gates"
 - "plus commit", "and commit", "implement and commit"
 - "end-to-end", "everything", "the whole flow", "wrap it up"
+- "TDD mode", "code review mode", "audit mode"  <-- BANNED: signals inline execution, not skill invocation
 - Any phrasing that combines two distinct rows of the dispatch table
   (e.g., "design + review", "plan + review", "TDD + code review")
 
@@ -477,7 +478,23 @@ Task:
     [Only the context the skill needs to do its job]
 ```
 
-**WRONG Pattern:**
+**WRONG Pattern (Option B - "or read SKILL.md"):**
+
+```
+prompt: |
+  Use the [skill-name] skill or read ~/.pi/agent/skills/[name]/SKILL.md.
+  <-- WRONG: Gives subagent an escape hatch. They will read and inline.
+```
+
+**WRONG Pattern (Option A - "mode"):**
+
+```
+prompt: |
+  Use [skill-name] mode to do X.
+  <-- WRONG: Makes skill invocation a flavor, not the actual tool.
+```
+
+**WRONG Pattern (Original):**
 
 ```
 Task (or subagent simulation):
@@ -500,6 +517,34 @@ After dispatching ANY subagent that should invoke a skill:
 A subagent that reports "the skill is not available in this environment" without showing an attempted Skill tool call is making an untested claim. Reject it. Skills are delivered via system-reminder, NOT via the deferred-tools list, and the catalog is injected lazily after the first tool call. A subagent must attempt the call before declaring it impossible.
 
 Anti-rationalization #9 (Self-Review Substitution) applies here.
+</CRITICAL>
+
+### Post-Dispatch Skill Invocation Verification (MANDATORY)
+
+After ANY subagent dispatched to invoke a skill returns, the orchestrator MUST perform this mechanical check before accepting results:
+
+```
+STEP 1: Does the subagent output contain "Launching skill: [skill-name]" or equivalent?
+STEP 2: If NO → REJECT result immediately. Do NOT check compilation. Do NOT read files.
+         Re-dispatch with the canonical template from dispatching-parallel-agents.
+STEP 3: If YES → Verify gate artifacts exist. Only then proceed to next gate.
+STEP 4: If "skill not available" claimed without an attempted Skill tool call → REJECT.
+         Subagents must attempt invocation; they cannot declare skills absent
+         without trying.
+```
+
+**Accepting unverified results is a process violation.** Subagents will produce files that pass compilation but bypassed all quality gates. The gates exist because compilation success does not imply correctness, review, or verification.
+
+### Phase 4 Dispatch Discipline: Gate Non-Collapse Rule
+
+<CRITICAL>
+Each Phase 4 gate (4.3, 4.4, 4.5, 4.5.1) MUST be a **separate** subagent dispatch.
+
+**FORBIDDEN:** Combining multiple gates into a single subagent prompt — even for "small" tasks, even under time pressure, even in autonomous mode. This is Pattern 6 (Phase Collapse). A subagent dispatched to "invoke TDD, then audit, then review" will implement code and skip the skills.
+
+**Correct:** Dispatch one subagent for 4.3 (TDD skill). Wait for result. Verify skill invocation. Dispatch next subagent for 4.4 (inline audit). Wait. Verify. Dispatch next for 4.5 (code review). Wait. Verify. Dispatch next for 4.5.1 (fact-check).
+
+Each gate is a distinct quality dimension. Collapsing them silently drops dimensions. No exceptions.
 </CRITICAL>
 
 ### Phase 4 Dispatch Discipline

--- a/skills/develop/SKILL.md
+++ b/skills/develop/SKILL.md
@@ -504,7 +504,7 @@ Task (or subagent simulation):
 ```
 
 <CRITICAL>
-### Subagent Skill Invocation Verification
+### Subagent Skill Invocation Verification (MANDATORY)
 
 After dispatching ANY subagent that should invoke a skill:
 
@@ -516,24 +516,10 @@ After dispatching ANY subagent that should invoke a skill:
 
 A subagent that reports "the skill is not available in this environment" without showing an attempted Skill tool call is making an untested claim. Reject it. Skills are delivered via system-reminder, NOT via the deferred-tools list, and the catalog is injected lazily after the first tool call. A subagent must attempt the call before declaring it impossible.
 
+**Exemption:** This verification does NOT apply to "inline audit prompt" gates (4.4, 4.6.1) which have no skill to invoke. For those gates, verify the audit artifact instead of skill invocation.
+
 Anti-rationalization #9 (Self-Review Substitution) applies here.
 </CRITICAL>
-
-### Post-Dispatch Skill Invocation Verification (MANDATORY)
-
-After ANY subagent dispatched to invoke a skill returns, the orchestrator MUST perform this mechanical check before accepting results:
-
-```
-STEP 1: Does the subagent output contain "Launching skill: [skill-name]" or equivalent?
-STEP 2: If NO → REJECT result immediately. Do NOT check compilation. Do NOT read files.
-         Re-dispatch with the canonical template from dispatching-parallel-agents.
-STEP 3: If YES → Verify gate artifacts exist. Only then proceed to next gate.
-STEP 4: If "skill not available" claimed without an attempted Skill tool call → REJECT.
-         Subagents must attempt invocation; they cannot declare skills absent
-         without trying.
-```
-
-**Accepting unverified results is a process violation.** Subagents will produce files that pass compilation but bypassed all quality gates. The gates exist because compilation success does not imply correctness, review, or verification.
 
 ### Phase 4 Dispatch Discipline: Gate Non-Collapse Rule
 


### PR DESCRIPTION
## What does this PR do?

Closes gaps in the develop skill that allowed subagents to bypass all Phase 4 quality gates (TDD, code review, fact-check) by giving them enough inline instructions to work without ever invoking the required `Skill` tool.

## Related issue

<!-- No open issue — fix discovered during pi-mesh implementation session -->

## Checklist

- [ ] Tests pass locally
- [x] Documentation updated (if applicable)

## Changes

1. **Banned "mode" phrasings** — `"TDD mode"`, `"code review mode"`, etc. are now in the Banned Phrasings list. These signal subagents to inline behavior from memory, skipping actual skill invocation.

2. **Banned `"or read SKILL.md"` fallback** — Added as a new WRONG Pattern. Making skill invocation optional by offering "read the file instead" gives subagents an escape hatch they will take.

3. **Post-Dispatch Skill Invocation Verification** — New mandatory 4-step mechanical check:
   - Verify output contains `"Launching skill: [name]"` or equivalent
   - If NO → **reject result immediately** (don't check compilation, don't read files)
   - Accepting unverified results is a process violation

4. **Phase 4 Gate Non-Collapse Rule** — Explicit `<CRITICAL>` block: each gate (4.3, 4.4, 4.5, 4.5.1) MUST be a **separate** subagent dispatch. Parallelizing across tasks does NOT parallelize gates within a task.

## Impact

No breaking changes to downstream users. The skill now provides stronger guardrails against Pattern 6 (Phase Collapse) during parallel dispatch scenarios.