### PR TITLE
Share corpus tree memberships; close a docs/rules rot hole

### DIFF
--- a/extensions/prime-agent/README.md
+++ b/extensions/prime-agent/README.md
@@ -97,7 +97,7 @@ with it on the next install.
 
 ## Testing
 
-`tests/installer/test_prime_agent_rules_install.py` covers the installer
+`tests/integration/test_prime_agent_rules_install.py` covers the installer
 side: selection honored, symlinks created, deselection removes stale
 symlinks, extension file present, idempotent reinstall.
 

--- a/scripts/check-readme-completeness.py
+++ b/scripts/check-readme-completeness.py
@@ -15,7 +15,10 @@ Validates:
    mechanism that reads these three.
 5. The reverse direction: every README table entry, every README
    link-reference definition, every mkdocs.yml nav entry, and every page
-   under docs/{skills,commands,agents}/ resolves to a real source file.
+   under each generated docs/ subtree resolves to a real source file. The
+   README-facing parts follow README_ARTIFACT_KINDS; the orphan-page sweep
+   reads docs/ rather than README, so it follows DOCUMENTED_TREES and
+   covers docs/rules/ as well.
 
 Checks 1-4 are one-directional -- they assert that every real item is
 documented, never that every documented item is real. That asymmetry let
@@ -31,6 +34,7 @@ import re
 import sys
 from pathlib import Path
 
+from corpus_trees import DOCUMENTED_TREES, README_ARTIFACT_KINDS
 from docs_config import (
     EXCLUDED_SKILLS,
     EXCLUDED_COMMANDS,
@@ -43,8 +47,14 @@ DOCS_BASE_URL = "https://axiomantic.github.io/spellbook/latest/"
 
 # A link-reference definition may legitimately point at hand-authored docs
 # (guides, reference pages) rather than at a generated artifact page. Only
-# these three prefixes name an artifact whose source this script can resolve.
-ARTIFACT_PREFIXES = ("skills", "commands", "agents")
+# these three prefixes name an artifact with a README table and link
+# definitions; `rules` is absent because README has no Rules section.
+ARTIFACT_PREFIXES = README_ARTIFACT_KINDS
+
+# The orphan sweep reads docs/, not README, so the README-table exclusion of
+# `rules` never applied to it. Every tree that generates pages can orphan
+# them, so the sweep follows what is GENERATED, not what README tabulates.
+ORPHAN_SWEEP_TREES = DOCUMENTED_TREES
 
 LINK_DEF_RE = re.compile(r"^\[([^\]^]+)\]:[ \t]*(\S+)[ \t]*$", re.M)
 NAV_ENTRY_RE = re.compile(r"\b(skills|commands|agents)/([A-Za-z0-9._-]+)\.md\b")
@@ -80,7 +90,16 @@ def real_sources(repo_root):
             for f in (repo_root / "agents").glob("*.md")
             if not f.name.startswith("_") and "crystallized2" not in f.name
         }
-    return {"skills": skills, "commands": commands, "agents": agents}
+    # Rules have no README table, but they DO generate docs/rules/ pages, so
+    # the orphan sweep needs a real-source set to check those pages against.
+    rules = set()
+    if (repo_root / "rules").exists():
+        rules = {
+            f.stem
+            for f in (repo_root / "rules").glob("*.md")
+            if not f.name.startswith("_")
+        }
+    return {"skills": skills, "commands": commands, "agents": agents, "rules": rules}
 
 
 def section(readme_content, label):
@@ -160,7 +179,7 @@ def check_reverse(repo_root, readme_content, mkdocs_content, issues):
             )
 
     # Generated documentation pages.
-    for kind in ARTIFACT_PREFIXES:
+    for kind in ORPHAN_SWEEP_TREES:
         docs_subdir = repo_root / "docs" / kind
         if not docs_subdir.exists():
             continue

--- a/scripts/check-readme-completeness.py
+++ b/scripts/check-readme-completeness.py
@@ -16,9 +16,9 @@ Validates:
 5. The reverse direction: every README table entry, every README
    link-reference definition, every mkdocs.yml nav entry, and every page
    under each generated docs/ subtree resolves to a real source file. The
-   README-facing parts follow README_ARTIFACT_KINDS; the orphan-page sweep
-   reads docs/ rather than README, so it follows DOCUMENTED_TREES and
-   covers docs/rules/ as well.
+   README-facing parts follow README_ARTIFACT_KINDS; the nav checks and the
+   orphan-page sweep read mkdocs.yml and docs/ rather than README, so they
+   follow DOCUMENTED_TREES and cover rules as well.
 
 Checks 1-4 are one-directional -- they assert that every real item is
 documented, never that every documented item is real. That asymmetry let
@@ -56,8 +56,16 @@ ARTIFACT_PREFIXES = README_ARTIFACT_KINDS
 # them, so the sweep follows what is GENERATED, not what README tabulates.
 ORPHAN_SWEEP_TREES = DOCUMENTED_TREES
 
+# The nav publishes every generated tree, rules included, so both nav
+# directions follow DOCUMENTED_TREES rather than README_ARTIFACT_KINDS. The
+# alternation is BUILT from that tuple: a literal re-spelling of the same
+# names is the drift this module exists to prevent.
+NAV_TREES = DOCUMENTED_TREES
+
 LINK_DEF_RE = re.compile(r"^\[([^\]^]+)\]:[ \t]*(\S+)[ \t]*$", re.M)
-NAV_ENTRY_RE = re.compile(r"\b(skills|commands|agents)/([A-Za-z0-9._-]+)\.md\b")
+NAV_ENTRY_RE = re.compile(
+    rf"\b({'|'.join(re.escape(t) for t in NAV_TREES)})/([A-Za-z0-9._-]+)\.md\b"
+)
 
 
 def real_sources(repo_root):
@@ -286,6 +294,13 @@ def main():
     for agent in agents:
         if f"agents/{agent}.md" not in mkdocs_content:
             issues.append(f"mkdocs.yml nav missing: agents/{agent}.md")
+
+    # Rules have no README table, so they are absent from the checks above --
+    # but generate_docs.py publishes docs/rules/ and mkdocs.yml navigates it,
+    # so the nav direction applies to them exactly like the other trees.
+    for rule in sorted(real_sources(repo_root)["rules"]):
+        if f"rules/{rule}.md" not in mkdocs_content:
+            issues.append(f"mkdocs.yml nav missing: rules/{rule}.md")
 
     # Check the "(N total)" counts in README section headings and TOC anchors.
     for label, items in (("Skills", skills), ("Commands", commands), ("Agents", agents)):

--- a/scripts/check_reference_resolution.py
+++ b/scripts/check_reference_resolution.py
@@ -96,16 +96,26 @@ from typing import Callable, Iterator
 
 import yaml
 
+from corpus_trees import DOCUMENTED_TREES
+
 # ---------------------------------------------------------------------------
 # Shared configuration
 # ---------------------------------------------------------------------------
 
 # Prose sources. AGENTS.md is a file; the rest are directories scanned for *.md.
-PROSE_DIRS = ("skills", "commands", "agents", "rules")
+PROSE_DIRS = DOCUMENTED_TREES
 PROSE_FILES = ("AGENTS.md",)
+
+# Derived, never duplicated: this string is printed beside a reference count,
+# so a hardcoded copy states what was checked and can be wrong about it. That
+# was OBSERVED -- the four-tree label printed unchanged beside a nine-tree scan.
+PROSE_SOURCE_LABEL = ", ".join([f"{d}/" for d in PROSE_DIRS] + list(PROSE_FILES))
 
 # A prose path reference is checked only when its first segment names one of
 # these. See blind spot 1 and 2 in the module docstring for why `docs` is absent.
+# Deliberately NOT corpus_trees: this is a path-prefix vocabulary for reference
+# TARGETS, a different axis from the prose SOURCES scanned above, so it also
+# admits installer/, tests/, spellbook/, and .github/.
 ANCHOR_DIRS = frozenset(
     {
         ".github",
@@ -688,7 +698,7 @@ def build_rows(repo_root: Path) -> tuple[Row, ...]:
         ),
         Row(
             name="prose-paths",
-            source="skills/, commands/, agents/, rules/, AGENTS.md",
+            source=PROSE_SOURCE_LABEL,
             extract=extract_prose_paths,
             resolve=resolve_prose_path,
             what="repository file or directory",
@@ -696,7 +706,7 @@ def build_rows(repo_root: Path) -> tuple[Row, ...]:
         ),
         Row(
             name="prose-modules",
-            source="skills/, commands/, agents/, rules/, AGENTS.md",
+            source=PROSE_SOURCE_LABEL,
             extract=extract_prose_modules,
             resolve=resolve_prose_module,
             what="importable module or attribute",
@@ -704,7 +714,7 @@ def build_rows(repo_root: Path) -> tuple[Row, ...]:
         ),
         Row(
             name="prose-skills",
-            source="skills/, commands/, agents/, rules/, AGENTS.md",
+            source=PROSE_SOURCE_LABEL,
             extract=extract_prose_skills,
             resolve=resolve_skill,
             what="skill directory",
@@ -712,7 +722,7 @@ def build_rows(repo_root: Path) -> tuple[Row, ...]:
         ),
         Row(
             name="prose-commands",
-            source="skills/, commands/, agents/, rules/, AGENTS.md",
+            source=PROSE_SOURCE_LABEL,
             extract=extract_prose_commands,
             resolve=resolve_slash_name,
             what="command or skill",

--- a/scripts/check_self_manufactured_evidence.py
+++ b/scripts/check_self_manufactured_evidence.py
@@ -75,9 +75,25 @@ import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 
-CORPUS_DIRS = ("skills", "rules", "commands", "agents", "patterns", "profiles", "extensions")
+from corpus_trees import ENUMERABLE_TREES
+
+# The vocabulary that MARKS a Python file as corpus-facing. Naming one of
+# these is evidence about a file's subject, not a directory this script
+# walks; the scan roots are named explicitly in discover_script_checks.
+CORPUS_DIRS = ENUMERABLE_TREES
 _CORPUS_ALT = "|".join(CORPUS_DIRS)
-CORPUS_RE = re.compile(rf"""["']({_CORPUS_ALT})["']|/({_CORPUS_ALT})/""")
+# Importing a membership from corpus_trees names those trees just as much as
+# spelling them out, and this detection is textual. Without these symbols the
+# shared module would be a blind-spot generator: every checker that adopted it
+# would silently drop out of this inventory while still enumerating the tree.
+CORPUS_MEMBERSHIP_NAMES = frozenset(
+    {"DOCUMENTED_TREES", "ENUMERABLE_TREES", "README_ARTIFACT_KINDS"}
+)
+_CORPUS_SYMBOLS = ("corpus_trees", *sorted(CORPUS_MEMBERSHIP_NAMES))
+_SYMBOL_ALT = "|".join(_CORPUS_SYMBOLS)
+CORPUS_RE = re.compile(
+    rf"""["']({_CORPUS_ALT})["']|/({_CORPUS_ALT})/|\b({_SYMBOL_ALT})\b"""
+)
 CHECKER_RE = re.compile(
     r"^def (main|check_|find_|validate_|build_|scan_|collect_|run_)", re.MULTILINE
 )
@@ -210,7 +226,14 @@ class Tainter:
         return "neutral"
 
     def is_corpus(self, node: ast.AST) -> bool:
-        if self._names(node) & self.sets.corpus:
+        names = self._names(node)
+        if names & self.sets.corpus:
+            return True
+        # A membership imported from corpus_trees IS a list of corpus dirs;
+        # the constants simply live in another module. Without this, adopting
+        # the shared module would launder a corpus enumeration into an
+        # unrecognised one and drop the check out of the inventory.
+        if names & CORPUS_MEMBERSHIP_NAMES:
             return True
         return any(
             isinstance(n, ast.Constant) and isinstance(n.value, str) and n.value in CORPUS_DIRS
@@ -472,6 +495,7 @@ class Finding:
 def discover_script_checks(root: Path) -> dict[str, Path]:
     """Return {module_stem: path} for every corpus checker under scripts/hooks."""
     found: dict[str, Path] = {}
+    # Where CHECKERS live, not corpus trees -- deliberately not corpus_trees.
     for d in ("scripts", "hooks"):
         for p in sorted((root / d).glob("*.py")):
             src = p.read_text(encoding="utf-8", errors="replace")

--- a/scripts/corpus_trees.py
+++ b/scripts/corpus_trees.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Shared corpus-tree memberships for the repository's checkers and tests.
+
+Scripts under ``scripts/`` and tests under ``tests/`` import from here so that
+a tree added to the repository is added to each membership deliberately,
+rather than being missed in one hardcoded tuple out of several.
+
+These sets are DELIBERATELY unequal. The inequality is the content: each name
+answers a different question, and collapsing them onto one another would
+silently change what a checker scans or reports. A consumer imports the set
+whose REASON matches its own, never the set that happens to have the right
+members today.
+"""
+
+DOCUMENTED_TREES = ("skills", "commands", "agents", "rules")
+"""Trees whose sources generate a page under ``docs/`` and an mkdocs nav entry.
+
+Membership reason: ``generate_docs.py`` mirrors each of these into
+``docs/<tree>/``. A tree belongs here when its sources are published, so
+prose scanned for references and docs pages swept for orphans both follow
+this set.
+"""
+
+ENUMERABLE_TREES = DOCUMENTED_TREES + ("patterns", "profiles", "extensions")
+"""Trees that constitute the repository corpus a checker might enumerate.
+
+Membership reason: these are the trees holding authored corpus content, as
+opposed to code (``scripts``, ``hooks``, ``installer``), tests, or generated
+output (``docs``). This is a DETECTION VOCABULARY -- naming a member is what
+marks a file as corpus-facing. It is not a list of scan roots, and a consumer
+that walks directories wants its own explicit roots instead.
+
+``patterns``, ``profiles``, and ``extensions`` extend ``DOCUMENTED_TREES``
+because they are corpus content that ships without a generated docs page.
+"""
+
+README_ARTIFACT_KINDS = ("skills", "commands", "agents")
+"""Artifact kinds that have a README table and README link-reference entries.
+
+Membership reason: README.md has a section and a ``(N total)`` table for each
+of these. ``rules`` is ABSENT because README has no Rules section -- there is
+no table to check a rule against, so a README-table check over ``rules``
+would have nothing to read. Reverse checks that read ``docs/`` rather than
+README are not bounded by this set; they follow ``DOCUMENTED_TREES``.
+"""

--- a/scripts/generate_docs.py
+++ b/scripts/generate_docs.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 import yaml
 
+from corpus_trees import DOCUMENTED_TREES
 from docs_config import (
     EXCLUDED_AGENTS,
     EXCLUDED_COMMANDS,
@@ -48,10 +49,11 @@ SUPERPOWERS_COMMANDS = {"design-explore", "execute-plan", "write-plan"}
 SUPERPOWERS_AGENTS = {"code-reviewer"}
 
 # The docs/ subtrees this script owns end to end. Pruning is confined to
-# these four: every other path under docs/ (getting-started/, reference/,
+# these: every other path under docs/ (getting-started/, reference/,
 # windows-support-report.md, ...) is hand-authored and must
-# never be touched by a generator run.
-GENERATED_SUBDIRS = ("skills", "commands", "agents", "rules")
+# never be touched by a generator run. This script is what MAKES a tree
+# documented, so it is the same membership as DOCUMENTED_TREES by definition.
+GENERATED_SUBDIRS = DOCUMENTED_TREES
 
 # Hand-authored pages that live INSIDE a generated subtree. Membership in
 # GENERATED_SUBDIRS is not sufficient to call a page generated, and this

--- a/tests/docker/conftest.py
+++ b/tests/docker/conftest.py
@@ -30,6 +30,8 @@ PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
 
 # Files and directories essential for a functional spellbook repo clone.
 # Directories are copied recursively; files are copied individually.
+# A copy manifest, not a corpus membership -- it is "what an install needs",
+# so it is deliberately not corpus_trees.
 ESSENTIAL_DIRS = [
     "installer",
     "spellbook",

--- a/tests/scripts/test_docs_mirror_freshness.py
+++ b/tests/scripts/test_docs_mirror_freshness.py
@@ -29,6 +29,8 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 GENERATOR = REPO_ROOT / "scripts" / "generate_docs.py"
 DOCS_DIR = REPO_ROOT / "docs"
+# A copy manifest for the scratch repo, not a corpus membership -- it is
+# "what the generator needs to run", so it is deliberately not corpus_trees.
 SOURCE_DIRS = ("scripts", "skills", "commands", "agents", "rules", "docs")
 
 

--- a/tests/scripts/test_documented_cli_invocations.py
+++ b/tests/scripts/test_documented_cli_invocations.py
@@ -35,12 +35,18 @@ from pathlib import Path
 import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from corpus_trees import DOCUMENTED_TREES  # noqa: E402
+
 CLI_REL = "scripts/develop_gate_ledger.py"
 CLI_PATH = REPO_ROOT / CLI_REL
 
 # docs/ is a generated mirror of these sources; scanning it would only
 # re-test the same strings. Freshness of that mirror is a separate check.
-SCAN_DIRS = ("commands", "skills", "rules", "agents")
+# The set to scan is exactly "what gets mirrored into docs/", so it is
+# DOCUMENTED_TREES by definition rather than by coincidence.
+SCAN_DIRS = DOCUMENTED_TREES
 
 # The documented invocations are illustrative, so they carry placeholders.
 # Substituting realistic values keeps the hard cases IN the sample; a check

--- a/tests/scripts/test_readme_no_phantoms.py
+++ b/tests/scripts/test_readme_no_phantoms.py
@@ -10,6 +10,7 @@ These tests pin the reverse direction: every documented item must
 resolve to a real source file.
 """
 
+import importlib.util
 import shutil
 import subprocess
 import sys
@@ -17,6 +18,10 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 CHECKER = REPO_ROOT / "scripts" / "check-readme-completeness.py"
+
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+import corpus_trees  # noqa: E402  (needs the scripts/ path entry above)
 # A copy manifest for the scratch repo, not a corpus membership -- it is
 # "what the checker needs to run", so it is deliberately not corpus_trees.
 SOURCE_DIRS = ("scripts", "skills", "commands", "agents", "rules", "docs")
@@ -39,6 +44,14 @@ def _run(root: Path) -> subprocess.CompletedProcess:
         cwd=str(root),
         timeout=300,
     )
+
+
+def _load_checker_module():
+    """Import the checker by path; its filename is not a valid module name."""
+    spec = importlib.util.spec_from_file_location("check_readme_completeness", CHECKER)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 def test_repository_documents_nothing_phantom():
@@ -138,6 +151,50 @@ def test_real_rules_pages_are_not_orphans():
     )
     assert "docs/rules/" not in result.stdout, result.stdout
     assert result.returncode == 0, f"{result.stdout}{result.stderr}"
+
+
+def test_phantom_rules_nav_entry_is_named(tmp_path):
+    """A nav entry for a deleted rule must be reported.
+
+    Without this, deleting a rule leaves a stale nav entry, and once
+    generate_docs.py drops the docs page the orphan sweep cannot see it
+    either -- so nothing reports it, ever.
+    """
+    root = _scratch_repo(tmp_path)
+    mkdocs = root / "mkdocs.yml"
+    text = mkdocs.read_text(encoding="utf-8")
+    marker = "      - rules/00-core.md\n"
+    assert marker in text, "fixture expects rules/00-core.md in the nav"
+    mkdocs.write_text(
+        text.replace(marker, marker + "      - rules/99-ghost-rule.md\n", 1),
+        encoding="utf-8",
+    )
+
+    result = _run(root)
+    assert result.returncode == 1, result.stdout
+    assert "rules/99-ghost-rule.md" in result.stdout, result.stdout
+
+
+def test_rule_missing_from_nav_is_named(tmp_path):
+    """A real rule with no nav entry must be reported."""
+    root = _scratch_repo(tmp_path)
+    mkdocs = root / "mkdocs.yml"
+    text = mkdocs.read_text(encoding="utf-8")
+    marker = "      - rules/00-core.md\n"
+    assert marker in text, "fixture expects rules/00-core.md in the nav"
+    mkdocs.write_text(text.replace(marker, "", 1), encoding="utf-8")
+
+    result = _run(root)
+    assert result.returncode == 1, result.stdout
+    assert "mkdocs.yml nav missing: rules/00-core.md" in result.stdout, result.stdout
+
+
+def test_nav_entry_regex_tracks_documented_trees():
+    """The nav regex alternation must not drift from DOCUMENTED_TREES."""
+    checker = _load_checker_module()
+    for tree in corpus_trees.DOCUMENTED_TREES:
+        assert checker.NAV_ENTRY_RE.findall(f"{tree}/probe.md") == [(tree, "probe")]
+    assert checker.NAV_ENTRY_RE.findall("patterns/probe.md") == []
 
 
 def test_duplicated_link_definition_is_reported(tmp_path):

--- a/tests/scripts/test_readme_no_phantoms.py
+++ b/tests/scripts/test_readme_no_phantoms.py
@@ -17,6 +17,8 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 CHECKER = REPO_ROOT / "scripts" / "check-readme-completeness.py"
+# A copy manifest for the scratch repo, not a corpus membership -- it is
+# "what the checker needs to run", so it is deliberately not corpus_trees.
 SOURCE_DIRS = ("scripts", "skills", "commands", "agents", "rules", "docs")
 
 
@@ -105,6 +107,37 @@ def test_orphan_docs_page_is_named(tmp_path):
     result = _run(root)
     assert result.returncode == 1, result.stdout
     assert "docs/commands/ghost-command.md" in result.stdout, result.stdout
+
+
+def test_orphan_rules_docs_page_is_named(tmp_path):
+    """docs/rules/ is generated, so it can rot exactly like the other trees.
+
+    README has no Rules section, so the README-table checks correctly skip
+    rules. The orphan sweep reads docs/, not README, so that exclusion never
+    applied to it -- and 20 generated pages sat with no reverse-direction
+    guard at all.
+    """
+    root = _scratch_repo(tmp_path)
+    (root / "docs" / "rules" / "99-ghost-rule.md").write_text(
+        "# ghost\n", encoding="utf-8"
+    )
+
+    result = _run(root)
+    assert result.returncode == 1, result.stdout
+    assert "docs/rules/99-ghost-rule.md" in result.stdout, result.stdout
+
+
+def test_real_rules_pages_are_not_orphans():
+    """The sweep must not report the 20 legitimate generated rule pages."""
+    result = subprocess.run(
+        [sys.executable, str(CHECKER)],
+        capture_output=True,
+        text=True,
+        cwd=str(REPO_ROOT),
+        timeout=300,
+    )
+    assert "docs/rules/" not in result.stdout, result.stdout
+    assert result.returncode == 0, f"{result.stdout}{result.stderr}"
 
 
 def test_duplicated_link_definition_is_reported(tmp_path):

--- a/tests/scripts/test_reference_resolution.py
+++ b/tests/scripts/test_reference_resolution.py
@@ -270,6 +270,13 @@ def test_prose_row_label_matches_the_scanned_source(row_name):
     The label is what a reader sees beside a count, so a stale one turns a
     widened scan into a false statement about what was checked. This was
     OBSERVED: the four-tree label printed unchanged beside a nine-tree scan.
+
+    Not subsumed by the identity test below. Identity pins every row to the
+    same object; it says nothing about whether that object is right. Build
+    PROSE_SOURCE_LABEL with the wrong separator, or from PROSE_DIRS alone
+    with PROSE_FILES dropped, and every identity assertion still holds while
+    this one -- which recomputes the label independently -- is the only thing
+    that fails.
     """
     expected = ", ".join(
         [f"{d}/" for d in PROSE_DIRS] + [str(f) for f in PROSE_FILES]

--- a/tests/scripts/test_reference_resolution.py
+++ b/tests/scripts/test_reference_resolution.py
@@ -31,6 +31,9 @@ sys.path.insert(0, str(REPO_ROOT / "scripts"))
 
 from check_reference_resolution import (  # noqa: E402
     ALLOWLIST,
+    PROSE_DIRS,
+    PROSE_FILES,
+    PROSE_SOURCE_LABEL,
     Reference,
     build_rows,
     is_allowlisted,
@@ -250,6 +253,62 @@ def test_red_prose_commands_accepts_commands_and_skills(tmp_path):
     unresolved = _targets("prose-commands", repo)
     for name in ("verify", "systematic-debugging", "develop"):
         assert name not in unresolved
+
+
+# ---------------------------------------------------------------------------
+# Row labels must describe the source actually scanned
+# ---------------------------------------------------------------------------
+
+
+PROSE_ROWS = ("prose-paths", "prose-modules", "prose-skills", "prose-commands")
+
+
+@pytest.mark.parametrize("row_name", PROSE_ROWS)
+def test_prose_row_label_matches_the_scanned_source(row_name):
+    """A hardcoded label misreports the moment the scanned set changes.
+
+    The label is what a reader sees beside a count, so a stale one turns a
+    widened scan into a false statement about what was checked. This was
+    OBSERVED: the four-tree label printed unchanged beside a nine-tree scan.
+    """
+    expected = ", ".join(
+        [f"{d}/" for d in PROSE_DIRS] + [str(f) for f in PROSE_FILES]
+    )
+    assert ROWS[row_name].source == expected, (
+        f"Row {row_name!r} labels its source {ROWS[row_name].source!r}, but it "
+        f"scans {expected!r}. The label is duplicated data, not derived data, "
+        f"so it can misreport what was checked."
+    )
+
+
+@pytest.mark.parametrize("row_name", PROSE_ROWS)
+def test_prose_row_label_is_derived_not_copied(row_name):
+    """Equality today is not derivation; a copy that matches still rots.
+
+    PROSE_SOURCE_LABEL is built at import time by ``join``, so it is not an
+    interned literal. A hardcoded label that happens to read the same is a
+    DIFFERENT object, and that is exactly the state this pins against: the
+    copy stays put while PROSE_DIRS moves underneath it.
+    """
+    assert ROWS[row_name].source is PROSE_SOURCE_LABEL, (
+        f"Row {row_name!r} carries its own copy of the source label instead of "
+        f"PROSE_SOURCE_LABEL. It reads correctly now and will not when "
+        f"PROSE_DIRS changes."
+    )
+
+
+def test_prose_row_label_names_every_scanned_dir():
+    """Derivation, not just equality: every scanned tree appears in the label."""
+    for row_name in PROSE_ROWS:
+        label = ROWS[row_name].source
+        for d in PROSE_DIRS:
+            assert f"{d}/" in label, (
+                f"Row {row_name!r} scans {d}/ but its label {label!r} omits it."
+            )
+        for f in PROSE_FILES:
+            assert str(f) in label, (
+                f"Row {row_name!r} scans {f} but its label {label!r} omits it."
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/scripts/test_self_manufactured_evidence.py
+++ b/tests/scripts/test_self_manufactured_evidence.py
@@ -27,7 +27,9 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO_ROOT / "scripts"))
 
+import corpus_trees
 from check_self_manufactured_evidence import (
+    CORPUS_MEMBERSHIP_NAMES,
     discover_script_checks,
     evaluate,
     rel_posix,
@@ -86,6 +88,62 @@ def test_test_shaped_discovery_floor():
 def test_the_gate_discovers_itself():
     """A checker that cannot see its own shape is not checking that shape."""
     assert "check_self_manufactured_evidence" in discover_script_checks(REPO_ROOT)
+
+
+# ---------------------------------------------------------------------------
+# The recognition list must track corpus_trees
+# ---------------------------------------------------------------------------
+
+
+def _exported_memberships() -> set[str]:
+    """Public module-level names in ``corpus_trees`` whose value is a tuple of str.
+
+    Derived from the imported module rather than parsed out of its source: a
+    membership is defined by its VALUE, so this sees one however it is spelled
+    -- a literal, a concatenation of two others, or something computed. A
+    source parser has to model each spelling, and the spelling it fails to
+    model drops out of the expected set silently, which is the very defect
+    this guard exists to catch.
+    """
+    return {
+        name
+        for name, value in vars(corpus_trees).items()
+        if not name.startswith("_")
+        and isinstance(value, tuple)
+        and all(isinstance(item, str) for item in value)
+    }
+
+
+def test_membership_derivation_meets_its_floor():
+    """A derivation that finds nothing would make the drift test pass vacuously."""
+    derived = _exported_memberships()
+    assert len(derived) >= 3, (
+        f"Derived only {len(derived)} membership tuple(s) from corpus_trees: "
+        f"{sorted(derived)}. Three were present when this floor was measured. "
+        "Either a membership was removed, or the derivation stopped seeing "
+        "them and this test silently stopped checking anything."
+    )
+
+
+def test_recognition_list_covers_every_corpus_membership():
+    """``CORPUS_MEMBERSHIP_NAMES`` is hand-maintained; both drifts are silent.
+
+    A membership missing from the list reopens the blind spot the list was
+    added to close -- a checker that imports it drops out of this inventory
+    while still enumerating the tree, and the run stays green. A stale name
+    left behind after a tuple is removed points the detector at a symbol no
+    file can spell, so it can never match. Neither direction announces itself,
+    so both are asserted here and reported separately.
+    """
+    derived = _exported_memberships()
+    unrecognised = sorted(derived - set(CORPUS_MEMBERSHIP_NAMES))
+    stale = sorted(set(CORPUS_MEMBERSHIP_NAMES) - derived)
+    assert not unrecognised and not stale, (
+        f"CORPUS_MEMBERSHIP_NAMES has drifted from corpus_trees.\n"
+        f"  unrecognised (exported by corpus_trees, absent from the list): "
+        f"{unrecognised}\n"
+        f"  stale (in the list, no longer exported by corpus_trees): {stale}"
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Collapses the duplicated "corpus tree" lists onto a shared module, fixes one genuinely
broken reference, and closes a documentation-rot hole that was open.

A read-only survey measured **eleven sites** hardcoding these lists across **seven
distinct memberships** — not the seven sites and four lists the work started from. Only
the measured-safe subset is here. Five scope questions that the measurement could not
decide are left open deliberately and listed at the bottom.

`scripts/corpus_trees.py` exports three named tuples, each documenting why it differs from
the others: `DOCUMENTED_TREES` (produce a page under `docs/` and a nav entry),
`ENUMERABLE_TREES` (the detection vocabulary for "a tree a corpus checker might
enumerate"), and `README_ARTIFACT_KINDS` (kinds with a README table — `rules` is absent
because README has no Rules section). The inequality between them is the point; a single
flat list would have erased distinctions that four separate checkers depend on.

**One broken reference.** `extensions/prime-agent/README.md` pointed at
`tests/installer/test_prime_agent_rules_install.py`, which does not exist — the file is
under `tests/integration/`. Found only because the survey measured what a widened
reference check would catch.

**One live rot hole.** `generate_docs.py` generates 21 pages under `docs/rules/` that had
no reverse-direction guard at all — the exact class the completeness checker's docstring
says its orphan sweep exists to kill. A planted `docs/rules/99-ghost-rule.md` went
**undetected at exit 0** before this change. Naively adding `rules` to `ARTIFACT_PREFIXES`
raises `KeyError` instead, because that tuple is coupled to `real_sources()`'s dict keys;
the sweep now iterates `DOCUMENTED_TREES` while the README-table checks keep
`README_ARTIFACT_KINDS`.

**A display string that could already misreport.** Four rows in
`check_reference_resolution.py` hardcoded `source="skills/, commands/, agents/, rules/,
AGENTS.md"` beside the data it duplicated. Under a widened scan it was observed printing
the old four-tree label next to a scan of nine. Now derived, with two tests: one pinning
the label to the data, one pinning identity. Neither subsumes the other — dropping
`PROSE_FILES` from the label leaves all four identity assertions green while the equality
test fails.

## Findings worth flagging to a reviewer

**Sharing the lists blinded a detector, and the fix needed two layers.** Replacing a
hardcoded tuple with an import removed the last corpus string literal from a test file, so
`check_self_manufactured_evidence.py` could no longer classify it as a corpus check —
discovery fell 12 → 11 while the file enumerated the checkout exactly as before. Every
checker adopting the shared module would have silently dropped out of its own inventory.
Teaching only the textual regex was insufficient; the AST membership test needed the
vocabulary too, and the intermediate state was measured and still under-reported.

**`CORPUS_DIRS` is not a scan root**, despite reading like one. It feeds a regex that
classifies whether a *Python file* is a corpus check; the real scan roots are
`("scripts", "hooks")`. Repointing it at a scan-root list would have silently changed what
the checker discovers. Its verdict list is byte-identical after this change.

**The recognition list is now derived rather than trusted.** `CORPUS_MEMBERSHIP_NAMES` was
hand-maintained, so a fourth membership added later would not be recognised and the
failure would be silent — the same shape this branch had already paid for once. A test
derives the expected set by importing the module and asserts set equality, so drift fails
in both directions.

## Deliberately not done

Five questions the measurement could not settle: whether `rules/` belongs under the
tier-token ban (costs zero findings today), whether `patterns/` prose should be
reference-checked (it is teaching material about other repositories, where illustrative
paths may be the norm), three false-positive allowlist entries that need a human assertion
about references pointing outside this repo, whether `.pre-commit-config.yaml` should
import the shared list, and whether `extensions/` joins the scratch-repo copy manifests
(138 MB per test invocation for zero finding gain).

## Related issue

None.

## Checklist

- [x] Tests pass locally — 1815 passed, 2 skipped
- [x] Documentation updated (if applicable) — `docs/` mirror verified up to date; the
      shared module documents each membership's reason inline
