### PR TITLE
fix(tests): make claude_code installer log drain Windows-safe

### DIFF
--- a/tests/installer/test_claude_code_wires_default_mode_and_permissions.py
+++ b/tests/installer/test_claude_code_wires_default_mode_and_permissions.py
@@ -222,9 +222,31 @@ def _drain_cco_install_exception_log() -> None:
     """Drain the optional ``logger.exception`` ERROR emitted by
     ``claude_code.py`` when ``install_spellbook_cco`` raises.
 
-    Wrapped in a helper so the optional/required(False) semantics live
-    in one place. Always called inside an enclosing
+    The ERROR log is only emitted on POSIX where ``install_spellbook_cco``
+    actually attempts a ``git clone`` of the elijahr/cco fork; on Windows
+    the function short-circuits with a shape-only noop
+    (``installer/components/spellbook_cco.py``: ``if os.name == "nt"``),
+    so no exception, no ERROR log, nothing to drain.
+
+    Wrapped in a helper so the optional drain semantics live in one
+    place. Always called inside an enclosing
     ``with tripwire.in_any_order():`` block.
+
+    The installed pytest-tripwire 0.21.0 ``LoggingPlugin.assert_log``
+    signature is ``(level, message, logger_name)`` -- no ``required=``
+    kwarg. We tolerate both shapes (kwarg-supported and not) and both
+    outcomes (log emitted on POSIX, log absent on Windows) by:
+
+    1. Trying the ``required=False`` form first (forward-compatible with
+       future tripwire builds that may add the kwarg).
+    2. Falling back to the positional form, catching the
+       ``InteractionMismatchError`` that fires when no matching ERROR
+       log is in the timeline (the Windows case).
+
+    The strict verifier still surfaces a genuine
+    ``UnassertedInteractionsError`` at teardown if an ERROR log WAS
+    emitted but not drained by this call, so swallowing the mismatch
+    here does not mask real test signal.
     """
     try:
         tripwire.log.assert_log(
@@ -233,17 +255,24 @@ def _drain_cco_install_exception_log() -> None:
             logger_name="installer.platforms.claude_code",
             required=False,
         )
+        return
     except TypeError:
-        # Some tripwire builds do not accept required=; fall back to
-        # an always-attempt-but-tolerate pattern by swallowing the
-        # mismatch error here. The strict verifier will surface a
-        # genuine UnassertedInteractionsError if the log was emitted
-        # but not drained by any other call.
+        # pytest-tripwire 0.21.0: assert_log does not accept required=.
+        # Fall through to the positional form with an explicit
+        # InteractionMismatchError catch.
+        pass
+
+    try:
         tripwire.log.assert_log(
             level="ERROR",
             message=AnyThing,
             logger_name="installer.platforms.claude_code",
         )
+    except tripwire.InteractionMismatchError:
+        # No matching ERROR log in the timeline (Windows case: cco
+        # install is a shape-only noop and never raises). The drain is
+        # genuinely optional here.
+        pass
 
 
 def _assert_install_and_uninstall_mocks(


### PR DESCRIPTION
## What does this PR do?

Fixes 5 Windows-specific test failures in
`tests/installer/test_claude_code_wires_default_mode_and_permissions.py`
by making the `_drain_cco_install_exception_log` helper tolerate the
Windows case where no `logger.exception` ERROR log is emitted (cco
install short-circuits to a shape-only noop on `os.name == "nt"`).

## Related issue

<!-- intentionally omitted -->

## Checklist

- [x] Tests pass locally (macOS): all 5 named tests pass
- [ ] Documentation updated (if applicable) — not applicable, test-only change

## Root cause

`_drain_cco_install_exception_log` optimistically called
`tripwire.log.assert_log(required=False)` and fell back to an
unconditional `assert_log(...)` when tripwire raised `TypeError`
(pytest-tripwire 0.21.0 has no `required=` kwarg). The fallback
assumed the ERROR log would always be present, which holds on POSIX
where `install_spellbook_cco` actually runs a `git clone` against the
elijahr/cco fork and `logger.exception`s on failure inside the
tripwire sandbox. On Windows the function short-circuits with a
shape-only noop (`installer/components/spellbook_cco.py`:
`if os.name == "nt"`), so no exception is raised, no ERROR log is
emitted, and the fallback `assert_log` raised
`InteractionMismatchError`. That terminated each of the 5 tests before
they reached the remaining mock assertions, which then surfaced as
`UnassertedInteractionsError` at teardown.

## Fix

Catch `tripwire.InteractionMismatchError` in the fallback path so the
drain is genuinely optional. The strict verifier still surfaces a real
`UnassertedInteractionsError` at teardown if an ERROR log was emitted
but not drained by any other call, so swallowing the mismatch here
does not mask real test signal. Helper docstring expanded to document
the Windows shape-only-noop rationale and the version-specific
`assert_log` signature constraint.

The fix is test-only; no production code is touched. The reporter's
initial hypothesis (path-separator mismatches) was incorrect — the
tripwire failure messages did not reference paths, but the API misuse
and the missing-log timeline state.
