### PR TITLE
Develop-skill token/time audit fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,8 @@ If a pre-release exists that is newer than the last actual release, ask: "There'
 
 - **AGENTS.md** (this file) is for working **on the spellbook repo itself**. Only update it when changing the development workflow for this specific project (build commands, test conventions, architecture notes). It is NOT installed anywhere.
 - **`rules/*.md`** are the **global user-facing rule modules** that the spellbook installer ships. Directory-capable platforms receive one symlink per selected module in the platform's rules directory (`~/.claude/rules/` for Claude Code); flat platforms receive a generated concatenation at their real instruction path. Each module carries YAML frontmatter (`id`, `class`, `default`, `benefit`) and holds global directives, instructions, and behavioral rules that apply to ALL projects. This is where cross-project instructions belong.
+  - **Editing an existing `rules/*.md` file takes effect immediately** on directory-capable platforms — the installed file is a symlink to the source, so no reinstall step is needed.
+  - **Adding a NEW file under `rules/`** does need a step: run `uv run install.py` to create its symlink (or regenerate the flat-platform concatenation) before the new module reaches any installed platform. `MANIFEST.md` does not track `rules/*.md` — it only registers skills, commands, and agents — so there is no manifest entry to add for a new rule module, just the install step.
 - **Skills** go in `skills/<name>/SKILL.md` with YAML frontmatter
 - **Commands** go in `commands/<name>.md` with YAML frontmatter
 - **Hooks** go in `hooks/` and must be registered in `installer/components/hooks.py`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,69 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Comment discipline in the `code-quality` rule module. Comments are sparse and
+  explain a decision. Counts, present-tense coverage claims, and history notes
+  are forbidden in comments, because the next change makes them wrong and
+  nothing catches it. The one exception is a number a mechanism reads and checks
+  at build or test time, which fails loudly when it drifts. The rule applies to
+  code we author and leaves inherited upstream comments alone.
+- Search-visibility rule in the `file-reading` rule module. A negative search
+  result is evidence only if the tool could see the file. `git grep` skips
+  untracked files, so an empty result and an unsearched file produce the same
+  output. Use `grep -r`, `rg`, or `git grep --untracked`, and name the tool
+  beside any "appears nowhere" claim.
+- Subagent Efficiency Contract in the `dispatching-parallel-agents` skill.
+  Every dispatch prompt must now include explicit tool-output-reduction and
+  call-batching instructions, because an audit of a real multi-day project
+  found raw, unsummarized tool output present in 80-90% of over 1,300 sampled
+  transcript chunks.
+- `code-review` and `advanced-code-review` skills now require delegating
+  green-mirage (test-quality) assessment to the dedicated
+  `auditing-green-mirage` skill instead of an inline/ad hoc mutation check --
+  the same audit found a case where an inline check reached the wrong
+  conclusion ("robust, not a green mirage") that a dedicated audit later
+  reversed.
+- Re-Review Protocol added to `reviewing-impl-plans`. Review rounds after the
+  first must verify only what changed since the last verified pass, and a
+  convergence check now forbids another same-style manual round if more than
+  half of a round's findings are induced by the previous round's own repairs
+  rather than newly-discovered defects.
+- "Stop Semantics in Batched Dispatches" clarification in
+  `rules/40-develop-discipline.md`. Stopping on a design defect means leaving
+  the task open, not withholding a commit -- directly motivated by a real
+  incident where an ambiguous reading of that rule let 47 of 48 files in a
+  batch land without a working implementation.
+- Explicit invariant in the `feature-implement-execute` command: a batched
+  dispatch does not exempt any of its tasks from per-task completion gates.
+- Claim-verification gate in the `handoff` command. Concrete claims in a
+  handoff (build commands, repo attributions, counts) must be verified by
+  execution or computation before the handoff is considered final, not
+  shipped from recall.
+- One-time, non-blocking suggestion in the `feature-config` command to use a
+  dedicated project directory for multi-session efforts, since project-scoped
+  tooling depends on it.
+- Clarification in `skills/develop/SKILL.md` that a response which dispatches
+  no subagent needs no Phase Declaration.
+- One additional real-world example each in `rules/45-verification.md`,
+  `rules/60-autonomy.md`, and `rules/20-orchestration.md`, illustrating their
+  existing rules (hand-counted vs. computed verification, a false constraint
+  recorded after a single failed fetch, and dispatch scope matching the size
+  of its trigger).
+
+### Fixed
+
+- `scripts/develop_gate_ledger.py` defaulted to one global ledger state file
+  shared across every project; it now defaults to a per-project path using
+  the existing project-encoding convention, so concurrent develop runs in
+  different projects no longer read or write each other's gate/phase state.
+  The `SPELLBOOK_DEV_DIR` override is unchanged.
+- Stale `workflow_state_save MCP` label in the handoff command's diagrams
+  (`docs/diagrams/commands/handoff.md`, `docs/commands/handoff.md`) that
+  didn't match the rest of the same document's terminology
+  (`persistWorkflowState`).
+
 ## [0.87.0] - 2026-08-11
 
 ### Added

--- a/commands/feature-config.md
+++ b/commands/feature-config.md
@@ -204,6 +204,10 @@ Options:
 - **Treat as ready (design doc):** Skip entire Phase 2, start at Phase 3
 - **Treat as ready (impl plan):** Skip Phases 2–3, start at Phase 4
 
+### 0.1.5 Suggest Dedicated Project Directory (multi-session efforts)
+
+<RULE>If `cwd` is a home directory or generic parent (`~`, `~/Development`, or similar non-project-specific path), and the effort looks multi-session (based on Q-flags or cost/scope assessment), suggest — once, non-blocking — starting from or creating a dedicated project directory, since session artifacts, transcripts, and project-scoped tooling all key off the project path.</RULE>
+
 ### 0.2 Clarify Motivation (WHY)
 
 <RULE>Before diving into WHAT to build, understand WHY. Motivation shapes every subsequent decision.</RULE>

--- a/commands/feature-implement-execute.md
+++ b/commands/feature-implement-execute.md
@@ -29,6 +29,7 @@ is never zero.
 2. **Delegate actual work** - Main context orchestrates; subagents write code, run tests, perform reviews
 3. **Quality gates are mandatory** - Code review, fact-checking, and green mirage audit after every task; no exceptions
 4. **Behavior preservation in refactoring** - Test verification at every transformation; no behavior changes without approval
+5. **No batch exemption** - A batched or multi-task dispatch exempts NOTHING: every task the batch covers passes gates 4.4 (Implementation Completion Verification) through 4.6.3 (Green Mirage Audit) individually before it may be marked complete. Batch size never substitutes for per-task gating.
 
 <analysis>
 Before executing Phase 4:

--- a/commands/handoff.md
+++ b/commands/handoff.md
@@ -82,6 +82,15 @@ After generating, verify:
 - Planning docs have ABSOLUTE paths?
 - Todos EXACTLY preserved (verbatim)?
 - Would I inherit this confidently with zero context?
+- **Claim verification gate (before the handoff is final):** every concrete,
+  checkable claim in the handoff — build/test command sequences, repo and
+  path attributions, counts, version numbers — must be verified by
+  execution or computation, not recall. Run each quoted command sequence
+  (or its cheapest dry-run equivalent) and compute each count. A handoff
+  that ships an untested build command has already required a correction
+  pass in practice ("Trust the corrections over the body", 2026-08-10).
+  For handoffs with many claims, dispatch one subagent invoking the
+  fact-checking skill over the claim list.
 </reflection>
 
 ---

--- a/docs/commands/handoff.md
+++ b/docs/commands/handoff.md
@@ -30,7 +30,7 @@ flowchart TD
     ConversationCtx --> MachineYAML[Section 1.20: YAML State]
 
     MachineYAML --> PersistCheck{Mode auto or checkpoint?}
-    PersistCheck -->|Yes| MCPSave[workflow_state_save MCP]
+    PersistCheck -->|Yes| MCPSave[persistWorkflowState]
     PersistCheck -->|No| SkipPersist[Skip Persistence]
 
     MCPSave --> GenSection2[Generate Section 2: Continuation]

--- a/docs/diagrams/commands/handoff.md
+++ b/docs/diagrams/commands/handoff.md
@@ -29,7 +29,7 @@ flowchart TD
     ConversationCtx --> MachineYAML[Section 1.20: YAML State]
 
     MachineYAML --> PersistCheck{Mode auto or checkpoint?}
-    PersistCheck -->|Yes| MCPSave[workflow_state_save MCP]
+    PersistCheck -->|Yes| MCPSave[persistWorkflowState]
     PersistCheck -->|No| SkipPersist[Skip Persistence]
 
     MCPSave --> GenSection2[Generate Section 2: Continuation]

--- a/docs/pending-rule-additions-2026-08-14.md
+++ b/docs/pending-rule-additions-2026-08-14.md
@@ -1,0 +1,165 @@
+# Pending spellbook rule additions — blocked by a concurrent session
+
+Written 2026-08-14. Another session holds uncommitted work in
+`/Users/eek/Development/spellbook`. These three modules were dirty at the time of
+writing, so nothing below was applied:
+
+- `rules/45-verification.md`
+- `rules/86-review-posture.md`
+- `rules/80-code-quality.md`
+
+None of the text below duplicates what that session added. Its additions were read
+first: 45 gained the measurement-conditions and stale-generated-file paragraphs, 86
+gained the "Build the failure" rule, 80 gained the `### Comments` section, 20 gained
+the carried-figure item, and 92 gained the silent-mechanism paragraph. The three
+findings below are absent from all of them.
+
+Each block must also be mirrored into `docs/rules/<same-name>.md` inside its
+```markdown fence, and needs a CHANGELOG entry. `scripts/generate_docs.py`
+regenerates the mirrors, but it rewrites every file under `docs/rules/`, so do not
+run it while another session holds uncommitted work there.
+
+---
+
+## 1. For `rules/45-verification.md`
+
+Place after the "Verify by inspecting the product" bullet list, before "When you
+cannot verify".
+
+```markdown
+**A dispatch's completion notification is not evidence that its writes have
+stopped.** A report describes a tree the reader does not control, and the report
+cannot say so. Only file modification times can. Two clauses follow:
+
+- A dispatch brief that permits writes states "do not dispatch sub-agents".
+  Nothing else bounds what a second-level dispatch may touch.
+- Before you commit after a dispatch, re-check `git status` AND the modification
+  times of the paths in scope. In the observed case the completion signal was
+  unreliable and the modification times were not.
+
+**Observed.** A sweep dispatch fanned out without being asked to. Its parent
+reported completion, and the children then wrote into the repository after a commit
+had already been made from that tree. One verification build measured a tree that
+was changing under it. The writes were comment-only and the outcome was cheap, and
+the cheapness was luck rather than containment — nothing in the arrangement bounded
+what a second-level dispatch could reach. A tree written under a measurement and a
+tree not written under one produce the same transcript.
+```
+
+Project record of the same incident: §24.6 row W3-72 in the nmg2-emulator
+implementation plan. Do not restate the incident there.
+
+---
+
+## 2. For `rules/86-review-posture.md`
+
+Add as a bullet under the "Build the failure" `<RULE>`, after the existing
+"For a claimed clean result" bullet.
+
+```markdown
+- **Perturbing an expected VALUE proves an assertion is LIVE. Only mutating the
+  PRODUCTION code proves it CATCHES the defect it exists for.** Both checks are
+  needed and neither substitutes for the other. A suite that passes the first and
+  fails the second runs, reports, and measures nothing.
+```
+
+Then append to that section's `**Observed.**` paragraph, or add a second one:
+
+```markdown
+**Observed.** One test file carried bare assertions that compiled away under
+`NDEBUG`. It printed its success line and returned 0 whatever the model did, for
+its whole life, while its own comments claimed a named refactor "would fail here".
+After conversion to a reporting check, perturbing each expected value proved every
+assertion live — necessary, and not sufficient. Only mutating the production code
+proved the assertions detect anything, and one mutation reddened a majority of the
+cases, which made the property under test positively verified rather than merely
+unrefuted. The false comment had stood beside the dead assertions the whole time.
+```
+
+Project record: §24.6 row W3-70 (struck), and §7.7 of the plan carries the rule.
+
+---
+
+## 3. For `rules/80-code-quality.md`, the `### Comments` section
+
+Add two entries to the existing `<FORBIDDEN>` list:
+
+```markdown
+- An ENUMERATION whose length is the claim. **A stale enumeration is a stale count
+  with the number spelled out.** Deleting the word "four" from "any of those four
+  values" leaves the four-item list standing, and the list then goes wrong by the
+  mechanism the word did.
+- A path that does not resolve. A comment or a document that NAMES a file, a
+  script, a test, or a type must name one that exists.
+```
+
+Then add, after the existing "One exception" paragraph:
+
+```markdown
+**The path clause is the first one a machine can decide, and it is stated
+separately for that reason.** Every other class in this section needs a reader's
+judgement. A check that every path-shaped token in a changed comment resolves is a
+regular expression and a file test. Write that check rather than trusting a sweep
+to hold.
+
+**"Delete, do not correct" has no sensible reading for a path.** A moved path has a
+correct target, so it gets one. A named script that exists nowhere has no target,
+so the sentence goes — UNLESS the sentence records a known GAP, in which case the
+gap moves to a tracked item BEFORE the comment is deleted. Deleting it turns a
+known gap into an unknown one, which is worse than the stale comment it removes.
+```
+
+And append to that section's `**Observed.**` paragraph:
+
+```markdown
+The sweep that installed this rule removed digits and the word "count" and left
+spelled-out enumerations standing in two files. Separately, a README named three
+script invocations, not one of which resolves as written, and every test path in
+that same file had moved one directory down. Each named path still read as current.
+```
+
+Project record: the two classes are new. They are absent from §24.6 row W3-76's
+three ruled classes, and row W3-77 records them.
+
+---
+
+## 4. For `rules/80-code-quality.md`, the `### Comments` section
+
+A fourth class, added after the two in block 3. Append to the same `<FORBIDDEN>`
+list:
+
+```markdown
+- A claim about the REST OF THE TREE. A comment describes the code beside it. Do
+  not write what else imports this module, what its only consumer is, which task
+  will consume it next, or what some other file does not name. The import graph
+  answers those questions and stays correct; a sentence about them is derivable,
+  goes stale the moment another task moves, and records no decision.
+```
+
+Then add, after the path-clause paragraphs from block 3:
+
+```markdown
+**A cross-reference that helps a reader NAVIGATE still stands.** "The frame layout
+is also computed in `machine.nim`" earns its place and stays, provided it asserts
+no exclusivity and no sequence. What goes is ONLY, FIRST, NEXT, and "does not
+name": those are the falsifiable forms, and that difference is the whole of the
+rule. The narrow form survives because it points somewhere; the broad form fails
+because it quantifies over a tree that keeps moving.
+```
+
+And append to that section's `**Observed.**` paragraph:
+
+```markdown
+A comment written into one test registration asserted that its own test was the
+only thing in the tree that compiled a module, that the library entry module did
+not carry it, and that a named future task would be its first consumer. The entry
+module reached the module transitively through two imports; a different task had
+already made it reachable; the named future task had not been written. The same
+file contradicted the block a few hundred lines below it. Three comment sweeps ran
+over that file and none caught the block, because each looked for counts, coverage
+claims and history narration — and a claim about the rest of the tree is none of
+those.
+```
+
+Applied the same day to the `## Comments` section of the `AGENTS.md` in mcf5307,
+gearmulator, dsp56300 and nmg2-tools, each in that document's own voice.

--- a/docs/rules/20-orchestration.md
+++ b/docs/rules/20-orchestration.md
@@ -111,6 +111,9 @@ All skills MUST adhere to these efficiency and quality standards to prevent cont
 3. **Mandatory Summarization**: Tools returning structured data (Figma, DevTools, verbose logs) MUST be wrapped in a summarization step before returning to the main orchestrator.
 4. **Subagent Strict Schema**: Dispatches via the `Task` tool MUST specify a strict JSON schema for results. Conversational subagent leak is forbidden.
 5. **Phase-Implementation Separation**: Coordination logic lives in the skill; implementation details belong in subagent prompts or phase-specific commands.
+6. **Mark Carried Figures**: A number is CARRIED if you did not measure it yourself in this session. Say so in the dispatch prompt: "This figure is carried from an earlier pass. It is not verified. Re-measure before you write it down." Never present a carried figure as a fresh measurement. The orchestrator reads reports; it does not take measurements itself. Nearly every figure it passes along is carried.
+
+   **Observed: seven cases in one session. The subagent's own measurement refuted all seven.** A lint baseline reported as "one finding" measured 156 on recheck. A count attributed to a code comment; the comment did not exist. A flag rule relayed without the `-R` prefix the original measurement required. A proposed fix whose mechanism failed in both directions once tested. The agents caught all seven mistakes, which is why none caused damage. But in a codebase where a written measurement is trusted by default, a carried figure written as if measured will not stay flagged. It gets copied into a source comment, and the next reader has no way to tell it apart from a real measurement.
 
 ### Context Minimization, Subagent Dispatch, and Compacting
 

--- a/docs/rules/45-verification.md
+++ b/docs/rules/45-verification.md
@@ -21,6 +21,11 @@ evidence that it ran. Verify the ARTIFACT it should have produced. If a rule on
 self-unblocking before declaring an environment constraint is installed, this rule
 is its mirror.
 
+Related: `92-core-philosophy.md` states the design-time version of this rule — a
+mechanism that fails silently fails exactly like a missing one. This file catches
+that failure at check time; the other file stops you from building it in the
+first place.
+
 **Trigger:** any step that writes a file, regenerates code, sends a message,
 or targets a path you did not name explicitly. Before reporting it done, ask:
 *if this had silently done nothing, what would I be looking at right now?*
@@ -53,6 +58,36 @@ false fact enters the record wearing the costume of a verified one.
 
 **When you cannot verify**, say so explicitly rather than reporting done.
 "Ran, exit 0, artifact unverified" is honest. "Done" is not.
+
+**A measurement means nothing without its conditions.** Write down what you ran
+next to the result. A rule stated more broadly than what you tested is false in a
+way the test itself will not show you. The test result is accurate; only the
+broader claim is wrong.
+
+**Observed.** Three passes each wrote a general rule about which CTest flags break
+a fixture-based guard. Each rule was true only for what its author ran. The real
+rule reverses depending on one flag: `-E` is safe only when paired with `-R` and
+`-FS`; `-FS`/`-FA` is safe only without `-R`. A fourth flag combination then broke
+even that combined rule. Each pass had tested one path through a four-variable
+space and generalized from it. **The fix: list every combination, or state exactly
+which combination you tested and claim nothing beyond it.**
+
+**A generated file is only evidence if it is newer than its source.** Reading the
+generated file is correct, but not enough on its own. Before you draw a conclusion
+from it, check its timestamp against the source, or find a marker from the current
+source inside it. A stale generated file carries the authority of the tool while
+describing a state that no longer exists. That is worse than reading the source
+directly — the source at least does not pretend to be current.
+
+**Observed, four times, three repos, two toolchains.** A compile failed, left a
+stale binary in place, and the test runner reported "100% tests passed." A
+mutation tool measured stale C code because the source-to-C step ran at configure
+time, not build time, so edits to the source were never reflected in what got
+tested. A test passed green against a binary that could no longer be rebuilt from
+current source. Two review gates read a generated manifest instead of its source —
+one of the two manifests was generated from an older version of the file the
+reviewer thought it audited, and its own line-number reference now pointed past
+the end of the current file.
 
 Related: `auditing-green-mirage` is the test-suite specialization of this
 rule (tests that pass without verifying behavior); the capability-claim

--- a/docs/rules/80-code-quality.md
+++ b/docs/rules/80-code-quality.md
@@ -3,11 +3,11 @@
 !!! info "Optional module"
     The installer offers this module pre-checked. Config key: `rules.module.code-quality`.
 
-The standing quality bar for produced code and the rule against silently skipping pre-existing issues.
+The standing quality bar for produced code, the comment discipline that keeps stale claims out of source files, and the rule against silently skipping pre-existing issues.
 
-**Why keep it:** No `any` types, no blanket try/catch, no test shortcuts, no resource leaks.
+**Why keep it:** No `any` types, no blanket try/catch, no test shortcuts, no resource leaks, and no counts or coverage claims in comments that go stale on the next change.
 
-**If you decline:** The agent applies no standing quality bar beyond the harness default and may pass over pre-existing issues without mentioning them.
+**If you decline:** The agent applies no standing quality bar beyond the harness default, may write counts and coverage claims into comments, and may pass over pre-existing issues without mentioning them.
 
 **Related artifacts:**
 
@@ -21,6 +21,24 @@ The standing quality bar for produced code and the rule against silently skippin
 <RULE>No `any` types, no blanket try-catch, no test shortcuts, no resource leaks, no non-null assertions without validation. Read existing patterns first. Production-quality or nothing.</RULE>
 
 If you encounter pre-existing issues, do NOT skip them. Ask if the user wants them fixed. Users usually say yes, so propose the fix alongside the question.
+
+### Comments
+
+<RULE>Comments are sparse. Write one only where a reader must otherwise reconstruct a DECISION. The code says what it does. The comment says why you chose it instead of the alternative.</RULE>
+
+<FORBIDDEN>
+- A count in a comment — cases, tests, scenarios, mutations, symbols, files, or lines. The next change makes the count wrong, and nothing catches it.
+- A present-tense claim about what the tests cover, or about what a wrong implementation would fail. If coverage matters, assert it in a test. A failing test is the only durable statement about coverage.
+- A note about history ("this used to...", "the previous version..."). Git holds that.
+</FORBIDDEN>
+
+**One exception, and it is the only one.** A number that a mechanism reads and checks at build time or at test time may stay. The check is then the source of truth, not the comment, and it fails loudly when the number drifts. A number that no mechanism reads is a liability.
+
+**A date does not rescue a stale claim.** Within a day of churn, a date discriminates nothing.
+
+**Applies to code you write.** In a fork or a vendored tree, leave the comments that came from upstream. Repair a comment you made wrong; do not sweep comments you did not author.
+
+**Observed.** One review-and-repair loop fired four times on a single class of defect. Each repair arrived with a new claim about the tree that outran what was measured — a suite size, a coverage assertion. Two mechanisms and one prose convention were built to stop it, and none did. Every dated claim in the affected files carried the same date, because the suite changed several times in that one day. One figure had its number re-derived and its date left alone, so it advertised a measurement older than both changes it was wrong about. The machinery built to verify these claims grew larger than the code it guards. **What did work was a registry that pins a mutation's red count and is CHECKED at test time** — it caught a test weakened from a whole-tuple comparison to a single boolean while every other gate stayed silent. That is the one exception this module allows, and it earned its place.
 
 Load `enforcing-code-quality` skill for full standards and checklist.
 ```

--- a/docs/rules/82-file-reading.md
+++ b/docs/rules/82-file-reading.md
@@ -3,11 +3,11 @@
 !!! info "Optional module"
     The installer offers this module pre-checked. Config key: `rules.module.file-reading`.
 
-Sizing a file or command output before reading it, and the ban on truncating reads.
+Sizing a file or command output before reading it, the ban on truncating reads, and why a negative search result is evidence only when its tool is named.
 
-**Why keep it:** Checks size before reading so long files are never silently truncated.
+**Why keep it:** Checks size before reading so long files are never silently truncated, and stops an unsearched file from being reported as an absence.
 
-**If you decline:** The agent may read files without sizing them first and may truncate output with `head` or `tail`.
+**If you decline:** The agent may read files without sizing them first, may truncate output with `head` or `tail`, and may write "appears nowhere" from a tool that could not see the file.
 
 **Related artifacts:**
 
@@ -19,6 +19,18 @@ Sizing a file or command output before reading it, and the ban on truncating rea
 ## File Reading
 
 <RULE>Before reading any file or command output of unknown size, check line count first (`wc -l`). Never truncate with `head`, `tail -n`, or pipes that discard data.</RULE>
+
+<RULE>A negative search result is evidence only if the tool could see the file. `git grep` skips untracked files. Use `grep -r`, `rg`, or `git grep --untracked`, and NAME the tool beside any "appears nowhere" claim.</RULE>
+
+An empty result and an unsearched file produce the same output. This is the
+silent-failure shape arriving in a search tool instead of in a check: nothing
+reports an error, and the absence looks measured.
+
+**Observed.** In one day, `git grep` produced two false "appears nowhere" findings.
+Every file of the task under review was untracked at the time, so the tool returned
+an empty result that reads exactly as an absence. One of the two claims was re-run
+with a tool that reads untracked files, and the answer moved. The claim had already
+been written down as a measurement.
 
 Load `smart-reading` skill for the full protocol.
 ```

--- a/docs/rules/86-review-posture.md
+++ b/docs/rules/86-review-posture.md
@@ -29,6 +29,15 @@ An adversarial, zero-tolerance quality-gate posture for code review.
 - A review that "found nothing" on a non-trivial diff is a **FAILED review**, not a clean one.
   Treat an empty finding list as evidence about the review, not about the code.
 
+<RULE>Build the failure. Do not just check the author's claim. Both actions cost the same dispatch. Building the failure finds more problems.</RULE>
+
+- Ask "can I make this fail?" Do not ask "does this pass?" The second question only checks the author's own transcript. The first question does not.
+- A check that has never failed is not proven. If nobody has watched a check's failure path fire, the check is a claim, not a mechanism.
+- For a claimed clean result — a mutation that should change nothing, a guard that should stay silent — prove the change reached the code under test. A no-op edit looks the same as a correct no-effect. Only the exit status cannot tell them apart.
+- Reproduce the defect before you fix it. If you never saw the gap yourself, you are guessing at the gap. A guessed fix cannot be tested.
+
+**Observed.** One guard failed four times, in four versions, each broken one level deeper than the last. Version 1 baked a path in at configure time; a reviewer defeated it by copying the tree. Version 2 replaced the real check with a flag; the reviewer deleted the check but kept the flag set. Version 3 checked a token at the end of the branch; the reviewer deleted one part of the branch and kept the token. Version 4 used per-site counters. Every version passed its own author's tests. A reviewer who rebuilt the failure — not one who reran the author's tests — broke every version. Separately, a reviewer built three silent failure modes in an isolated copy of the code. This method found a false-pass path that four earlier readings of the same file had missed.
+
 **The known cost, stated plainly:** this posture produces more findings, and some of them will
 be noise. That trade is the point of the posture, and it is why this module is opt-in rather
 than installed by default.

--- a/docs/rules/92-core-philosophy.md
+++ b/docs/rules/92-core-philosophy.md
@@ -23,4 +23,16 @@ The standing dispositions that govern how a solution is chosen: verify before tr
 **Steady correctness over speed.** Thoroughness is the default; speed is the exception that requires explicit operator instruction. When in doubt, choose the tortoise's path: slow, steady, and arrives. Where the `develop-discipline` module is installed, its thoroughness contract is the strongest specialization of this disposition.
 
 **Build the right thing, not the easy thing.** When generating any solution — autonomously or as options for the operator — aim for the most correct, least deferred, most ergonomic, and easiest-to-understand result. "Most correct" means it actually solves the real problem, not a proxy. "Least deferred" means it does not push necessary work into an unspecified later; if you must defer, the deferred work is called out explicitly (what is undone, what would pick it up), never a hand-wave. "Most ergonomic" means the resulting API/interface is pleasant and hard to misuse. "Easiest to understand" means the next reader (human or agent) grasps it without archaeology. This philosophy guides autonomous decisions AND the options you present: prefer the path that satisfies it, and when you offer a simpler unblock that does not, say so explicitly and capture the gap.
+
+**A working mechanism that fails silently fails exactly like a missing one.** When you choose a mechanism, ask what its silence means. If "working correctly" and "absent, misconfigured, or never run" produce the same visible result, you do not have a mechanism yet. Choose the uglier form if it fails loudly.
+
+Observed cases, each found by testing, not by reasoning about the code:
+
+- A fix that blinded its own check, and the blindness looked like progress.
+- A log entry that claimed more than the evidence supported — it described the state *before* the edit it was attached to. Six times in one project.
+- A check that passed for the wrong reason. One of its clauses was already guaranteed true by a neighboring clause, so it could never affect the result.
+- A name that described the wrong thing. A constant named `fetchCycles` was actually the program-counter increment. The two meanings happened to match at the one value tested, which hid the mismatch.
+- A deduplication that lowered test precision. Two separate error sites were merged into one check that could cancel itself out. The cleanup looked like a strict improvement. It was not.
+- A guard built from the same value it was supposed to check. It could never fail for an independent reason.
+- A count used where a comparison was needed. A row-count check let a duplicate row through, and the duplicate silently replaced the real row.
 ```

--- a/docs/rules/index.md
+++ b/docs/rules/index.md
@@ -24,9 +24,9 @@ you decline is never reinstalled and a module added later is offered once.
 | [Diff and Branch Semantics](55-diff-semantics.md) | mandatory | How the merge target and merge base are detected, and how the diff endpoint is chosen for the task at hand. |
 | [Autonomous Mode](60-autonomy.md) | optional (default on) | How the agent behaves when it is running without turn-by-turn confirmation. |
 | [Bash Gate Navigation](70-bash-gate.md) | mandatory | How to read a spellbook bash-gate denial, which layer produced it, and what the correct response is for each block class. |
-| [Code Quality](80-code-quality.md) | optional (default on) | The standing quality bar for produced code and the rule against silently skipping pre-existing issues. |
+| [Code Quality](80-code-quality.md) | optional (default on) | The standing quality bar for produced code, the comment discipline that keeps stale claims out of source files, and the rule against silently skipping pre-existing issues. |
 | [Testing Discipline](81-testing.md) | optional (default on) | How many test commands run at once and how test scope is matched to change scope. |
-| [File Reading](82-file-reading.md) | optional (default on) | Sizing a file or command output before reading it, and the ban on truncating reads. |
+| [File Reading](82-file-reading.md) | optional (default on) | Sizing a file or command output before reading it, the ban on truncating reads, and why a negative search result is evidence only when its tool is named. |
 | [Python Conventions](83-language-python.md) | optional (default on) | Import placement convention for Python code. |
 | [Review Method](85-review-method.md) | optional (default on) | How a code review loads the standards it will judge against, and how much of the diff it is obliged to read. |
 | [Review Posture (Zero Tolerance)](86-review-posture.md) | optional (default off) | An adversarial, zero-tolerance quality-gate posture for code review. |

--- a/rules/20-orchestration.md
+++ b/rules/20-orchestration.md
@@ -56,7 +56,7 @@ belongs in this repo. Which model a tier means is the operator's choice, recorde
 | `light` | Carrying out an already-approved plan or spec: TDD implementation against a written spec, completion/artifact verification against a checklist, precisely-specified amends, rote edits, running tests, git/PR/Jira mechanics, applying a described change | `low` |
 
 Debugging splits across tiers. Diagnosing an unknown failure is `heavy`; working through a
-TDD red-green cycle whose test and target are already specified is `light`.
+TDD red-green cycle whose test and target are already specified is `light`. Scope the dispatch to the trigger's size: a 140-line test file does not justify a build-configuration-wide toolchain investigation, and a precision lookup with a known location is a direct read, not a web-research dispatch.
 
 **The specialized agent types already declare their tier** in frontmatter (`tier: heavy`), so
 dispatching the right type gets the right tier for free:
@@ -111,6 +111,9 @@ All skills MUST adhere to these efficiency and quality standards to prevent cont
 3. **Mandatory Summarization**: Tools returning structured data (Figma, DevTools, verbose logs) MUST be wrapped in a summarization step before returning to the main orchestrator.
 4. **Subagent Strict Schema**: Dispatches via the `Task` tool MUST specify a strict JSON schema for results. Conversational subagent leak is forbidden.
 5. **Phase-Implementation Separation**: Coordination logic lives in the skill; implementation details belong in subagent prompts or phase-specific commands.
+6. **Mark Carried Figures**: A number is CARRIED if you did not measure it yourself in this session. Say so in the dispatch prompt: "This figure is carried from an earlier pass. It is not verified. Re-measure before you write it down." Never present a carried figure as a fresh measurement. The orchestrator reads reports; it does not take measurements itself. Nearly every figure it passes along is carried.
+
+   **Observed: seven cases in one session. The subagent's own measurement refuted all seven.** A lint baseline reported as "one finding" measured 156 on recheck. A count attributed to a code comment; the comment did not exist. A flag rule relayed without the `-R` prefix the original measurement required. A proposed fix whose mechanism failed in both directions once tested. The agents caught all seven mistakes, which is why none caused damage. But in a codebase where a written measurement is trusted by default, a carried figure written as if measured will not stay flagged. It gets copied into a source comment, and the next reader has no way to tell it apart from a real measurement.
 
 ### Context Minimization, Subagent Dispatch, and Compacting
 

--- a/rules/40-develop-discipline.md
+++ b/rules/40-develop-discipline.md
@@ -162,4 +162,21 @@ next phase will inherit. The motivating failure mode is documented in
 the nmg2-emulator handoff (2026-08-10): "Wave 3a done" markings made
 without §24.6 verification propagated across handoffs because no later
 step re-checked.
+
+### Stop Semantics in Batched Dispatches
+
+"A task that finds the design wrong stops and reports" is ambiguous inside
+a batched dispatch, and the ambiguity has already produced a 48-file
+low-quality landing (Wave 3a, nmg2-emulator, 2026-08). The binding
+definition:
+
+- Stopping is NOT "writing no commit." An implementer may commit partial,
+  clearly-labeled work.
+- Stopping IS "not marking the task complete." A task whose implementer
+  found a design defect stays OPEN — in the ledger and in the plan — until
+  the defect is resolved and the task re-verified.
+- A batched dispatch inherits this per task: one blocked task does not
+  block siblings, and no sibling's completion marks the blocked one.
+- The dispatch report MUST list each covered task as COMPLETE or
+  OPEN(reason). A batch report with no per-task status is invalid.
 </CRITICAL>

--- a/rules/45-verification.md
+++ b/rules/45-verification.md
@@ -21,6 +21,11 @@ evidence that it ran. Verify the ARTIFACT it should have produced. If a rule on
 self-unblocking before declaring an environment constraint is installed, this rule
 is its mirror.
 
+Related: `92-core-philosophy.md` states the design-time version of this rule — a
+mechanism that fails silently fails exactly like a missing one. This file catches
+that failure at check time; the other file stops you from building it in the
+first place.
+
 **Trigger:** any step that writes a file, regenerates code, sends a message,
 or targets a path you did not name explicitly. Before reporting it done, ask:
 *if this had silently done nothing, what would I be looking at right now?*
@@ -46,6 +51,7 @@ If the answer is "exactly what I am looking at", you have not verified it.
   caller's branch.
 - A message body containing backticks was command-substituted by the shell
   before send. The message arrived; parts of it were silently blank.
+- Four agents independently hand-counted the same consumer set and returned 0, 5, 9, and 10; the computed answer was 14. A count is an artifact: compute it (grep -c, wc -l, a script), never recall or estimate it. A verification table also claimed four repositories checked when the command covered three — the table must be generated from the command's output, not written beside it.
 
 The shape is always the same: **the operator-visible signal looks normal.**
 That is what makes it expensive — no error to notice, no retry prompt, and a
@@ -53,6 +59,36 @@ false fact enters the record wearing the costume of a verified one.
 
 **When you cannot verify**, say so explicitly rather than reporting done.
 "Ran, exit 0, artifact unverified" is honest. "Done" is not.
+
+**A measurement means nothing without its conditions.** Write down what you ran
+next to the result. A rule stated more broadly than what you tested is false in a
+way the test itself will not show you. The test result is accurate; only the
+broader claim is wrong.
+
+**Observed.** Three passes each wrote a general rule about which CTest flags break
+a fixture-based guard. Each rule was true only for what its author ran. The real
+rule reverses depending on one flag: `-E` is safe only when paired with `-R` and
+`-FS`; `-FS`/`-FA` is safe only without `-R`. A fourth flag combination then broke
+even that combined rule. Each pass had tested one path through a four-variable
+space and generalized from it. **The fix: list every combination, or state exactly
+which combination you tested and claim nothing beyond it.**
+
+**A generated file is only evidence if it is newer than its source.** Reading the
+generated file is correct, but not enough on its own. Before you draw a conclusion
+from it, check its timestamp against the source, or find a marker from the current
+source inside it. A stale generated file carries the authority of the tool while
+describing a state that no longer exists. That is worse than reading the source
+directly — the source at least does not pretend to be current.
+
+**Observed, four times, three repos, two toolchains.** A compile failed, left a
+stale binary in place, and the test runner reported "100% tests passed." A
+mutation tool measured stale C code because the source-to-C step ran at configure
+time, not build time, so edits to the source were never reflected in what got
+tested. A test passed green against a binary that could no longer be rebuilt from
+current source. Two review gates read a generated manifest instead of its source —
+one of the two manifests was generated from an older version of the file the
+reviewer thought it audited, and its own line-number reference now pointed past
+the end of the current file.
 
 Related: `auditing-green-mirage` is the test-suite specialization of this
 rule (tests that pass without verifying behavior); the capability-claim

--- a/rules/60-autonomy.md
+++ b/rules/60-autonomy.md
@@ -35,6 +35,7 @@ Common failure → try next:
 - Network timeout on `git clone` → retry once (transient) → `curl -L` tarball → `WebFetch` → package registry
 - `nimble install` from github fails → registry alias → manual clone + `--path:` → tarball
 - Permission/egress failure on one tool → try adjacent tools; `WebFetch` / `curl` / `git` may route differently
+- Required reference doc fetch fails once → retry, alternate mirror/source, different fetch tool. A manual recorded "unavailable" after ONE failed fetch was obtained on the next retry days later; the false constraint nearly shipped wrong MUL/DIV semantics.
 
 **FORBIDDEN:** writing an "environment constraints" journal/notes entry after a
 single failure, pivoting away, and never retesting. That is not autonomous — that

--- a/rules/80-code-quality.md
+++ b/rules/80-code-quality.md
@@ -4,13 +4,16 @@ name: Code Quality
 class: preference
 default: "on"
 description: >
-  The standing quality bar for produced code and the rule against silently
-  skipping pre-existing issues.
+  The standing quality bar for produced code, the comment discipline that keeps
+  stale claims out of source files, and the rule against silently skipping
+  pre-existing issues.
 benefit: >
-  No `any` types, no blanket try/catch, no test shortcuts, no resource leaks.
+  No `any` types, no blanket try/catch, no test shortcuts, no resource leaks,
+  and no counts or coverage claims in comments that go stale on the next change.
 declining_means: >
-  The agent applies no standing quality bar beyond the harness default and may
-  pass over pre-existing issues without mentioning them.
+  The agent applies no standing quality bar beyond the harness default, may
+  write counts and coverage claims into comments, and may pass over
+  pre-existing issues without mentioning them.
 related:
   - skills/enforcing-code-quality
 renamed_from: []
@@ -23,5 +26,23 @@ paths: []
 <RULE>No `any` types, no blanket try-catch, no test shortcuts, no resource leaks, no non-null assertions without validation. Read existing patterns first. Production-quality or nothing.</RULE>
 
 If you encounter pre-existing issues, do NOT skip them. Ask if the user wants them fixed. Users usually say yes, so propose the fix alongside the question.
+
+### Comments
+
+<RULE>Comments are sparse. Write one only where a reader must otherwise reconstruct a DECISION. The code says what it does. The comment says why you chose it instead of the alternative.</RULE>
+
+<FORBIDDEN>
+- A count in a comment — cases, tests, scenarios, mutations, symbols, files, or lines. The next change makes the count wrong, and nothing catches it.
+- A present-tense claim about what the tests cover, or about what a wrong implementation would fail. If coverage matters, assert it in a test. A failing test is the only durable statement about coverage.
+- A note about history ("this used to...", "the previous version..."). Git holds that.
+</FORBIDDEN>
+
+**One exception, and it is the only one.** A number that a mechanism reads and checks at build time or at test time may stay. The check is then the source of truth, not the comment, and it fails loudly when the number drifts. A number that no mechanism reads is a liability.
+
+**A date does not rescue a stale claim.** Within a day of churn, a date discriminates nothing.
+
+**Applies to code you write.** In a fork or a vendored tree, leave the comments that came from upstream. Repair a comment you made wrong; do not sweep comments you did not author.
+
+**Observed.** One review-and-repair loop fired four times on a single class of defect. Each repair arrived with a new claim about the tree that outran what was measured — a suite size, a coverage assertion. Two mechanisms and one prose convention were built to stop it, and none did. Every dated claim in the affected files carried the same date, because the suite changed several times in that one day. One figure had its number re-derived and its date left alone, so it advertised a measurement older than both changes it was wrong about. The machinery built to verify these claims grew larger than the code it guards. **What did work was a registry that pins a mutation's red count and is CHECKED at test time** — it caught a test weakened from a whole-tuple comparison to a single boolean while every other gate stayed silent. That is the one exception this module allows, and it earned its place.
 
 Load `enforcing-code-quality` skill for full standards and checklist.

--- a/rules/82-file-reading.md
+++ b/rules/82-file-reading.md
@@ -4,12 +4,15 @@ name: File Reading
 class: preference
 default: "on"
 description: >
-  Sizing a file or command output before reading it, and the ban on truncating reads.
+  Sizing a file or command output before reading it, the ban on truncating reads,
+  and why a negative search result is evidence only when its tool is named.
 benefit: >
-  Checks size before reading so long files are never silently truncated.
+  Checks size before reading so long files are never silently truncated, and stops
+  an unsearched file from being reported as an absence.
 declining_means: >
-  The agent may read files without sizing them first and may truncate output with
-  `head` or `tail`.
+  The agent may read files without sizing them first, may truncate output with
+  `head` or `tail`, and may write "appears nowhere" from a tool that could not see
+  the file.
 related:
   - skills/smart-reading
 renamed_from: []
@@ -20,5 +23,17 @@ paths: []
 ## File Reading
 
 <RULE>Before reading any file or command output of unknown size, check line count first (`wc -l`). Never truncate with `head`, `tail -n`, or pipes that discard data.</RULE>
+
+<RULE>A negative search result is evidence only if the tool could see the file. `git grep` skips untracked files. Use `grep -r`, `rg`, or `git grep --untracked`, and NAME the tool beside any "appears nowhere" claim.</RULE>
+
+An empty result and an unsearched file produce the same output. This is the
+silent-failure shape arriving in a search tool instead of in a check: nothing
+reports an error, and the absence looks measured.
+
+**Observed.** In one day, `git grep` produced two false "appears nowhere" findings.
+Every file of the task under review was untracked at the time, so the tool returned
+an empty result that reads exactly as an absence. One of the two claims was re-run
+with a tool that reads untracked files, and the answer moved. The claim had already
+been written down as a measurement.
 
 Load `smart-reading` skill for the full protocol.

--- a/rules/86-review-posture.md
+++ b/rules/86-review-posture.md
@@ -30,6 +30,15 @@ paths: []
 - A review that "found nothing" on a non-trivial diff is a **FAILED review**, not a clean one.
   Treat an empty finding list as evidence about the review, not about the code.
 
+<RULE>Build the failure. Do not just check the author's claim. Both actions cost the same dispatch. Building the failure finds more problems.</RULE>
+
+- Ask "can I make this fail?" Do not ask "does this pass?" The second question only checks the author's own transcript. The first question does not.
+- A check that has never failed is not proven. If nobody has watched a check's failure path fire, the check is a claim, not a mechanism.
+- For a claimed clean result — a mutation that should change nothing, a guard that should stay silent — prove the change reached the code under test. A no-op edit looks the same as a correct no-effect. Only the exit status cannot tell them apart.
+- Reproduce the defect before you fix it. If you never saw the gap yourself, you are guessing at the gap. A guessed fix cannot be tested.
+
+**Observed.** One guard failed four times, in four versions, each broken one level deeper than the last. Version 1 baked a path in at configure time; a reviewer defeated it by copying the tree. Version 2 replaced the real check with a flag; the reviewer deleted the check but kept the flag set. Version 3 checked a token at the end of the branch; the reviewer deleted one part of the branch and kept the token. Version 4 used per-site counters. Every version passed its own author's tests. A reviewer who rebuilt the failure — not one who reran the author's tests — broke every version. Separately, a reviewer built three silent failure modes in an isolated copy of the code. This method found a false-pass path that four earlier readings of the same file had missed.
+
 **The known cost, stated plainly:** this posture produces more findings, and some of them will
 be noise. That trade is the point of the posture, and it is why this module is opt-in rather
 than installed by default.

--- a/rules/92-core-philosophy.md
+++ b/rules/92-core-philosophy.md
@@ -23,3 +23,15 @@ paths: []
 **Steady correctness over speed.** Thoroughness is the default; speed is the exception that requires explicit operator instruction. When in doubt, choose the tortoise's path: slow, steady, and arrives. Where the `develop-discipline` module is installed, its thoroughness contract is the strongest specialization of this disposition.
 
 **Build the right thing, not the easy thing.** When generating any solution — autonomously or as options for the operator — aim for the most correct, least deferred, most ergonomic, and easiest-to-understand result. "Most correct" means it actually solves the real problem, not a proxy. "Least deferred" means it does not push necessary work into an unspecified later; if you must defer, the deferred work is called out explicitly (what is undone, what would pick it up), never a hand-wave. "Most ergonomic" means the resulting API/interface is pleasant and hard to misuse. "Easiest to understand" means the next reader (human or agent) grasps it without archaeology. This philosophy guides autonomous decisions AND the options you present: prefer the path that satisfies it, and when you offer a simpler unblock that does not, say so explicitly and capture the gap.
+
+**A working mechanism that fails silently fails exactly like a missing one.** When you choose a mechanism, ask what its silence means. If "working correctly" and "absent, misconfigured, or never run" produce the same visible result, you do not have a mechanism yet. Choose the uglier form if it fails loudly.
+
+Observed cases, each found by testing, not by reasoning about the code:
+
+- A fix that blinded its own check, and the blindness looked like progress.
+- A log entry that claimed more than the evidence supported — it described the state *before* the edit it was attached to. Six times in one project.
+- A check that passed for the wrong reason. One of its clauses was already guaranteed true by a neighboring clause, so it could never affect the result.
+- A name that described the wrong thing. A constant named `fetchCycles` was actually the program-counter increment. The two meanings happened to match at the one value tested, which hid the mismatch.
+- A deduplication that lowered test precision. Two separate error sites were merged into one check that could cancel itself out. The cleanup looked like a strict improvement. It was not.
+- A guard built from the same value it was supposed to check. It could never fail for an independent reason.
+- A count used where a comparison was needed. A row-count check let a duplicate row through, and the duplicate silently replaced the real row.

--- a/rules/93-communication.md
+++ b/rules/93-communication.md
@@ -20,6 +20,14 @@ paths: []
 
 <RULE>Use AskUserQuestion tool for any question requiring more than yes/no. Include suggested answers. If you are unsure whether to continue, that uncertainty is itself a question — resolve it with AskUserQuestion carrying a SPECIFIC question and concrete options. Never resolve it by ending the turn and waiting. This applies to binary questions too: "should I do X or pause?" goes through the tool, not through prose. Prose questions go unseen.</RULE>
 
+<RULE>When AskUserQuestion options carry a real trade-off — architecture, scope, effort, risk, timeline — label each option with what it optimizes for. Use a short tag: "most correct", "fastest", "least scope", "lowest cost", or similar. Skip this for trivial picks with no trade-off, like a filename or a wording style.
+
+Pick the recommended option in this order:
+1. If the user stated a priority for this specific question (for example: "give me the fastest option", "I want the MVP"), recommend the option that matches it.
+2. Otherwise, recommend the option that is most correct, least deferred, and most consistent with the rest of the implementation. Mark it "(Recommended)" as the tool requires.
+
+Every option keeps its trade-off label, including options that are not recommended, so the user can see what they give up by picking a different one.</RULE>
+
 - Be direct and professional in documentation, README, and comments
 - Make every word count
 - No chummy or silly tone

--- a/scripts/develop_gate_ledger.py
+++ b/scripts/develop_gate_ledger.py
@@ -9,9 +9,15 @@ the Python reference implementation for reading and writing that shape
 to a persistent state file.
 
 State file location: ``$SPELLBOOK_DEV_DIR/develop_gate_ledger.json``,
-defaulting to ``~/.local/spellbook/develop_gate_ledger.json``. The file
-is JSON for human inspectability -- a developer or subagent can read it
-directly without the Python module.
+defaulting to a PER-PROJECT file under
+``~/.local/spellbook/develop_gate_ledger-<project-encoded>.json``, where
+``<project-encoded>`` is the current working directory's repo root
+encoded per the project-encoded convention (leading ``/`` stripped,
+``/`` replaced with ``-``; see ``spellbook.core.path_utils.encode_cwd``).
+This keeps two different projects -- or two concurrent sessions in
+different projects -- from reading and writing the same ledger file.
+The file is JSON for human inspectability -- a developer or subagent
+can read it directly without the Python module.
 
 ## Merge semantics (per the develop skill)
 
@@ -69,10 +75,11 @@ from collections.abc import Iterable, Mapping
 from pathlib import Path
 from typing import Any
 
+from spellbook.core.path_utils import encode_cwd
+
 logger = logging.getLogger(__name__)
 
 DEFAULT_STATE_DIR = Path.home() / ".local" / "spellbook"
-DEFAULT_LEDGER_PATH = DEFAULT_STATE_DIR / "develop_gate_ledger.json"
 
 # Fields the ledger may contain, per skills/develop/SKILL.md
 # "Ledger shape (develop_gate_ledger, design §5.3)" section.
@@ -88,12 +95,29 @@ CEREMONY_FIELDS = (
 )
 
 
+def default_ledger_path() -> Path:
+    """Compute the per-project default ledger path for the current cwd.
+
+    One ledger file per project (see module docstring "State file
+    location"): two different projects, or two concurrent sessions in
+    different projects, must not read/write the same ledger file.
+    """
+    encoded = encode_cwd(os.getcwd())
+    return DEFAULT_STATE_DIR / f"develop_gate_ledger-{encoded}.json"
+
+
 def ledger_path() -> Path:
-    """Resolve the ledger path, honoring ``$SPELLBOOK_DEV_DIR`` if set."""
+    """Resolve the ledger path, honoring ``$SPELLBOOK_DEV_DIR`` if set.
+
+    ``$SPELLBOOK_DEV_DIR`` (when set) still names an exact directory
+    holding a single ``develop_gate_ledger.json``, unchanged from before.
+    Only the fallback default changes: it is now per-project rather than
+    one fixed global path.
+    """
     override = os.environ.get("SPELLBOOK_DEV_DIR")
     if override:
         return Path(override) / "develop_gate_ledger.json"
-    return DEFAULT_LEDGER_PATH
+    return default_ledger_path()
 
 
 def _ensure_parent(path: Path) -> None:
@@ -405,7 +429,8 @@ def build_parser() -> argparse.ArgumentParser:
         help=(
             "Override the ledger file path. Default: "
             "$SPELLBOOK_DEV_DIR/develop_gate_ledger.json, "
-            "falling back to ~/.local/spellbook/develop_gate_ledger.json"
+            "falling back to a per-project file under "
+            "~/.local/spellbook/develop_gate_ledger-<project-encoded>.json"
         ),
     )
 

--- a/skills/advanced-code-review/SKILL.md
+++ b/skills/advanced-code-review/SKILL.md
@@ -223,6 +223,8 @@ Multi-pass analysis: Security, Correctness, Quality, and Polish passes.
 
 **Self-Check:** Coverage reconciled N-of-N at hunk level with gaps disclosed, all passes complete, declined items respected, required fields present including `rule`.
 
+Findings about test adequacy are PLAUSIBLE at best until auditing-green-mirage has run on the test in question; Phase 4 must not promote such a finding to verified without it.
+
 ---
 
 ## Phase 4: Verification
@@ -315,6 +317,11 @@ exist. If a future edit removes a consumer, remove the row.
 - Proceed past failed self-check
 - **Read local files to verify or refute PR findings when local HEAD ≠ PR HEAD SHA** — this is the most dangerous error in PR reviews; it produces confidently wrong REFUTED verdicts on real bugs
 - **Declare a finding REFUTED based on local file content during a PR review** without first confirming SHA match via `git rev-parse HEAD`
+- Assess whether a test is a green mirage with an inline/ad hoc mutation
+  table. Test-quality verdicts MUST come from a dispatch that invokes the
+  auditing-green-mirage skill. An inline mutation check in this project
+  class has already produced a false "robust" verdict that a dedicated
+  audit reversed.
 </FORBIDDEN>
 
 ---

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -161,6 +161,8 @@ When reviewing AI-generated code, these checks are elevated to HIGH severity. LL
 
 Output: Executive Summary, findings by category (same severity thresholds as Self Mode), Risk Assessment (LOW/MEDIUM/HIGH/CRITICAL)
 
+**Test-quality scope:** if the audit scope includes judging whether tests would catch regressions, dispatch a subagent invoking auditing-green-mirage for those tests; do not run mutation reasoning inline.
+
 ---
 
 <FORBIDDEN>
@@ -173,6 +175,11 @@ Output: Executive Summary, findings by category (same severity thresholds as Sel
 - Hardcode a base ref or a default-branch name instead of shelling out to `branch-context.sh`
 - Report findings without stating the base used and how it was resolved
 - Use "branch diff" without saying which endpoint (committed-only vs. working tree)
+- Assess whether a test is a green mirage with an inline/ad hoc mutation
+  table. Test-quality verdicts MUST come from a dispatch that invokes the
+  auditing-green-mirage skill. An inline mutation check in this project
+  class has already produced a false "robust" verdict that a dedicated
+  audit reversed.
 </FORBIDDEN>
 
 ## Self-Check

--- a/skills/develop/SKILL.md
+++ b/skills/develop/SKILL.md
@@ -462,6 +462,10 @@ sufficient referent on its own — the operative set is the one recorded in
 3. **The reverse move does not exist.** Nothing ever moves from `selected` to
    `declined`. `selected` and `core` shrink only by completion, never by decision.
 
+The Phase Declaration is required per Task() dispatch. A response that dispatches
+nothing — a status answer, a question to the operator — requires no declaration
+and no artifact write.
+
 If the ledger has no `ceremony` block (a pre-existing or externally-resumed
 session), treat the ceremony as `default_full`: every flag-derived gate is
 selected and nothing is declined. Absence is never read as permission to skip.

--- a/skills/dispatching-parallel-agents/SKILL.md
+++ b/skills/dispatching-parallel-agents/SKILL.md
@@ -493,6 +493,8 @@ REVIEW MODE INSTRUCTIONS:
 - Using `isolation: "worktree"` for tasks that depend on prior uncommitted work (isolated worktrees branch from current HEAD, missing uncommitted changes)
 - Dispatching subagents without specifying which branch to base worktrees on
 - Dispatching open-ended analytical prompts to Explore subagents without a scope isolation preamble (agent will latch onto session metadata instead of performing the task)
+- Dispatching without the Subagent Efficiency Contract block in the prompt
+- Carrying raw tool output >2,000 chars forward instead of a reduction
 </FORBIDDEN>
 
 ---
@@ -598,6 +600,31 @@ will reject any result that does not contain a "Launching skill:" line.
 )
 ```
 
+### Subagent Efficiency Contract (include in EVERY dispatch prompt)
+
+Append this block verbatim to every subagent prompt:
+
+```
+TOOL OUTPUT DISCIPLINE:
+- After any tool call whose output exceeds ~2,000 characters, immediately
+  reduce it to the facts the task needs before your next step. Do not carry
+  raw logs, full file dumps, or listings forward turn over turn.
+- Build/test/lint output: reduce to pass/fail counts plus the names and
+  messages of failures. Never re-paste a passing log.
+- Never load base64 or image data into context unless the task is to
+  analyze that exact image.
+
+CALL BATCHING:
+- Read a file ONCE, in full (or one bounded range), not in repeated
+  offset windows.
+- Combine related searches into one grep with alternation
+  (grep -E 'a|b|c'), not one call per identifier.
+- Treat configure/build/test as ONE step with one summarized result
+  unless a gate requires them separated.
+- Report repetitive results (e.g., mutation variants M1..M23) as one
+  table in one message, not one message each.
+```
+
 **Agent Type Selection:**
 | Parent Agent | Subagent Type | Notes |
 |--------------|---------------|-------|
@@ -620,6 +647,8 @@ The Skill tool is included for most subagent types but not all. Verify before di
 | `statusline-setup` | no | Restricted to Read, Edit |
 
 Dispatching a skill-using prompt to an agent type without the Skill tool is a contract bug. The dispatch will produce no "Launching skill:" line and the orchestrator must reject the result.
+
+Every dispatch pays a fixed skill-catalog injection cost (~30K characters) regardless of whether the subagent uses any skill. When several small sequential tasks would each need a dispatch, prefer one subagent with the combined sequential scope — provided the tasks are not separate rows of a develop dispatch table (that combination is forbidden by 40-develop-discipline).
 
 **Lazy-injection caveat:** The skills catalog system-reminder is injected into a subagent's context AFTER its first tool call, not at session start. A subagent that introspects its tools or system reminders before acting may falsely conclude that no skills are available. The dispatch template's "First, invoke the [SKILL-NAME] skill" instruction forces the first tool call to BE the skill invocation, sidestepping this footgun. Do not weaken that instruction.
 

--- a/skills/reviewing-impl-plans/SKILL.md
+++ b/skills/reviewing-impl-plans/SKILL.md
@@ -161,6 +161,26 @@ Verifies definition of done per work item, risk assessment per phase, QA checkpo
 
 **Gate:** Proceed only when completeness audit is done and all escalation claims are cataloged.
 
+## Re-Review Protocol (round 2 and later)
+
+When this skill runs on a plan it has reviewed before:
+
+1. **Delta-only verification.** Re-verify ONLY claims, citations, and
+   sections changed since the last verified pass. Record the prior pass's
+   verified set and diff against it. A full-corpus re-verification is
+   permitted only on the first pass, or when the prior pass's record is
+   lost. Re-verifying an unchanged, previously-verified citation is
+   duplicated work, not added rigor.
+2. **Convergence check.** Before scheduling round N+1, classify round N's
+   Critical findings: NEW (pre-existing defect newly found) vs INDUCED
+   (introduced by round N-1's own repairs). If more than half are INDUCED,
+   another same-style round is FORBIDDEN. Switch method: build or extend a
+   mechanical check (a planlint rule, a compile check, a symbol-table
+   diff) for the oscillating defect class, run it, and only then resume
+   prose review for what the check cannot cover.
+3. Record in the report: `Round N: X new / Y induced. Convergence:
+   CONVERGING | OSCILLATING (mechanized: <check name>)`.
+
 ## Report Assembly
 
 Assemble the final report from subagent outputs:
@@ -273,6 +293,7 @@ Before completing review:
 [ ] Did I separate Critical/Important/Minor findings?
 [ ] Did I provide prioritized remediation plan?
 [ ] Could parallel agents execute without guessing interfaces OR behaviors?
+[ ] If round 2+: did I verify only the delta, and run the convergence check?
 
 If NO to ANY item, go back and complete it.
 </reflection>


### PR DESCRIPTION
## What does this PR do?

Applies fixes from a token/time-usage audit of the develop skill run against a real multi-day project (Nord Modular G2 emulator, mcf5307): subagent tool-output and call-batching discipline, green-mirage delegation in code review instead of inline mutation checks, a delta-only re-review protocol with a convergence check in `reviewing-impl-plans`, explicit batched-dispatch stop semantics in `40-develop-discipline.md`, a claim-verification gate in the handoff command, a fix for `develop_gate_ledger.py` defaulting to one global state file shared across all projects (now per-project), and several new illustrative examples in existing rule modules. Full audit report: `docs/Users-eek-Development-spellbook/audits/develop-skill-token-time-audit-mcf5307-2026-08-16.md`.

This commit also includes a separate, unrelated set of rule additions (comment discipline in `code-quality`, search-visibility in `file-reading`) from a different concurrent session that were already staged uncommitted in the working tree at commit time. They're unrelated to the audit above but are included here at the operator's explicit request rather than left blocking further work.

## Related issue

None.

## Checklist

- [ ] Tests pass locally
- [ ] Documentation updated (if applicable)
