### PR TITLE
fix(tests): isolate HOME in ClaudeCodeInstaller integration tests

### DIFF
--- a/tests/installer/test_agents_symlink.py
+++ b/tests/installer/test_agents_symlink.py
@@ -649,7 +649,16 @@ class TestClaudeCodeInstallerWiring:
     """
 
     @pytest.mark.skipif(sys.platform == "win32", reason="POSIX symlink semantics")
-    def test_install_creates_agent_symlinks_in_config_dir(self, tmp_path):
+    def test_install_creates_agent_symlinks_in_config_dir(self, tmp_path, monkeypatch):
+        # Isolate HOME so the alias-install step (which writes the
+        # SPELLBOOK_ALIASES block to ``$HOME/.zshrc`` via Path.home()) does
+        # not touch the operator's real rc file. install() runs the alias
+        # step unconditionally even under skip_global_steps=True; without
+        # this isolation, on a developer machine that has spellbook-cco on
+        # PATH the test will rewrite ``~/.zshrc`` with aliases pointing at
+        # the pytest tmp_path, which pytest then deletes -- leaving the
+        # operator's shell broken on next login.
+        monkeypatch.setenv("HOME", str(tmp_path))
         from installer.platforms.claude_code import ClaudeCodeInstaller
 
         spellbook_dir = _scaffold_spellbook(tmp_path / "spellbook")
@@ -677,7 +686,9 @@ class TestClaudeCodeInstallerWiring:
             assert target.read_text(encoding="utf-8") == f"body-{name}"
 
     @pytest.mark.skipif(sys.platform == "win32", reason="POSIX symlink semantics")
-    def test_install_returns_install_result_for_agents_step(self, tmp_path):
+    def test_install_returns_install_result_for_agents_step(self, tmp_path, monkeypatch):
+        # See test_install_creates_agent_symlinks_in_config_dir for rationale.
+        monkeypatch.setenv("HOME", str(tmp_path))
         from installer.core import InstallResult
         from installer.platforms.claude_code import ClaudeCodeInstaller
 
@@ -707,7 +718,12 @@ class TestClaudeCodeInstallerWiring:
         ]
 
     @pytest.mark.skipif(sys.platform == "win32", reason="POSIX symlink semantics")
-    def test_install_dry_run_creates_no_files(self, tmp_path):
+    def test_install_dry_run_creates_no_files(self, tmp_path, monkeypatch):
+        # See test_install_creates_agent_symlinks_in_config_dir for rationale.
+        # dry_run=True suppresses the rc-file write in the current
+        # implementation, but isolate HOME anyway so a future change that
+        # logs HOME or stats the rc file under dry_run cannot leak.
+        monkeypatch.setenv("HOME", str(tmp_path))
         from installer.core import InstallResult
         from installer.platforms.claude_code import ClaudeCodeInstaller
 
@@ -744,8 +760,10 @@ class TestClaudeCodeInstallerWiring:
 
     @pytest.mark.skipif(sys.platform == "win32", reason="POSIX symlink semantics")
     def test_uninstall_removes_agent_symlinks_only_spellbook_pointing(
-        self, tmp_path
+        self, tmp_path, monkeypatch
     ):
+        # See test_install_creates_agent_symlinks_in_config_dir for rationale.
+        monkeypatch.setenv("HOME", str(tmp_path))
         from installer.platforms.claude_code import ClaudeCodeInstaller
 
         spellbook_dir = _scaffold_spellbook(tmp_path / "spellbook")
@@ -777,7 +795,9 @@ class TestClaudeCodeInstallerWiring:
         assert user_file.read_text(encoding="utf-8") == "user content"
 
     @pytest.mark.skipif(sys.platform == "win32", reason="POSIX symlink semantics")
-    def test_install_idempotent_re_run_no_duplicates(self, tmp_path):
+    def test_install_idempotent_re_run_no_duplicates(self, tmp_path, monkeypatch):
+        # See test_install_creates_agent_symlinks_in_config_dir for rationale.
+        monkeypatch.setenv("HOME", str(tmp_path))
         from installer.core import InstallResult
         from installer.platforms.claude_code import ClaudeCodeInstaller
 
@@ -822,7 +842,7 @@ class TestClaudeCodeInstallerWiring:
         assert before == after
 
     @pytest.mark.skipif(sys.platform == "win32", reason="POSIX symlink semantics")
-    def test_install_cleanup_purges_stale_agent_symlink(self, tmp_path):
+    def test_install_cleanup_purges_stale_agent_symlink(self, tmp_path, monkeypatch):
         """Install-time cleanup purges stale symlinks into THIS spellbook.
 
         When a source agent is renamed/removed, the prior symlink at
@@ -833,6 +853,8 @@ class TestClaudeCodeInstallerWiring:
         broken links are NOT in scope for this cleanup -- see
         ``test_install_cleanup_preserves_other_spellbook_broken_symlinks``.)
         """
+        # See test_install_creates_agent_symlinks_in_config_dir for rationale.
+        monkeypatch.setenv("HOME", str(tmp_path))
         from installer.platforms.claude_code import ClaudeCodeInstaller
 
         spellbook_dir = _scaffold_spellbook(tmp_path / "spellbook")
@@ -868,7 +890,7 @@ class TestClaudeCodeInstallerWiring:
 
     @pytest.mark.skipif(sys.platform == "win32", reason="POSIX symlink semantics")
     def test_install_cleanup_preserves_other_spellbook_broken_symlinks(
-        self, tmp_path
+        self, tmp_path, monkeypatch
     ):
         """Broken-symlink heuristic must not remove links into a *different*
         spellbook installation.
@@ -883,6 +905,8 @@ class TestClaudeCodeInstallerWiring:
         equality. A broken symlink whose path contains "spellbook" but
         points into a different installation must be preserved.
         """
+        # See test_install_creates_agent_symlinks_in_config_dir for rationale.
+        monkeypatch.setenv("HOME", str(tmp_path))
         from installer.platforms.claude_code import ClaudeCodeInstaller
 
         spellbook_dir = _scaffold_spellbook(tmp_path / "spellbook")

--- a/tests/installer/test_l2_derivation.py
+++ b/tests/installer/test_l2_derivation.py
@@ -342,12 +342,19 @@ def test_unprojectable_record_warns_does_not_fail(tmp_path, caplog):
 # ---------------------------------------------------------------------------
 
 
-def test_claude_code_installer_uses_derived_deny(tmp_path):
+def test_claude_code_installer_uses_derived_deny(tmp_path, monkeypatch):
     """End-to-end: ClaudeCodeInstaller.install() writes T3 deny patterns to
     settings.json by calling install_permissions with derive_managed_deny output.
 
     Uses a fixture spellbook_dir that contains a minimal tiers.toml.
     """
+    # Isolate HOME so the alias-install step inside install() (which writes
+    # the SPELLBOOK_ALIASES block to ``$HOME/.zshrc`` via Path.home()) does
+    # not touch the operator's real rc file. install() runs the alias step
+    # unconditionally even under skip_global_steps=True; on a machine that
+    # has spellbook-cco on PATH the test would otherwise rewrite ~/.zshrc
+    # with aliases pointing at the pytest tmp_path.
+    monkeypatch.setenv("HOME", str(tmp_path))
     from installer.platforms.claude_code import ClaudeCodeInstaller
 
     # ``ClaudeCodeInstaller.install(skip_global_steps=True)`` calls

--- a/tests/installer/test_l2_derivation.py
+++ b/tests/installer/test_l2_derivation.py
@@ -348,13 +348,21 @@ def test_claude_code_installer_uses_derived_deny(tmp_path, monkeypatch):
 
     Uses a fixture spellbook_dir that contains a minimal tiers.toml.
     """
-    # Isolate HOME so the alias-install step inside install() (which writes
-    # the SPELLBOOK_ALIASES block to ``$HOME/.zshrc`` via Path.home()) does
-    # not touch the operator's real rc file. install() runs the alias step
-    # unconditionally even under skip_global_steps=True; on a machine that
-    # has spellbook-cco on PATH the test would otherwise rewrite ~/.zshrc
-    # with aliases pointing at the pytest tmp_path.
+    # Isolate HOME (and USERPROFILE for forward-compat with Q-O Windows
+    # alias install) so the alias-install step inside install() -- which
+    # writes the SPELLBOOK_ALIASES block to ``$HOME/.zshrc`` via
+    # Path.home() on POSIX -- does not touch the operator's real rc file.
+    # install() runs the alias step unconditionally even under
+    # skip_global_steps=True; on a machine that has spellbook-cco on PATH
+    # the test would otherwise rewrite ~/.zshrc with aliases pointing at
+    # the pytest tmp_path. This test is the only one in tests/installer/
+    # without a sys.platform == "win32" skip; the rest of the affected
+    # tests (in test_agents_symlink.py) skip Windows entirely, so
+    # USERPROFILE isolation is unnecessary there. Today install_aliases_windows
+    # is a noop stub, but isolating USERPROFILE here keeps the test safe
+    # if/when Q-O lands a real Windows alias path.
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
     from installer.platforms.claude_code import ClaudeCodeInstaller
 
     # ``ClaudeCodeInstaller.install(skip_global_steps=True)`` calls


### PR DESCRIPTION
## What does this PR do?

Adds `monkeypatch.setenv("HOME", str(tmp_path))` to the 8 integration tests under `tests/installer/` that construct a `ClaudeCodeInstaller` against a `tmp_path`-scaffolded fake spellbook and call `installer.install()`. Without this, on a developer machine that has `spellbook-cco` on `PATH`, the alias-install step inside `install()` writes a `SPELLBOOK_ALIASES` block to the operator's real `~/.zshrc` pointing at the pytest tmpdir. pytest then deletes the tmpdir, leaving every subsequent shell with dangling `claude` / `opencode` aliases (`zsh: no such file or directory: ...`).

CI did not catch this because CI does not install `spellbook-cco` on `PATH`, so the alias step short-circuits to `skipped` and never writes the rc file.

Files touched:

- `tests/installer/test_agents_symlink.py` — 7 tests in `TestClaudeCodeInstallerWiring` (including `test_install_cleanup_preserves_other_spellbook_broken_symlinks`, the canonical reproducer).
- `tests/installer/test_l2_derivation.py` — `test_claude_code_installer_uses_derived_deny` (only other `ClaudeCodeInstaller.install()` caller under `tests/installer/` not already protected by a tripwire `pathlib:Path.home` mock).

Idiom matches the existing repo pattern (see `tests/test_spellbook_start.py:35`, `tests/test_infrastructure.py:176`).

Verification: snapshotted `~/.zshrc` size/shasum/mtime before and after running all 8 affected tests in isolation against a worktree where `spellbook-cco` is on `PATH`. Post-run state was byte-identical and no `SPELLBOOK_ALIASES` markers were present.

## Related issue

<!-- none -->

## Checklist

- [x] Tests pass locally
- [ ] Documentation updated (if applicable)
