### PR TITLE
fix(daemon): launch MCP via spellbook.mcp package, not server shim

### DIFF
--- a/spellbook/daemon/manager.py
+++ b/spellbook/daemon/manager.py
@@ -92,9 +92,9 @@ def start_daemon(foreground: bool = False) -> None:
     env["SPELLBOOK_DIR"] = str(spellbook_dir)
 
     if daemon_python:
-        cmd = [daemon_python, "-m", "spellbook.mcp.server"]
+        cmd = [daemon_python, "-m", "spellbook.mcp"]
     else:
-        cmd = [uv_path, "run", str(server_script)]  # type: ignore[list-item]
+        cmd = [uv_path, "run", "python", "-m", "spellbook.mcp"]  # type: ignore[list-item]
 
     if foreground:
         print(f"Starting server on {host}:{port} (foreground mode)")

--- a/spellbook/daemon/manager.py
+++ b/spellbook/daemon/manager.py
@@ -94,7 +94,8 @@ def start_daemon(foreground: bool = False) -> None:
     if daemon_python:
         cmd = [daemon_python, "-m", "spellbook.mcp"]
     else:
-        cmd = [uv_path, "run", "python", "-m", "spellbook.mcp"]  # type: ignore[list-item]
+        assert uv_path is not None
+        cmd = [uv_path, "run", "python", "-m", "spellbook.mcp"]
 
     if foreground:
         print(f"Starting server on {host}:{port} (foreground mode)")


### PR DESCRIPTION
## What does this PR do?

Fixes a silent daemon startup failure. `daemon/manager.py` launches the MCP server with `python -m spellbook.mcp.server`, but that target is the backward-compat shim in `spellbook/mcp/server.py` — it only re-exports symbols and has no top-level execution, so the subprocess imports the module, exits 0, and the daemon never binds to the port. `spellbook server start` then reports "Server failed to start" with no traceback in the log (nothing was logged because nothing ran). Switching to `python -m spellbook.mcp` invokes `spellbook/mcp/__main__.py`, which calls `mcp.run(...)` as intended. Same fix applied to the `uv run` fallback path so it goes through the module entry instead of the shim script.

## Related issue

## Checklist

- [ ] Tests pass locally
- [ ] Documentation updated (if applicable)

### Reproduction

With a fresh editable install and a working daemon-venv (`SPELLBOOK_DAEMON_PYTHON` set, `fastmcp` / `fastapi` / `uvicorn` / `mcp` / `spellbook` all importable from that interpreter):

```
$ spellbook server start
Starting server on 127.0.0.1:8765
Error: Server failed to start. Check log: /Users/<me>/.local/spellbook/spellbook-mcp.log
```

The log file is empty after this attempt (modulo any prior tracebacks). Running the daemon command by hand:

```
$ python -m spellbook.mcp.server
$ echo $?
0
```

…confirms the shim exits immediately. Same env, switching to the package entry:

```
$ python -m spellbook.mcp
... Starting MCP server 'spellbook' with transport 'streamable-http' (stateless) on http://127.0.0.1:8765/mcp
INFO: Uvicorn running on http://127.0.0.1:8765
```

…boots cleanly.

### Notes

The shim in `spellbook/server.py` (top-level, separate from `spellbook/mcp/server.py`) is also a re-export module with no `__main__`. It is the `server_script` used by the `uv run` fallback. I did not touch `server.py` itself — kept it as a back-compat re-export — and instead changed the fallback `cmd` to invoke `python -m spellbook.mcp` through `uv run` so both paths go through the same canonical entry point.
