### PR TITLE
feat: add Pi platform support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,3 +175,6 @@ mise.toml
 .claude/worktrees
 *.db
 .claude/prompts/
+
+# Machine-local Claude Code permission allowlist
+.claude/settings.local.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   control-flow constructs. With neither opt-in active, default behavior
   is unchanged from 0.63.2.
 
+### Added
+
+- **Pi (pi-coding-agent) is now a supported install target.** Spellbook can
+  install into [Pi](https://github.com/badlogic/pi): a context file
+  (`AGENTS.md`), the Agent-Skills skills directory, prompt templates, and an
+  MCP server config at `~/.pi/agent/mcp.json`. Installer wiring adds the `pi`
+  platform, the `PI_CONFIG_DIR` setting, and the `--pi-config-dir` CLI flag.
+
 ### Fixed
 
 - **Admin session cookie scope.** `spellbook_admin_session` is now

--- a/install.py
+++ b/install.py
@@ -26,7 +26,7 @@ Usage:
 Options:
     --yes, -y           Accept all defaults without prompting
     --install-dir DIR   Install spellbook to DIR (default: ~/.local/share/spellbook)
-    --platforms LIST    Comma-separated platforms (claude_code,opencode,codex,gemini)
+    --platforms LIST    Comma-separated platforms (claude_code,opencode,codex,gemini,pi)
     --force             Reinstall even if version matches
     --dry-run           Show what would be done without making changes
     --no-interactive    Skip platform selection UI
@@ -1173,6 +1173,8 @@ def run_installation(spellbook_dir: Path, args: argparse.Namespace) -> int:
                     _post_notes.append("Claude Code: MCP server registered. Verify: /mcp")
                 elif p == "forgecode":
                     _post_notes.append("ForgeCode: Restart forge to load the spellbook MCP server")
+                elif p == "pi":
+                    _post_notes.append("Pi: Restart to reload skills and prompts. Verify: /reload")
             renderer.render_post_install(_post_notes)
         elif is_interactive():
             try:
@@ -1210,12 +1212,14 @@ Examples:
   curl -fsSL .../install.py | python3 - --yes
 
   # Specific platforms only
-  python3 install.py --platforms claude_code,codex
+  python3 install.py --platforms claude_code,codex,pi
 
   # Install to multiple config dirs for a platform
   python3 install.py --claude-config-dir ~/.claude --claude-config-dir ~/.claude-work
-""",
-    )
+
+  # Select or override Pi config directory
+  python3 install.py --pi-config-dir ~/.pi/agent
+""",    )
     parser.add_argument(
         "--yes", "-y",
         action="store_true",
@@ -1231,7 +1235,7 @@ Examples:
         "--platforms",
         type=str,
         default=None,
-        help="Comma-separated platforms (claude_code,opencode,codex,gemini)",
+        help="Comma-separated platforms (claude_code,opencode,codex,gemini,pi)",
     )
     parser.add_argument(
         "--force",

--- a/installer/config.py
+++ b/installer/config.py
@@ -35,7 +35,7 @@ def get_spellbook_config_dir() -> Path:
 
 
 # Supported platforms (AI coding assistants that can consume spellbook)
-SUPPORTED_PLATFORMS = ["claude_code", "opencode", "codex", "gemini", "forgecode"]
+SUPPORTED_PLATFORMS = ["claude_code", "opencode", "codex", "gemini", "forgecode", "pi"]
 
 # Platform configuration
 # NOTE: These are the AI assistant platforms that consume spellbook.
@@ -93,6 +93,17 @@ PLATFORM_CONFIG: Dict[str, Dict[str, Any]] = {
         "default_config_dir": Path.home() / ".forge",
         "cli_flag_name": "forge-config-dir",
         "context_file": "AGENTS.md",
+        "mcp_supported": True,
+        "mcp_server_name": "spellbook",
+    },
+    "pi": {
+        "name": "Pi",
+        "config_dir_env": "PI_CONFIG_DIR",
+        "default_config_dir": Path.home() / ".pi" / "agent",
+        "cli_flag_name": "pi-config-dir",
+        "context_file": "AGENTS.md",
+        "skills_subdir": "skills",
+        "prompts_subdir": "prompts",
         "mcp_supported": True,
         "mcp_server_name": "spellbook",
     },

--- a/installer/core.py
+++ b/installer/core.py
@@ -156,9 +156,10 @@ def get_platform_installer(
     """
     from .platforms.claude_code import ClaudeCodeInstaller
     from .platforms.codex import CodexInstaller
+    from .platforms.forgecode import ForgeCodeInstaller
     from .platforms.gemini import GeminiInstaller
     from .platforms.opencode import OpenCodeInstaller
-    from .platforms.forgecode import ForgeCodeInstaller
+    from .platforms.pi import PiInstaller
 
     config_dir = config_dir_override or get_platform_config_dir(platform)
 
@@ -168,6 +169,7 @@ def get_platform_installer(
         "codex": CodexInstaller,
         "gemini": GeminiInstaller,
         "forgecode": ForgeCodeInstaller,
+        "pi": PiInstaller,
     }
 
     installer_class = installers.get(platform)

--- a/installer/platforms/pi.py
+++ b/installer/platforms/pi.py
@@ -24,7 +24,6 @@ from ..components.symlinks import (
     cleanup_spellbook_symlinks,
     create_skill_symlinks,
     create_symlink,
-    remove_symlink,
     remove_spellbook_symlinks,
 )
 from ..demarcation import (
@@ -62,9 +61,25 @@ def _load_mcp_config_dict(config_path: Path) -> dict:
 
 
 def _write_mcp_config(config_path: Path, config: dict) -> None:
-    """Write JSON config atomically."""
+    """Write JSON config atomically.
+
+    Writes to a temporary file in the same directory as ``config_path`` (so
+    ``os.replace`` is an atomic rename on the same filesystem) and then
+    atomically replaces the target. On any failure the temporary file is
+    removed so a partial write never lands at ``config_path``.
+    """
     config_path.parent.mkdir(parents=True, exist_ok=True)
-    config_path.write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
+    payload = json.dumps(config, indent=2) + "\n"
+    tmp_path = config_path.with_name(f"{config_path.name}.tmp.{os.getpid()}")
+    try:
+        tmp_path.write_text(payload, encoding="utf-8")
+        os.replace(tmp_path, config_path)
+    except BaseException:
+        try:
+            tmp_path.unlink()
+        except FileNotFoundError:
+            pass
+        raise
 
 
 def _generate_mcp_json_section() -> dict:
@@ -157,16 +172,6 @@ class PiInstaller(PlatformInstaller):
         """Path to ~/.pi/agent/prompts/."""
         return self.config_dir / "prompts"
 
-    @property
-    def extensions_dir(self) -> Path:
-        """Path to ~/.pi/agent/extensions/."""
-        return self.config_dir / "extensions"
-
-    @property
-    def task_extension_source(self) -> Path:
-        """Source path for the Task extension in the spellbook repo."""
-        return self.spellbook_dir / "extensions" / "pi" / "Task"
-
     def detect(self) -> PlatformStatus:
         """Detect Pi installation status."""
         installed_version = get_installed_version(self.context_file)
@@ -212,23 +217,16 @@ class PiInstaller(PlatformInstaller):
                         except OSError:
                             pass
 
-        # Check for the Task extension
-        has_task_ext = False
-        task_ext_target = self.extensions_dir / "Task"
-        if task_ext_target.is_symlink() or task_ext_target.is_dir():
-            has_task_ext = True
-
         return PlatformStatus(
             platform=self.platform_id,
             available=self.config_dir.exists(),
-            installed=installed_version is not None or has_mcp or has_skills or has_prompts or has_task_ext,
+            installed=installed_version is not None or has_mcp or has_skills or has_prompts,
             version=installed_version,
             details={
                 "config_dir": str(self.config_dir),
                 "mcp_registered": has_mcp,
                 "skills_installed": has_skills,
                 "prompts_installed": has_prompts,
-                "task_extension_installed": has_task_ext,
             },
         )
 
@@ -373,25 +371,6 @@ class PiInstaller(PlatformInstaller):
                 )
             )
 
-        # Step 2.5: Install the Task extension for pi
-        self._step("Installing Task extension")
-        if not self.dry_run:
-            self.extensions_dir.mkdir(parents=True, exist_ok=True)
-
-        task_ext_target = self.extensions_dir / "Task"
-        task_ext_result = create_symlink(
-            self.task_extension_source, task_ext_target, self.dry_run
-        )
-        results.append(
-            InstallResult(
-                component="task_extension",
-                platform=self.platform_id,
-                success=task_ext_result.success,
-                action=task_ext_result.action,
-                message=f"Task extension: {task_ext_result.action}",
-            )
-        )
-
         # Step 3: Install AGENTS.md with demarcated section
         self._step("Updating AGENTS.md")
         spellbook_content = generate_claude_context(self.spellbook_dir)
@@ -509,24 +488,6 @@ class PiInstaller(PlatformInstaller):
                     )
                 )
 
-        # Remove Task extension symlink
-        task_ext_target = self.extensions_dir / "Task"
-        if task_ext_target.is_symlink():
-            task_ext_result = remove_symlink(
-                task_ext_target,
-                verify_source=self.task_extension_source,
-                dry_run=self.dry_run,
-            )
-            results.append(
-                InstallResult(
-                    component="task_extension",
-                    platform=self.platform_id,
-                    success=task_ext_result.success,
-                    action=task_ext_result.action,
-                    message=f"Task extension: {task_ext_result.action}",
-                )
-            )
-
         # Remove MCP server from mcp.json (global step)
         if not skip_global_steps:
             success, msg = _remove_pi_mcp_config(self.mcp_config_file, self.dry_run)
@@ -561,10 +522,5 @@ class PiInstaller(PlatformInstaller):
             for item in self.prompts_dir.iterdir():
                 if item.is_symlink():
                     symlinks.append(item)
-
-        # Task extension
-        task_ext_target = self.extensions_dir / "Task"
-        if task_ext_target.is_symlink():
-            symlinks.append(task_ext_target)
 
         return symlinks

--- a/installer/platforms/pi.py
+++ b/installer/platforms/pi.py
@@ -1,0 +1,570 @@
+"""Pi platform installer.
+
+Pi (https://github.com/badlogic/pi) supports:
+- AGENTS.md or CLAUDE.md for context (loaded from ~/.pi/agent/AGENTS.md globally)
+- Skills via Agent Skills standard in ~/.pi/agent/skills/ (directories or flat .md files)
+- Prompt templates as .md files in ~/.pi/agent/prompts/
+- MCP servers via JSON config in ~/.pi/agent/mcp.json (Claude Code shape)
+- HTTP MCP transport with headers map for Bearer auth
+
+Reference:
+- https://github.com/badlogic/pi-coding-agent/docs/skills.md
+- https://github.com/badlogic/pi-coding-agent/docs/prompt-templates.md
+"""
+
+import json
+import logging
+import os
+from pathlib import Path
+from typing import TYPE_CHECKING, List, Tuple
+
+from ..components.context_files import generate_claude_context
+from ..components.mcp import get_mcp_auth_token, get_spellbook_server_url
+from ..components.symlinks import (
+    cleanup_spellbook_symlinks,
+    create_skill_symlinks,
+    create_symlink,
+    remove_symlink,
+    remove_spellbook_symlinks,
+)
+from ..demarcation import (
+    get_installed_version,
+    remove_demarcated_section,
+    update_demarcated_section,
+)
+from .base import PlatformInstaller, PlatformStatus
+
+if TYPE_CHECKING:
+    from ..core import InstallResult
+
+logger = logging.getLogger(__name__)
+
+SPELLBOOK_SERVER_KEY: str = "spellbook"
+
+
+def _load_mcp_config_dict(config_path: Path) -> dict:
+    """Read and parse ``config_path`` as JSON, returning ``{}`` on failure."""
+    if not config_path.exists():
+        return {}
+    try:
+        data = json.loads(config_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as e:
+        logger.debug("Failed to parse %s: %s", config_path, e)
+        return {}
+    if not isinstance(data, dict):
+        logger.debug(
+            "Existing %s is not a JSON object (got %s); starting fresh",
+            config_path,
+            type(data).__name__,
+        )
+        return {}
+    return data
+
+
+def _write_mcp_config(config_path: Path, config: dict) -> None:
+    """Write JSON config atomically."""
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
+
+
+def _generate_mcp_json_section() -> dict:
+    """Generate the MCP server entry for spellbook (HTTP transport)."""
+    url = get_spellbook_server_url()
+    server_entry: dict = {
+        "url": url,
+    }
+    token = get_mcp_auth_token()
+    if token:
+        server_entry["headers"] = {"Authorization": f"Bearer {token}"}
+    return server_entry
+
+
+def _update_pi_mcp_config(
+    config_path: Path, dry_run: bool = False
+) -> Tuple[bool, str]:
+    """Add or update spellbook MCP server in pi's mcp.json (Claude Code shape)."""
+    if dry_run:
+        return (True, "would register MCP server (HTTP)")
+
+    config = _load_mcp_config_dict(config_path)
+
+    if "mcpServers" not in config or not isinstance(config["mcpServers"], dict):
+        config["mcpServers"] = {}
+
+    server_entry = _generate_mcp_json_section()
+    action = (
+        f"updated MCP server config (HTTP: {server_entry['url']})"
+        if SPELLBOOK_SERVER_KEY in config["mcpServers"]
+        else f"registered MCP server (HTTP: {server_entry['url']})"
+    )
+
+    config["mcpServers"][SPELLBOOK_SERVER_KEY] = server_entry
+    _write_mcp_config(config_path, config)
+    return (True, action)
+
+
+def _remove_pi_mcp_config(
+    config_path: Path, dry_run: bool = False
+) -> Tuple[bool, str]:
+    """Remove spellbook MCP server from pi's mcp.json."""
+    if not config_path.exists():
+        return (True, "config not found")
+
+    if dry_run:
+        return (True, "would remove MCP server config")
+
+    config = _load_mcp_config_dict(config_path)
+    if not config:
+        return (True, "config is not valid JSON")
+
+    servers = config.get("mcpServers")
+    if not isinstance(servers, dict) or SPELLBOOK_SERVER_KEY not in servers:
+        return (True, "MCP server was not configured")
+
+    del servers[SPELLBOOK_SERVER_KEY]
+    _write_mcp_config(config_path, config)
+    return (True, "removed MCP server config")
+
+
+class PiInstaller(PlatformInstaller):
+    """Installer for Pi platform."""
+
+    @property
+    def platform_name(self) -> str:
+        return "Pi"
+
+    @property
+    def platform_id(self) -> str:
+        return "pi"
+
+    @property
+    def mcp_config_file(self) -> Path:
+        """Path to ~/.pi/agent/mcp.json (Claude Code mcpServers shape)."""
+        return self.config_dir / "mcp.json"
+
+    @property
+    def context_file(self) -> Path:
+        """Path to ~/.pi/agent/AGENTS.md."""
+        return self.config_dir / "AGENTS.md"
+
+    @property
+    def skills_dir(self) -> Path:
+        """Path to ~/.pi/agent/skills/."""
+        return self.config_dir / "skills"
+
+    @property
+    def prompts_dir(self) -> Path:
+        """Path to ~/.pi/agent/prompts/."""
+        return self.config_dir / "prompts"
+
+    @property
+    def extensions_dir(self) -> Path:
+        """Path to ~/.pi/agent/extensions/."""
+        return self.config_dir / "extensions"
+
+    @property
+    def task_extension_source(self) -> Path:
+        """Source path for the Task extension in the spellbook repo."""
+        return self.spellbook_dir / "extensions" / "pi" / "Task"
+
+    def detect(self) -> PlatformStatus:
+        """Detect Pi installation status."""
+        installed_version = get_installed_version(self.context_file)
+
+        has_mcp = False
+        if self.mcp_config_file.exists():
+            cfg = _load_mcp_config_dict(self.mcp_config_file)
+            servers = cfg.get("mcpServers", {})
+            if isinstance(servers, dict):
+                has_mcp = SPELLBOOK_SERVER_KEY in servers
+
+        # Check for any spellbook-related skills or prompts
+        has_skills = False
+        if self.skills_dir.exists():
+            for item in self.skills_dir.iterdir():
+                if item.is_symlink() or item.is_file():
+                    # Check if it points to spellbook or has spellbook name
+                    if "spellbook" in item.name.lower():
+                        has_skills = True
+                        break
+                    if item.is_symlink():
+                        try:
+                            target = item.resolve()
+                            if "spellbook" in str(target).lower():
+                                has_skills = True
+                                break
+                        except OSError:
+                            pass
+
+        has_prompts = False
+        if self.prompts_dir.exists():
+            for item in self.prompts_dir.iterdir():
+                if item.is_symlink() or item.is_file():
+                    if "spellbook" in item.name.lower():
+                        has_prompts = True
+                        break
+                    if item.is_symlink():
+                        try:
+                            target = item.resolve()
+                            if "spellbook" in str(target).lower():
+                                has_prompts = True
+                                break
+                        except OSError:
+                            pass
+
+        # Check for the Task extension
+        has_task_ext = False
+        task_ext_target = self.extensions_dir / "Task"
+        if task_ext_target.is_symlink() or task_ext_target.is_dir():
+            has_task_ext = True
+
+        return PlatformStatus(
+            platform=self.platform_id,
+            available=self.config_dir.exists(),
+            installed=installed_version is not None or has_mcp or has_skills or has_prompts or has_task_ext,
+            version=installed_version,
+            details={
+                "config_dir": str(self.config_dir),
+                "mcp_registered": has_mcp,
+                "skills_installed": has_skills,
+                "prompts_installed": has_prompts,
+                "task_extension_installed": has_task_ext,
+            },
+        )
+
+    def install(self, force: bool = False, skip_global_steps: bool = False) -> List["InstallResult"]:
+        """Install Pi components.
+
+        Installs:
+        - Skills to ~/.pi/agent/skills/ (flat .md files or directory symlinks)
+        - Commands (prompt templates) to ~/.pi/agent/prompts/ (flat .md files)
+        - AGENTS.md context (demarcated section)
+        - MCP server config in mcp.json
+        """
+        from ..core import InstallResult
+
+        results: List[InstallResult] = []
+
+        if not self.config_dir.exists():
+            results.append(
+                InstallResult(
+                    component="platform",
+                    platform=self.platform_id,
+                    success=True,
+                    action="skipped",
+                    message=f"{self.config_dir} not found",
+                )
+            )
+            return results
+
+        # Step 1: Install skills to ~/.pi/agent/skills/
+        # Pi skill discovery: ~/.pi/agent/skills/*.md are individual skills,
+        # directories containing SKILL.md are also discovered.
+        # We install as directory symlinks (matching the skill dir structure).
+        self._step("Installing skills")
+        if not self.dry_run:
+            self.skills_dir.mkdir(parents=True, exist_ok=True)
+
+        # Clean up old symlinks first
+        total_cleaned = 0
+        if self.skills_dir.exists():
+            cleanup_results = cleanup_spellbook_symlinks(self.skills_dir, dry_run=self.dry_run)
+            total_cleaned = sum(1 for r in cleanup_results if r.success)
+
+        if total_cleaned > 0:
+            results.append(
+                InstallResult(
+                    component="cleanup",
+                    platform=self.platform_id,
+                    success=True,
+                    action="removed",
+                    message=f"cleanup: {total_cleaned} old symlinks removed",
+                )
+            )
+
+        # Create skill symlinks (as directories, matching pi's discovery rules)
+        skills_results = create_skill_symlinks(
+            self.spellbook_dir / "skills",
+            self.skills_dir,
+            as_directories=True,
+            dry_run=self.dry_run,
+        )
+        skill_count = sum(1 for r in skills_results if r.success)
+        results.append(
+            InstallResult(
+                component="skills",
+                platform=self.platform_id,
+                success=skill_count > 0 or not skills_results,
+                action="installed" if skills_results else "skipped",
+                message=f"skills: {skill_count} installed",
+            )
+        )
+
+        # Step 2: Install commands as prompt templates to ~/.pi/agent/prompts/
+        # Pi prompt template discovery: ~/.pi/agent/prompts/*.md are templates.
+        # We install as flat .md files (command name as filename).
+        self._step("Installing prompt templates (commands)")
+        if not self.dry_run:
+            self.prompts_dir.mkdir(parents=True, exist_ok=True)
+
+        # Clean up old command symlinks/prompts first
+        total_cleaned = 0
+        if self.prompts_dir.exists():
+            cleanup_results = cleanup_spellbook_symlinks(self.prompts_dir, dry_run=self.dry_run)
+            total_cleaned = sum(1 for r in cleanup_results if r.success)
+
+        if total_cleaned > 0:
+            results.append(
+                InstallResult(
+                    component="cleanup_prompts",
+                    platform=self.platform_id,
+                    success=True,
+                    action="removed",
+                    message=f"cleanup: {total_cleaned} old prompts removed",
+                )
+            )
+
+        # Install command files: simple .md files at root, and flatten
+        # .md files from subdirectories (pi prompts are non-recursive).
+        cmd_count = 0
+        commands_source = self.spellbook_dir / "commands"
+        if commands_source.exists():
+            # Simple commands: .md files in commands root
+            for cmd_file in commands_source.glob("*.md"):
+                target = self.prompts_dir / cmd_file.name
+                link_result = create_symlink(cmd_file, target, self.dry_run)
+                if link_result.success:
+                    cmd_count += 1
+
+            # Complex commands: subdirectory .md files need to be flattened
+            # because pi's prompt discovery is non-recursive.
+            for cmd_dir in commands_source.iterdir():
+                if not cmd_dir.is_dir():
+                    continue
+
+                # If the subdirectory has a .md matching the dir name,
+                # symlink it as <dir_name>.md for a clean /command-name
+                main_md = cmd_dir / f"{cmd_dir.name}.md"
+                if main_md.exists():
+                    target = self.prompts_dir / f"{cmd_dir.name}.md"
+                    link_result = create_symlink(main_md, target, self.dry_run)
+                    if link_result.success:
+                        cmd_count += 1
+
+                # Any other .md files in the subdirectory get prefixed with
+                # the subdirectory name to avoid collisions.
+                for sub_md in cmd_dir.glob("*.md"):
+                    if sub_md.name == f"{cmd_dir.name}.md":
+                        continue  # Already handled above
+                    target_name = f"{cmd_dir.name}--{sub_md.name}"
+                    target = self.prompts_dir / target_name
+                    link_result = create_symlink(sub_md, target, self.dry_run)
+                    if link_result.success:
+                        cmd_count += 1
+
+        if cmd_count > 0:
+            results.append(
+                InstallResult(
+                    component="prompts",
+                    platform=self.platform_id,
+                    success=True,
+                    action="installed",
+                    message=f"prompts: {cmd_count} installed",
+                )
+            )
+
+        # Step 2.5: Install the Task extension for pi
+        self._step("Installing Task extension")
+        if not self.dry_run:
+            self.extensions_dir.mkdir(parents=True, exist_ok=True)
+
+        task_ext_target = self.extensions_dir / "Task"
+        task_ext_result = create_symlink(
+            self.task_extension_source, task_ext_target, self.dry_run
+        )
+        results.append(
+            InstallResult(
+                component="task_extension",
+                platform=self.platform_id,
+                success=task_ext_result.success,
+                action=task_ext_result.action,
+                message=f"Task extension: {task_ext_result.action}",
+            )
+        )
+
+        # Step 3: Install AGENTS.md with demarcated section
+        self._step("Updating AGENTS.md")
+        spellbook_content = generate_claude_context(self.spellbook_dir)
+
+        if spellbook_content:
+            if self.dry_run:
+                results.append(
+                    InstallResult(
+                        component="AGENTS.md",
+                        platform=self.platform_id,
+                        success=True,
+                        action="installed",
+                        message="AGENTS.md: would be updated",
+                    )
+                )
+            else:
+                action, backup_path = update_demarcated_section(
+                    self.context_file, spellbook_content, self.version
+                )
+                msg = f"AGENTS.md: {action}"
+                if backup_path:
+                    msg += f" (backup: {backup_path.name})"
+                results.append(
+                    InstallResult(
+                        component="AGENTS.md",
+                        platform=self.platform_id,
+                        success=True,
+                        action=action,
+                        message=msg,
+                    )
+                )
+
+        # Step 4: Register MCP server in mcp.json
+        # This is a global step: MCP registration is system-wide, not per-dir.
+        if not skip_global_steps:
+            self._step("Registering MCP server")
+            success, msg = _update_pi_mcp_config(self.mcp_config_file, self.dry_run)
+            results.append(
+                InstallResult(
+                    component="mcp_server",
+                    platform=self.platform_id,
+                    success=success,
+                    action="installed" if success else "failed",
+                    message=f"MCP server: {msg}",
+                )
+            )
+
+        return results
+
+    def uninstall(self, skip_global_steps: bool = False) -> List["InstallResult"]:
+        """Uninstall Pi components."""
+        from ..core import InstallResult
+
+        results: List[InstallResult] = []
+
+        if not self.config_dir.exists():
+            return results
+
+        # Remove demarcated section from AGENTS.md
+        if self.context_file.exists():
+            if self.dry_run:
+                results.append(
+                    InstallResult(
+                        component="AGENTS.md",
+                        platform=self.platform_id,
+                        success=True,
+                        action="removed",
+                        message="AGENTS.md: would remove spellbook section",
+                    )
+                )
+            else:
+                action, _backup = remove_demarcated_section(self.context_file)
+                msg = f"AGENTS.md: {action}"
+                results.append(
+                    InstallResult(
+                        component="AGENTS.md",
+                        platform=self.platform_id,
+                        success=True,
+                        action=action,
+                        message=msg,
+                    )
+                )
+
+        # Remove skill symlinks
+        if self.skills_dir.exists():
+            symlink_results = remove_spellbook_symlinks(
+                self.skills_dir, self.spellbook_dir, dry_run=self.dry_run
+            )
+            if symlink_results:
+                removed_count = sum(1 for r in symlink_results if r.action == "removed")
+                results.append(
+                    InstallResult(
+                        component="skills",
+                        platform=self.platform_id,
+                        success=True,
+                        action="removed",
+                        message=f"skills: {removed_count} removed",
+                    )
+                )
+
+        # Remove prompt template symlinks
+        if self.prompts_dir.exists():
+            prompt_results = remove_spellbook_symlinks(
+                self.prompts_dir, self.spellbook_dir, dry_run=self.dry_run
+            )
+            if prompt_results:
+                removed_count = sum(1 for r in prompt_results if r.action == "removed")
+                results.append(
+                    InstallResult(
+                        component="prompts",
+                        platform=self.platform_id,
+                        success=True,
+                        action="removed",
+                        message=f"prompts: {removed_count} removed",
+                    )
+                )
+
+        # Remove Task extension symlink
+        task_ext_target = self.extensions_dir / "Task"
+        if task_ext_target.is_symlink():
+            task_ext_result = remove_symlink(
+                task_ext_target,
+                verify_source=self.task_extension_source,
+                dry_run=self.dry_run,
+            )
+            results.append(
+                InstallResult(
+                    component="task_extension",
+                    platform=self.platform_id,
+                    success=task_ext_result.success,
+                    action=task_ext_result.action,
+                    message=f"Task extension: {task_ext_result.action}",
+                )
+            )
+
+        # Remove MCP server from mcp.json (global step)
+        if not skip_global_steps:
+            success, msg = _remove_pi_mcp_config(self.mcp_config_file, self.dry_run)
+            results.append(
+                InstallResult(
+                    component="mcp_server",
+                    platform=self.platform_id,
+                    success=success,
+                    action="removed" if "removed" in msg else "skipped",
+                    message=f"MCP server: {msg}",
+                )
+            )
+
+        return results
+
+    def get_context_files(self) -> List[Path]:
+        """Get context files managed by this platform."""
+        return [self.context_file]
+
+    def get_symlinks(self) -> List[Path]:
+        """Get all symlinks created by this platform."""
+        symlinks: List[Path] = []
+
+        # Skills
+        if self.skills_dir.exists():
+            for item in self.skills_dir.iterdir():
+                if item.is_symlink():
+                    symlinks.append(item)
+
+        # Prompts
+        if self.prompts_dir.exists():
+            for item in self.prompts_dir.iterdir():
+                if item.is_symlink():
+                    symlinks.append(item)
+
+        # Task extension
+        task_ext_target = self.extensions_dir / "Task"
+        if task_ext_target.is_symlink():
+            symlinks.append(task_ext_target)
+
+        return symlinks

--- a/installer/tui.py
+++ b/installer/tui.py
@@ -401,6 +401,8 @@ def render_post_install_notes(
         lines.append("[cyan]Claude Code[/cyan]: MCP server registered. Verify: /mcp")
     if "forgecode" in platforms:
         lines.append("[cyan]ForgeCode[/cyan]: Restart forge to load the spellbook MCP server")
+    if "pi" in platforms:
+        lines.append("[cyan]Pi[/cyan]: Restart to reload skills and prompts. Verify: /reload")
 
     if shutil.which("cco"):
         lines.append(

--- a/skills/develop/SKILL.md
+++ b/skills/develop/SKILL.md
@@ -48,6 +48,17 @@ When operating in YOLO mode or when user selected "Fully autonomous":
   spawning of parallel sessions are gated by `feature-implement`
   Phase 3.4.7 (One-Pager Approval Gate). Autonomous mode does not
   waive that gate.
+- **APPROVAL GATES (2.3, 3.3) ARE NEVER AUTO-PROCEEDED.** Even in
+  full autonomous mode, design and plan approval gates require explicit
+  artifact verification before continuation. Before auto-proceeding:
+  1. Verify the artifact exists at the expected path (`ls`)
+  2. Verify section numbering is sequential and complete (no gaps like
+     starting at Section 8 with Sections 1–7 missing)
+  3. Verify cited file paths and function names actually exist
+  4. Verify dependency graph (for impl plans) has no cycles
+  Skipping these checks because "autonomous mode" is a Pattern 10
+  (Momentum Preservation) rationalization. The gate exists because
+  artifact-shaped failures are invisible without verification.
 
 If you find yourself typing "Should I proceed?" — STOP. You already have permission.
 </CRITICAL>
@@ -65,6 +76,42 @@ If you find yourself typing "Should I proceed?" — STOP. You already have permi
 - Neither → `CURRENT_AGENT_TYPE = "general"`
 
 **All Task tool calls MUST use `CURRENT_AGENT_TYPE` as `subagent_type`** (except pure exploration which may use `explore`).
+</CRITICAL>
+
+---
+
+## Platform Adaptation: Pi (π)
+
+<CRITICAL>
+**If running in Pi (`pi-coding-agent`):** The following adaptations apply.
+
+**Detection:** System prompt mentions "pi" or available tools include `subagent` (not `Task`).
+
+**Tool name mapping:**
+- "Task tool" → `subagent` tool. All references to `Task()` dispatch in this skill mean `subagent()` in Pi.
+- `subagent_type` field does NOT exist in Pi. Skip `CURRENT_AGENT_TYPE` propagation entirely.
+- `forge_project_init` is NOT available. Use `subagent` with `planner` or `delegate` agent for design synthesis.
+- `spawn_session` is NOT available.
+
+**Skill invocation in Pi:** Pi loads skills via system-prompt auto-trigger by text patterns or via `/skill:name`. There is no "Skill tool" RPC. To verify a subagent invoked the intended skill:
+
+1. Subagent prompt MUST instruct: "Begin your response with exactly: `SKILL_INVOCATION: [skill-name]`. If the skill is unavailable in your environment, output: `SKILL_UNAVAILABLE: [reason]` instead."
+2. Orchestrator MUST verify the `SKILL_INVOCATION:` header is present in the first 3 lines of subagent output.
+3. If header missing or wrong skill name: REJECT the result. Re-dispatch with clearer instruction. Do NOT integrate findings from a subagent that may have executed from memory rather than invoking the skill.
+
+**Available Pi subagent types:** `delegate`, `scout`, `worker`, `reviewer`, `planner`, `oracle`, `context-builder`, `researcher`. Map develop-skill agent references as:
+
+| Develop says | Pi uses |
+|---|---|
+| explore agent | `scout` or `delegate` |
+| dehallucination/devils-advocate | `delegate` (skill auto-fires) |
+| design-exploration | `planner` |
+| reviewing-design-docs / reviewing-impl-plans / requesting-code-review | `reviewer` |
+| writing-plans | `planner` |
+| executing-plans / test-driven-development / finishing | `worker` |
+| fact-checking / auditing-green-mirage | `delegate` or `reviewer` |
+
+**Artifact paths:** Pi sessions typically use `~/Development/<project>/` instead of `~/.local/spellbook/docs/<project-encoded>/`. Use whichever convention the operator established; do not silently switch.
 </CRITICAL>
 
 ---
@@ -211,6 +258,57 @@ ls ~/.local/spellbook/docs/<project-encoded>/plans/*-impl.md
 
 ---
 
+## MANDATORY: Artifact Verification Protocol
+
+<CRITICAL>
+Subagents are unreliable contract executors. They over-deliver, under-deliver,
+and silently use the wrong path. Every dispatch must enforce an artifact contract
+in BOTH directions: prompt and return.
+</CRITICAL>
+
+### Orchestrator → Subagent (in every dispatch prompt)
+
+1. **Absolute paths only.** "Write to `/Users/.../project/design.md`" — NEVER
+   "write to `design.md`". Subagent CWD may differ from orchestrator CWD.
+2. **Exact artifact count.** "Produce EXACTLY one file: `[path]`. Do NOT
+   produce `plan.md`, `notes.md`, or any sibling artifact. If your skill
+   wants to produce more, list them in your return summary and ask before
+   writing."
+3. **Section schema.** For documents: "The document MUST have sections
+   numbered 1 through N with no gaps. Section headings: [list]. Verify
+   sequential numbering before returning."
+4. **Forbidden phrasing.** Do not say "create the design AND the plan" —
+   that triggers Phase Collapse (Pattern 6) inside the subagent.
+
+### Subagent → Orchestrator (in every return summary)
+
+Subagent return MUST include:
+
+```
+ARTIFACTS_WRITTEN:
+  - /absolute/path/file1.md (N lines, sections 1–K)
+  - /absolute/path/file2.ts (M lines)
+ARTIFACTS_NOT_WRITTEN: (anything skill wanted to write but operator forbade)
+SKILL_INVOCATION: [skill-name]
+COMPILE_STATUS: pass | fail | n/a
+TEST_STATUS: N/N pass | n/a
+```
+
+### Orchestrator post-dispatch verification (mandatory)
+
+Before moving to next phase, run via subagent:
+
+```bash
+ls -la [expected_paths]
+# For documents: grep -c "^## " [path]   # section count check
+```
+
+If artifact missing, at wrong path, or section count wrong: re-dispatch.
+Do NOT accept "the file is there, trust me" — verify. The cost of one
+`ls` is far lower than the cost of building Phase N+1 on a missing artifact.
+
+---
+
 ## MANDATORY: Pre-Dispatch Ritual
 
 <CRITICAL>
@@ -309,18 +407,33 @@ If a subagent fails or returns empty results: re-dispatch with additional contex
 ### What To Do Instead
 
 ```
-Task:
+Task (or subagent in Pi):
   description: "[Brief description]"
-  subagent_type: "[CURRENT_AGENT_TYPE]"  # yolo, yolo-focused, or general
+  subagent_type: "[CURRENT_AGENT_TYPE]"  # OpenCode only; omit in Pi
   prompt: |
     First, invoke the [skill-name] skill using the Skill tool.
     Then follow its complete workflow.
+
+    Begin your response with exactly: SKILL_INVOCATION: [skill-name]
+    (or SKILL_UNAVAILABLE: [reason] if you cannot invoke).
+
+    CRITICAL: Write all files to ABSOLUTE paths. Do NOT use the
+    current working directory as an implicit output location.
+    Expected artifact path: [absolute path]
+    Expected artifact count: 1 (do not produce sibling files)
+
+    Return summary MUST include:
+      ARTIFACTS_WRITTEN: [absolute paths with line counts]
+      SKILL_INVOCATION: [skill-name]
+      COMPILE_STATUS: pass | fail | n/a
+      TEST_STATUS: N/N pass | n/a
 
     ## Context for the Skill
     [Provide context here]
 ```
 
 **OpenCode:** Always use `CURRENT_AGENT_TYPE` (detected at session start) to ensure subagents inherit YOLO permissions.
+**Pi:** Skip `subagent_type` field entirely; Pi has no agent-type permissions axis.
 </FORBIDDEN>
 
 ---
@@ -546,6 +659,81 @@ Every Phase 4 dispatch point follows this protocol:
 
 Skipping ANY step is forbidden. See Anti-Rationalization patterns #8, #9, #10.
 </CRITICAL>
+
+### Phase 4.0 Pre-Implementation Environment Gate
+
+<CRITICAL>
+Before dispatching any implementation subagent, verify test infrastructure
+is available. A subagent that writes Lua scripts but cannot run them against
+Real Redis is shipping unverified code regardless of how many mocks pass.
+</CRITICAL>
+
+Dispatch a one-shot environment probe before Phase 4.1:
+
+```bash
+# Examples — adapt per project tech stack
+redis-cli ping              # if Redis is in scope
+docker ps                   # if containers are in scope
+psql -c '\l' postgres       # if Postgres is in scope
+curl -fsS [healthcheck_url] # if external API is in scope
+node --version              # interpreter sanity
+```
+
+For each unavailable dependency: write a `test-limitations.md` documenting
+what cannot be validated this session. Implementation may proceed with mocks
+BUT all subagents implementing against the unavailable infrastructure MUST
+add at least one integration test file (skipped if infra absent) so a future
+session can validate. Do NOT silently assume mocks cover real behavior.
+
+### Phase 4.1 Worktree Pre-Check
+
+Before using `worktree: true` in subagent dispatch:
+
+```bash
+cd [project_root]
+git status                    # must be clean OR commit/stash first
+git log --oneline -1          # must show at least one commit
+git branch --show-current     # confirm target branch
+```
+
+Worktrees CANNOT be created from:
+- An empty git repo (no commits on branch)
+- A directory that is not a git repo at all
+- A branch with uncommitted changes that would conflict
+
+If any check fails: commit/init first, then dispatch with worktree.
+Do NOT silently fall back to non-isolated parallel — file collisions
+between subagents will eat your afternoon.
+
+### Phase 4 Batching Threshold Protocol
+
+<CRITICAL>
+For implementations with >12 tasks OR >2 parallel tracks: per-task gates
+(4.3 → 4.4 → 4.5 → 4.5.1) MUST be executed by track managers, not by
+the CEO orchestrator.
+</CRITICAL>
+
+**Why:** 24 tasks × 4 gates = 96 dispatches. Each return accumulates in
+CEO context. By task 12 the CEO is reading more than orchestrating, and
+the end-of-Phase-4 audit (4.6.1) runs in a context already polluted with
+implementation detail.
+
+**How:**
+
+| Task count | Mode | Per-task gates run by |
+|---|---|---|
+| < 8 | direct / delegated | CEO (one dispatch per gate per task) |
+| 8–12 | delegated | CEO with batched per-domain dispatches |
+| > 12 OR ≥ 2 tracks | sub_orchestrators | Track managers (CEO sees only summaries) |
+| > 25 OR cross-session | work_items | Separate sessions |
+
+When sub_orchestrators is selected, see `dispatching-sub-orchestrators`
+skill for the Manager dispatch template, including the inline quality
+gate that each Manager runs after every sub-task.
+
+**Do NOT collapse per-task gates into one batched gate at CEO level.**
+That is not batching — that is gate elision (Pattern 8). Batching means
+routing to managers; elision means running fewer gates.
 
 **Subagent Prompt Length Verification:**
 Before dispatching ANY subagent:
@@ -885,6 +1073,75 @@ Commands share state via these session variables:
 
 - `SESSION_PREFERENCES` - User workflow preferences (from Phase 0)
 - `SESSION_CONTEXT` - Research findings, design context (built across phases)
+
+### Session Handoff Protocol
+
+<CRITICAL>
+Long develop sessions hit context limits. The skill assumes one session
+completes all phases; reality is that COMPLEX features often span sessions.
+Without a standard handoff, the next session re-discovers state and drifts.
+</CRITICAL>
+
+**When to write a handoff:** before context compaction, when the operator
+pauses an in-flight develop session, or whenever the orchestrator estimates
+remaining context cannot complete the current phase plus the next gate.
+
+**Where:** `~/.local/spellbook/handoffs/YYYY-MM-DD-<feature-slug>.md`
+(or `<project_root>/HANDOFF.md` if the operator established that convention).
+
+**Schema:**
+
+```markdown
+# Handoff: <feature-slug>
+Generated: YYYY-MM-DD HH:MM
+Session: <session id or git branch>
+
+## Resume At
+- Phase: 4.5 (per-task code review)
+- Sub-step: Wave 2, group "coordination"
+- Tier: STANDARD
+- Execution mode: sub_orchestrators
+
+## Completed
+- Phases 0–3.4 (full audit trail in <design_doc> and <impl_plan>)
+- Tasks 1–10 implemented (commits abc123..def456)
+- Per-task gates 4.3–4.4 done for tasks 1–10
+
+## Pending
+- Tasks 11–24 (see plan.md §<task list>)
+- Per-task gate 4.5 (code review) for all tasks
+- End-of-Phase-4 gates 4.6.1–4.6.5
+
+## Blockers
+- Redis not available locally; integration tests skipped
+- Pi `exec()` API for spawn unverified (see spike/SPAWN_DECISION.md)
+
+## Artifacts
+- design.md  — /absolute/path (1664 lines, sections 1–15)
+- plan.md    — /absolute/path (402 lines, 24 tasks)
+- HANDOFF.md — /absolute/path (this file)
+- review/    — /absolute/path (post-hoc review reports)
+
+## Git State
+- Branch: main
+- HEAD: <sha>  <commit subject>
+- Working tree: clean | <list of dirty files>
+
+## Test Status
+- Unit: 109/109 pass (--pool=forks required for OOM)
+- Integration: 4/4 pass against real Redis db 4
+- TypeScript: 0 errors
+
+## Next Dispatch
+Phase 4.5 code-review subagent for coordination group:
+  files: src/mesh/{bidder,taskmaster,archivist,compacter}.ts
+  skill: requesting-code-review
+  output: review/code-review-coordination.md
+```
+
+**On resume:** the next session MUST read the handoff before any other action,
+then verify the git HEAD and test status still match. If the working tree
+diverged from the handoff, treat as new session and re-classify complexity.
 
 ### STOP AND VERIFY Markers
 

--- a/skills/dispatching-parallel-agents/SKILL.md
+++ b/skills/dispatching-parallel-agents/SKILL.md
@@ -77,6 +77,9 @@ Dispatch one agent per independent problem domain — only after the independenc
 3. **Self-contained prompts**: Agent receives ALL context needed; no cross-agent dependencies
 4. **Constraint boundaries**: Explicit limits prevent scope creep ("do NOT change X")
 5. **Merge verification required**: Agent work integrated only after conflict check + full test suite
+6. **Activity signaling**: Subagents with large scope (reading 5+ files OR prompt > 200 lines) MUST begin their response with `Starting: [task name]…` within ~30 seconds so the orchestrator sees activity and does not flag the run as stalled. Long silent setup is indistinguishable from a hung subagent.
+7. **Timeout tolerance**: Large-scope subagents (deep reads, large refactors, multi-file reviews) should be dispatched with extended timeout (120–180s) or as background runs. A subagent that hits the orchestrator's no-activity timer during a legitimate file-read phase has not failed; re-dispatch with narrower scope or background mode rather than declaring it broken.
+8. **Worktree pre-check**: Before any dispatch with `worktree: true` (or equivalent isolation flag), verify the project is a git repo with at least one commit on the target branch and a clean working tree. Worktrees cannot be created from empty branches; the operator-visible failure ("worktree isolation requires a git repository") is non-obvious and costs a full re-dispatch when it bites mid-fan-out.
 
 ## Inputs
 

--- a/skills/dispatching-sub-orchestrators/SKILL.md
+++ b/skills/dispatching-sub-orchestrators/SKILL.md
@@ -236,6 +236,45 @@ After all 4 gates pass, commit. THEN proceed to the next task. Do NOT
 batch gates across tasks. Do NOT batch commits across tasks. Each task
 is a complete unit: gates pass -> commit -> next task.
 
+## Manager Inline Quality Gate (per sub-task, BEFORE commit)
+
+<CRITICAL>
+Between the 4 per-task gates and the per-task commit, run a mechanical
+quality check on the ACTUAL working tree. The 4 gates above can pass with
+implementations that compile in isolation but break the rest of the project,
+or with tests that pass against a stub. This inline check catches both.
+</CRITICAL>
+
+For each task, after gate 4 (fact-check) and before commit:
+
+```bash
+# 1. Whole-project type-check (NOT just the new file)
+<typecheck command>   # e.g., npx tsc --noEmit, mypy ., cargo check
+
+# 2. Run the new test file specifically
+<targeted test command>   # e.g., vitest run path/to/new.spec.ts
+
+# 3. Quick anti-pattern grep on the modified files
+rg -n 'as any|: any[, )=]|@ts-ignore|@ts-expect-error|expect\(true\)\.toBe\(true\)' <modified_files>
+
+# 4. (If integration infrastructure is available) run the relevant
+#    integration test, NOT just unit tests with mocks. Mock-only coverage
+#    of an external system (Redis Lua, SQL, HTTP) is a known green-mirage
+#    source. If integration infra is unavailable, log this in your summary
+#    so the CEO end-of-Phase-4 gates know to weight green-mirage audit higher.
+```
+
+Report per-task in your final summary as one of:
+
+- `Task N: PASS (typecheck clean, K/K tests, no anti-patterns)`
+- `Task N: PASS-WITH-NOTES (typecheck clean, K/K tests; integration deferred: <reason>)`
+- `Task N: FAIL (<single-sentence reason>)` — in which case you must fix
+  before commit, OR roll the task back and report the blocker to the CEO.
+
+Do NOT silently let "FAIL" become "PASS" by relaxing the test or stubbing
+the failing branch. That is Pattern 9 (Self-Review Substitution) at the
+Manager tier. If you cannot honestly report PASS, the CEO needs to know.
+
 ## Task-Tool Availability (REPORT THIS)
 
 Subagents dispatched as `general` / `general-purpose` should have the

--- a/skills/test-driven-development/SKILL.md
+++ b/skills/test-driven-development/SKILL.md
@@ -287,6 +287,48 @@ The ESCAPE field must describe a SPECIFIC broken implementation, not a generic s
 - ESCAPE field describes something the test DOES catch (means you didn't think hard enough)
 - ESCAPE field is copy-pasted between tests (each test has unique escape paths)
 
+### Test Strength Verification (mechanical pre-commit grep)
+
+ESCAPE Analysis is the rigorous version. This is the cheap mechanical version
+that catches the most common green-mirage patterns at commit time. Run BEFORE
+any per-task commit:
+
+```bash
+# 1. Banned substring assertions on serialized output
+rg -n 'expect.*stringContaining.*JSON|expect.*stringContaining.*\{' <test_files>
+# Replace with: JSON.parse(...) + exact deep equality (toEqual)
+
+# 2. Tautological / dead assertions
+rg -n 'expect\(true\)\.toBe\(true\)|expect\(1\)\.toBe\(1\)|assert True$|assert 1$' <test_files>
+# Replace with: behavioral assertion that can actually fail
+
+# 3. Mock call without argument verification (catches "called X but with what?")
+rg -n 'toHaveBeenCalled\(\)$|assert_called\(\)$|called_once\(\)$' <test_files>
+# Strengthen with: toHaveBeenCalledWith(...) / assert_called_with(...) / called_once_with(...)
+
+# 4. Existence-only smoke tests (typeof === "function")
+rg -n 'typeof.*===.*function|isinstance.*function|callable\(' <test_files>
+# Replace with: actually call the thing and assert behavior
+
+# 5. Side-effect-free "happy path" tests for stateful operations
+#    (e.g., "forms a coalition" that asserts return value but never
+#    inspects the Redis hash that should have been written)
+#    — no greppable signature; require by checklist:
+#    For every test of a method that mutates external state, at least one
+#    assertion MUST inspect the post-state, not just the return value.
+```
+
+If any grep returns hits: strengthen the assertion BEFORE the next gate.
+A passing test with these patterns is a known green-mirage source
+(see `auditing-green-mirage` skill for the catalog).
+
+**Mock fidelity rule:** If your mock for an external system (Redis Lua,
+SQL, HTTP API) does not match the real system's contract, your test passes
+are lies. When integration infrastructure is available (Phase 4.0
+Environment Gate confirmed it), at least one integration test per module
+MUST exercise the real system. Mocks for `evalLua`, `set`, `xadd`, etc.
+are convenience aids, not coverage.
+
 ## Evidence Requirements
 
 | Claim | Required Evidence |

--- a/tests/test_multi_target_config.py
+++ b/tests/test_multi_target_config.py
@@ -11,8 +11,8 @@ class TestPlatformConfigEntries:
     """Tests for PLATFORM_CONFIG structure and values."""
 
     def test_all_platforms_have_config_dir_env(self):
-        """All 5 platforms in PLATFORM_CONFIG have non-None config_dir_env."""
-        assert len(PLATFORM_CONFIG) == 5
+        """All 6 platforms in PLATFORM_CONFIG have non-None config_dir_env."""
+        assert len(PLATFORM_CONFIG) == 6
         for platform_id, config in PLATFORM_CONFIG.items():
             assert config["config_dir_env"] is not None, (
                 f"{platform_id} has None config_dir_env"
@@ -22,7 +22,7 @@ class TestPlatformConfigEntries:
             )
 
     def test_all_platforms_have_cli_flag_name(self):
-        """All 5 platforms have string cli_flag_name using hyphens (not underscores)."""
+        """All 6 platforms have string cli_flag_name using hyphens (not underscores)."""
         for platform_id, config in PLATFORM_CONFIG.items():
             flag = config["cli_flag_name"]
             assert isinstance(flag, str), (
@@ -43,6 +43,7 @@ class TestPlatformConfigEntries:
             "codex": "CODEX_CONFIG_DIR",
             "gemini": "GEMINI_CONFIG_DIR",
             "forgecode": "FORGE_CONFIG",
+            "pi": "PI_CONFIG_DIR",
         }
         for platform_id, expected_env in expected.items():
             assert PLATFORM_CONFIG[platform_id]["config_dir_env"] == expected_env, (
@@ -58,6 +59,7 @@ class TestPlatformConfigEntries:
             "codex": "codex-config-dir",
             "gemini": "gemini-config-dir",
             "forgecode": "forge-config-dir",
+            "pi": "pi-config-dir",
         }
         for platform_id, expected_flag in expected.items():
             assert PLATFORM_CONFIG[platform_id]["cli_flag_name"] == expected_flag, (


### PR DESCRIPTION
## What does this PR do?

Adds Pi (`pi-coding-agent`) as a first-class spellbook install target and documents the corresponding skill adaptations. The installer learns the `pi` platform end to end — `SUPPORTED_PLATFORMS`, a `PLATFORM_CONFIG` block (`~/.pi/agent` default, `PI_CONFIG_DIR`, `--pi-config-dir`), the installer factory (`PiInstaller`), CLI help, and post-install notes — backed by a new `installer/platforms/pi.py`. The develop, dispatching-parallel-agents, dispatching-sub-orchestrators, and test-driven-development skills gain Pi platform-adaptation guidance (tool-name mapping, Pi subagent types, artifact-path conventions) plus related orchestration-protocol updates. The machine-local `.claude/settings.local.json` permission allowlist is now gitignored rather than tracked.

## Related issue

None.

## Checklist

- [ ] Tests pass locally
- [ ] Documentation updated (if applicable)
