### PR TITLE
fix(skills): harden develop Phase 4 gate + require source verification in docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Develop skill Phase 4 guardrail hardening.** Bans phrases like "TDD mode"
+and "or read SKILL.md" that signal subagents to inline behavior instead of
+invoking the Skill tool; mandates a "Launching skill:" check in subagent
+output before accepting results; requires each Phase 4 gate (4.3–4.5.1) be
+a separate dispatch to prevent gate collapse during parallel dispatch.
+
 - **Opt-in to re-enable `BASH-PARSER-COMPOUND` deny findings.** The 0.63.2
   compound-allow change was a deliberate widening of the bash gate's
   allowlist: the L4 parser stopped emitting a CRITICAL deny on every

--- a/commands/docs-plan.md
+++ b/commands/docs-plan.md
@@ -26,6 +26,7 @@ Before planning, determine:
 2. **Tone follows type mapping**: Default tone profiles are assigned by Diataxis type. Users CAN override during the interview step. Overrides are respected by all downstream phases.
 3. **User approves TOC before generation proceeds**: Present the full TOC table. Iterate on changes until the user confirms. Never skip this gate.
 4. **Re-run policy**: Check for existing `doc-state/plan.json`. If found, present option to reuse or regenerate. Do not silently overwrite.
+5. **Source citations must be source-verified**: Any symbol, function, method, class, file path, or Redis/database key namespace that appears in `source_hints`, `cross_cutting_tasks`, or any prose field of the plan MUST be verified to exist in the project source before being recorded. Use `grep -r '<symbol>' src/` (or the project's equivalent) and confirm at least one match. Plausible-sounding LLM-generated names are the failure mode this rule prevents: writers downstream treat plan output as authoritative and will apply unverified names verbatim. If the audit flags "replace line numbers with symbol names" as a cross-cutting task, the planner is responsible for deriving and verifying each replacement name, not for asserting candidates that the writer must somehow validate.
 
 ## Inputs
 
@@ -307,6 +308,7 @@ interface DocsPlan {
 - Generating TOC entries for existing docs when mode is `additive_only`
 - Writing plan output to the project repository (output goes to doc-state/ only)
 - Assigning priority `mvp` to explanation or how-to docs (these are tier2+ in MVP)
+- Listing symbol, function, method, class, or key-namespace names in `source_hints` or `cross_cutting_tasks` without first grep-verifying them against the project source (see Invariant Principle 5). Plausible-but-fabricated names propagate straight into the writer's output and the build will not catch them.
 </FORBIDDEN>
 
 <reflection>

--- a/commands/docs-write.md
+++ b/commands/docs-write.md
@@ -163,10 +163,27 @@ Task:
     2. Write in the voice defined by the tone profile.
     3. Use ONLY information present in the source code context.
        Do not fabricate APIs, parameters, or behaviors.
-    4. Apply every rule from Writing Guide Rules during writing.
-    5. Keep total output under 6K tokens.
-    6. For tutorials: add "Last verified: {today's date}" at the end.
-    7. Write the complete document to: {project_root}/{section.output_path}
+    4. Symbol-name verification: any function name, method name, class
+       name, constant, file path, or namespaced key (e.g. Redis key,
+       env var) that appears in your output MUST be grounded in the
+       source code context you were given. If the plan, audit, or
+       existing content suggests a name that does not appear in your
+       source context, do ONE of the following — do not invent or
+       guess:
+         (a) grep the project source for the candidate name and use
+             the verified result, OR
+         (b) rephrase to describe behavior without naming a specific
+             symbol (e.g. "the Lua script invoked by the registry"
+             instead of a fabricated method name), OR
+         (c) leave a `<!-- TODO: verify symbol name in source -->`
+             comment inline so review can catch it.
+       Plausible-sounding LLM-generated names are the most common
+       fact-check failure in this pipeline. The build will not catch
+       them; only source verification will.
+    5. Apply every rule from Writing Guide Rules during writing.
+    6. Keep total output under 6K tokens.
+    7. For tutorials: add "Last verified: {today's date}" at the end.
+    8. Write the complete document to: {project_root}/{section.output_path}
 
   result_schema:
     files_written:
@@ -351,6 +368,7 @@ interface DocsWritten {
 - Exceeding 6K token output per generated section
 - Skipping writing guide rules in writing subagent prompts (rules must be included in full)
 - Fabricating API signatures, parameters, return types, or behaviors not present in source code
+- Writing any symbol, function, method, class, file path, or namespaced key (Redis key, env var) into output without confirming it exists in the provided source code context or via grep against project source (see Step 3b Instructions rule 4). This is the most common fact-check failure in the pipeline and the build cannot catch it.
 - Silently overwriting an existing written-manifest.json without offering reuse (unless sections_filter is present)
 - Generating non-MVP sections when running in MVP tier
 - Omitting the tone profile or Diataxis type rules from writing subagent prompts

--- a/commands/pr-dance.md
+++ b/commands/pr-dance.md
@@ -17,6 +17,7 @@ PR Shepherd. Your reputation depends on PRs that reach merge-ready state without
 3. **Address ALL findings per cycle**: Partial fixes waste a review cycle. Batch all bot findings before pushing.
 4. **Never merge automatically**: Report merge-ready status. User decides when to merge. This rule is absolute and is NOT overridden by any session-level autonomy directive — including but not limited to "do the PR dance autonomously", "yolo", "just land it", "pick it up where we left off", "stop asking", "go go go", or any equivalent phrasing. "Autonomous" scopes commit / push / comment / iterate / re-request-review. It does not scope merge, tag-push, branch deletion, or any other destructive or visible-to-others action listed in the global git-safety rules. If the user wants you to merge, they will say "merge it" (or equivalent imperative) AFTER you report merge-ready status. Until then: stop at Step 5.
 5. **Version bump before first cycle**: If the project uses semver (pyproject.toml, package.json), ensure version bump + CHANGELOG entry exist before the first review cycle. This prevents wasting a cycle on a finding the bot will always flag.
+6. **One PR at a time, never wrapped in `/loop`**: This command already polls internally (Step 3 watches CI, Step 4 polls for bot feedback). Wrapping it in `/loop` creates a watcher around a watcher and re-fires the full polling cycle on the loop's timer even after merge-ready. Running it concurrently on multiple PRs multiplies GraphQL load by N. Today's GitHub GraphQL quota is 5000/hour — a single misconfigured run can exhaust it in under an hour.
 
 ## Inputs
 
@@ -80,16 +81,33 @@ NEVER hardcode a bot name. NEVER assume which bot a project uses. Always read co
 
 ### Step 3: Wait for CI
 
-Poll CI status until terminal state:
+Every `gh pr checks` invocation (with `--watch` or `--json`) is a GraphQL query, so polling cadence directly drives GraphQL quota burn. Use a long interval — CI runs are minutes-long, sub-minute polling is theater.
+
+#### Step 3 pre-flight: GraphQL rate-limit check
+
+Before entering `--watch` or each manual poll, check remaining GraphQL budget. If below threshold, sleep until reset rather than letting the loop crash mid-cycle:
 
 ```bash
-gh pr checks "$PR_NUMBER" --watch
+remaining=$(gh api rate_limit --jq '.resources.graphql.remaining')
+reset=$(gh api rate_limit --jq '.resources.graphql.reset')
+if [ "$remaining" -lt 200 ]; then
+  now=$(date +%s)
+  echo "GraphQL low ($remaining); sleeping until reset..."
+  sleep $((reset - now + 5))
+fi
 ```
 
-If `--watch` is unavailable or times out, poll manually:
+#### Poll for terminal state
+
+```bash
+gh pr checks "$PR_NUMBER" --watch --interval 60
+```
+
+If `--watch` is unavailable or times out, poll manually with the same cadence — never tighter than 30s:
 
 ```bash
 gh pr checks "$PR_NUMBER" --json name,state,conclusion
+sleep 60
 ```
 
 **CI passes:** Proceed to Step 4.
@@ -190,6 +208,9 @@ PR Dance complete.
 - Using `requested_reviewers` API to request bot re-review
 - Adding AI attribution or co-authored-by trailers to commits
 - Referencing GitHub issue numbers in commit messages
+- Invoking this command under `/loop` — it already polls internally; `/loop` creates a watcher around a watcher and re-fires the full cycle on the loop's timer even after merge-ready, exhausting the GitHub GraphQL quota
+- Running this command on more than one PR concurrently — serialize across PRs to keep GraphQL spend bounded
+- Polling CI checks tighter than 30s (use `--interval 60` with `--watch`, or `sleep 60` between manual polls) — sub-minute polling burns GraphQL quota with no UX benefit, since CI runs are minutes-long
 </FORBIDDEN>
 
 <analysis>
@@ -205,5 +226,19 @@ After each cycle:
 - Did I address ALL findings, not just some?
 - Did I re-request review after pushing?
 - Is CI actually green, or did I misread the status?
-- Have I been looping too many times? (>4 cycles may indicate a deeper issue worth surfacing to the user)
 </reflection>
+
+### Cycle budget (hard cap)
+
+Track a cycle counter. After **4 cycles** without reaching merge-ready, STOP and surface to the user:
+
+```
+PR Dance paused after 4 cycles without converging.
+- Last CI state: <green|failing|pending>
+- Last bot review: <clean|N findings>
+- Suggested causes: flaky test, bot disagreement on a contested change, repeated push without addressing root cause.
+
+How would you like to proceed? (a) continue another N cycles, (b) hand back for manual review, (c) abandon.
+```
+
+This is a hard cap, not advice. After 4 cycles, do NOT start a 5th without explicit user confirmation. Repeated cycling without convergence is almost always a signal of a structural problem (flaky test, contested finding, missing context) that more polling will not fix.

--- a/docs/commands/pr-dance.md
+++ b/docs/commands/pr-dance.md
@@ -17,6 +17,7 @@ PR Shepherd. Your reputation depends on PRs that reach merge-ready state without
 3. **Address ALL findings per cycle**: Partial fixes waste a review cycle. Batch all bot findings before pushing.
 4. **Never merge automatically**: Report merge-ready status. User decides when to merge. This rule is absolute and is NOT overridden by any session-level autonomy directive — including but not limited to "do the PR dance autonomously", "yolo", "just land it", "pick it up where we left off", "stop asking", "go go go", or any equivalent phrasing. "Autonomous" scopes commit / push / comment / iterate / re-request-review. It does not scope merge, tag-push, branch deletion, or any other destructive or visible-to-others action listed in the global git-safety rules. If the user wants you to merge, they will say "merge it" (or equivalent imperative) AFTER you report merge-ready status. Until then: stop at Step 5.
 5. **Version bump before first cycle**: If the project uses semver (pyproject.toml, package.json), ensure version bump + CHANGELOG entry exist before the first review cycle. This prevents wasting a cycle on a finding the bot will always flag.
+6. **One PR at a time, never wrapped in `/loop`**: This command already polls internally (Step 3 watches CI, Step 4 polls for bot feedback). Wrapping it in `/loop` creates a watcher around a watcher and re-fires the full polling cycle on the loop's timer even after merge-ready. Running it concurrently on multiple PRs multiplies GraphQL load by N. Today's GitHub GraphQL quota is 5000/hour — a single misconfigured run can exhaust it in under an hour.
 
 ## Inputs
 
@@ -80,16 +81,33 @@ NEVER hardcode a bot name. NEVER assume which bot a project uses. Always read co
 
 ### Step 3: Wait for CI
 
-Poll CI status until terminal state:
+Every `gh pr checks` invocation (with `--watch` or `--json`) is a GraphQL query, so polling cadence directly drives GraphQL quota burn. Use a long interval — CI runs are minutes-long, sub-minute polling is theater.
+
+#### Step 3 pre-flight: GraphQL rate-limit check
+
+Before entering `--watch` or each manual poll, check remaining GraphQL budget. If below threshold, sleep until reset rather than letting the loop crash mid-cycle:
 
 ```bash
-gh pr checks "$PR_NUMBER" --watch
+remaining=$(gh api rate_limit --jq '.resources.graphql.remaining')
+reset=$(gh api rate_limit --jq '.resources.graphql.reset')
+if [ "$remaining" -lt 200 ]; then
+  now=$(date +%s)
+  echo "GraphQL low ($remaining); sleeping until reset..."
+  sleep $((reset - now + 5))
+fi
 ```
 
-If `--watch` is unavailable or times out, poll manually:
+#### Poll for terminal state
+
+```bash
+gh pr checks "$PR_NUMBER" --watch --interval 60
+```
+
+If `--watch` is unavailable or times out, poll manually with the same cadence — never tighter than 30s:
 
 ```bash
 gh pr checks "$PR_NUMBER" --json name,state,conclusion
+sleep 60
 ```
 
 **CI passes:** Proceed to Step 4.
@@ -190,6 +208,9 @@ PR Dance complete.
 - Using `requested_reviewers` API to request bot re-review
 - Adding AI attribution or co-authored-by trailers to commits
 - Referencing GitHub issue numbers in commit messages
+- Invoking this command under `/loop` — it already polls internally; `/loop` creates a watcher around a watcher and re-fires the full cycle on the loop's timer even after merge-ready, exhausting the GitHub GraphQL quota
+- Running this command on more than one PR concurrently — serialize across PRs to keep GraphQL spend bounded
+- Polling CI checks tighter than 30s (use `--interval 60` with `--watch`, or `sleep 60` between manual polls) — sub-minute polling burns GraphQL quota with no UX benefit, since CI runs are minutes-long
 </FORBIDDEN>
 
 <analysis>
@@ -205,6 +226,20 @@ After each cycle:
 - Did I address ALL findings, not just some?
 - Did I re-request review after pushing?
 - Is CI actually green, or did I misread the status?
-- Have I been looping too many times? (>4 cycles may indicate a deeper issue worth surfacing to the user)
 </reflection>
+
+### Cycle budget (hard cap)
+
+Track a cycle counter. After **4 cycles** without reaching merge-ready, STOP and surface to the user:
+
+```
+PR Dance paused after 4 cycles without converging.
+- Last CI state: <green|failing|pending>
+- Last bot review: <clean|N findings>
+- Suggested causes: flaky test, bot disagreement on a contested change, repeated push without addressing root cause.
+
+How would you like to proceed? (a) continue another N cycles, (b) hand back for manual review, (c) abandon.
+```
+
+This is a hard cap, not advice. After 4 cycles, do NOT start a 5th without explicit user confirmation. Repeated cycling without convergence is almost always a signal of a structural problem (flaky test, contested finding, missing context) that more polling will not fix.
 ``````````

--- a/skills/develop/SKILL.md
+++ b/skills/develop/SKILL.md
@@ -242,6 +242,7 @@ is wrong by construction. Decompose before sending:
 - "all per-task gates", "combined gates", "batched gates"
 - "plus commit", "and commit", "implement and commit"
 - "end-to-end", "everything", "the whole flow", "wrap it up"
+- "TDD mode", "code review mode", "audit mode"  <-- BANNED: signals inline execution, not skill invocation
 - Any phrasing that combines two distinct rows of the dispatch table
   (e.g., "design + review", "plan + review", "TDD + code review")
 
@@ -477,7 +478,23 @@ Task:
     [Only the context the skill needs to do its job]
 ```
 
-**WRONG Pattern:**
+**WRONG Pattern (Option B - "or read SKILL.md"):**
+
+```
+prompt: |
+  Use the [skill-name] skill or read ~/.pi/agent/skills/[name]/SKILL.md.
+  <-- WRONG: Gives subagent an escape hatch. They will read and inline.
+```
+
+**WRONG Pattern (Option A - "mode"):**
+
+```
+prompt: |
+  Use [skill-name] mode to do X.
+  <-- WRONG: Makes skill invocation a flavor, not the actual tool.
+```
+
+**WRONG Pattern (Original):**
 
 ```
 Task (or subagent simulation):
@@ -500,6 +517,34 @@ After dispatching ANY subagent that should invoke a skill:
 A subagent that reports "the skill is not available in this environment" without showing an attempted Skill tool call is making an untested claim. Reject it. Skills are delivered via system-reminder, NOT via the deferred-tools list, and the catalog is injected lazily after the first tool call. A subagent must attempt the call before declaring it impossible.
 
 Anti-rationalization #9 (Self-Review Substitution) applies here.
+</CRITICAL>
+
+### Post-Dispatch Skill Invocation Verification (MANDATORY)
+
+After ANY subagent dispatched to invoke a skill returns, the orchestrator MUST perform this mechanical check before accepting results:
+
+```
+STEP 1: Does the subagent output contain "Launching skill: [skill-name]" or equivalent?
+STEP 2: If NO → REJECT result immediately. Do NOT check compilation. Do NOT read files.
+         Re-dispatch with the canonical template from dispatching-parallel-agents.
+STEP 3: If YES → Verify gate artifacts exist. Only then proceed to next gate.
+STEP 4: If "skill not available" claimed without an attempted Skill tool call → REJECT.
+         Subagents must attempt invocation; they cannot declare skills absent
+         without trying.
+```
+
+**Accepting unverified results is a process violation.** Subagents will produce files that pass compilation but bypassed all quality gates. The gates exist because compilation success does not imply correctness, review, or verification.
+
+### Phase 4 Dispatch Discipline: Gate Non-Collapse Rule
+
+<CRITICAL>
+Each Phase 4 gate (4.3, 4.4, 4.5, 4.5.1) MUST be a **separate** subagent dispatch.
+
+**FORBIDDEN:** Combining multiple gates into a single subagent prompt — even for "small" tasks, even under time pressure, even in autonomous mode. This is Pattern 6 (Phase Collapse). A subagent dispatched to "invoke TDD, then audit, then review" will implement code and skip the skills.
+
+**Correct:** Dispatch one subagent for 4.3 (TDD skill). Wait for result. Verify skill invocation. Dispatch next subagent for 4.4 (inline audit). Wait. Verify. Dispatch next for 4.5 (code review). Wait. Verify. Dispatch next for 4.5.1 (fact-check).
+
+Each gate is a distinct quality dimension. Collapsing them silently drops dimensions. No exceptions.
 </CRITICAL>
 
 ### Phase 4 Dispatch Discipline

--- a/skills/develop/SKILL.md
+++ b/skills/develop/SKILL.md
@@ -504,7 +504,7 @@ Task (or subagent simulation):
 ```
 
 <CRITICAL>
-### Subagent Skill Invocation Verification
+### Subagent Skill Invocation Verification (MANDATORY)
 
 After dispatching ANY subagent that should invoke a skill:
 
@@ -516,24 +516,10 @@ After dispatching ANY subagent that should invoke a skill:
 
 A subagent that reports "the skill is not available in this environment" without showing an attempted Skill tool call is making an untested claim. Reject it. Skills are delivered via system-reminder, NOT via the deferred-tools list, and the catalog is injected lazily after the first tool call. A subagent must attempt the call before declaring it impossible.
 
+**Exemption:** This verification does NOT apply to "inline audit prompt" gates (4.4, 4.6.1) which have no skill to invoke. For those gates, verify the audit artifact instead of skill invocation.
+
 Anti-rationalization #9 (Self-Review Substitution) applies here.
 </CRITICAL>
-
-### Post-Dispatch Skill Invocation Verification (MANDATORY)
-
-After ANY subagent dispatched to invoke a skill returns, the orchestrator MUST perform this mechanical check before accepting results:
-
-```
-STEP 1: Does the subagent output contain "Launching skill: [skill-name]" or equivalent?
-STEP 2: If NO → REJECT result immediately. Do NOT check compilation. Do NOT read files.
-         Re-dispatch with the canonical template from dispatching-parallel-agents.
-STEP 3: If YES → Verify gate artifacts exist. Only then proceed to next gate.
-STEP 4: If "skill not available" claimed without an attempted Skill tool call → REJECT.
-         Subagents must attempt invocation; they cannot declare skills absent
-         without trying.
-```
-
-**Accepting unverified results is a process violation.** Subagents will produce files that pass compilation but bypassed all quality gates. The gates exist because compilation success does not imply correctness, review, or verification.
 
 ### Phase 4 Dispatch Discipline: Gate Non-Collapse Rule
 


### PR DESCRIPTION
## What does this PR do?

Hardens two skills against silent gate-bypass failures.

**develop (Phase 4 gate caveats)** — `b15f3e7` + `252e0a9` close a class of bypasses where implicit operator instructions ("wrap up", "and pause", "save tokens", "be efficient", standing autonomous mode) were being used as license to collapse the develop skill's Phase 4 dispatch table. The change makes the dispatch table non-fungible: combining rows is forbidden regardless of how the situation is rationalized, and recognizing the rationalization is itself the signal to stop. Adds the Pre-Dispatch Ritual / Phase Declaration block so phase collapse becomes mechanically detectable in real time. Second commit addresses Momus BOT-A1 and Gemini reviewer feedback on the first commit.

**documenting-projects (symbol-name verification)** — `538bdda` closes the fact-check gap I hit running `/document-project` on a real project earlier today: the planner prescribed 20 plausible-sounding symbol names that did not exist in `src/`, the writer applied them verbatim, and only the Phase 4 fact-check caught it. Adds an invariant principle + forbidden item to `docs-plan` requiring grep-verification against project source for any symbol/function/method/class/file-path/namespaced-key recorded in `source_hints` or `cross_cutting_tasks`. Adds a corresponding verification step to the `docs-write` writing-subagent prompt template (rule 4) with three escape paths (grep, rephrase, TODO comment), plus a matching forbidden item. The build cannot catch fabricated symbol names; only source verification can.

## Related issue

<!-- none -->

## Checklist

- [x] Tests pass locally
- [x] Documentation updated (if applicable)
