### PR TITLE
Refuse or repair malformed ledger maps instead of tracebacking

### DIFF
--- a/scripts/develop_gate_ledger.py
+++ b/scripts/develop_gate_ledger.py
@@ -133,7 +133,7 @@ import sys
 from collections.abc import Iterable, Mapping
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, NamedTuple
 
 # This module's own docstring says "a developer or subagent can read it
 # directly", and every doc instructs invoking it as
@@ -490,6 +490,105 @@ def set_scalar(field: str, value: Any, *, path: Path | None = None) -> dict[str,
     return write_ledger({field: value}, path=path)
 
 
+def _require_ledger_map(
+    container: Mapping[str, Any],
+    key: str,
+    *,
+    remedy: str,
+    label: str | None = None,
+) -> dict[str, Any]:
+    """Return the object at ``key``, refusing a non-object shape.
+
+    The READ half of the malformed-shape contract, and the sibling of
+    ``_require_ceremony_dict`` for the accumulating maps: ``blockers``,
+    ``waves``, and the entries nested inside them. Every one of these
+    shapes is reachable -- the shipped CLI wrote ``{"blockers":
+    "collapsed"}`` and ``{"waves": "collapsed"}`` at exit 0 before the
+    bare-``set`` refusal closed that route -- so a ledger on disk can
+    already hold them, and the module docstring separately invites a
+    developer to edit the file by hand.
+
+    A read that GATES A CLAIM must refuse rather than answer. Feeding a
+    scalar to ``.get`` raised ``AttributeError`` and escaped as a raw
+    traceback; swallowing it with ``or {}`` was worse, because the falsy
+    shapes then reported "no open blocker to close" and "this wave did not
+    pass" -- both of which name a MISSING ENTRY when the real fault is a
+    malformed field, sending the reader to look for the wrong thing.
+    ``is_wave_done_claimable`` is the case that makes this matter: "False"
+    and "nothing could be read" are different facts, and only one of them
+    is about the wave.
+
+    ``None`` returns ``{}``: that is JSON's spelling of absent, and an
+    absent map is the ordinary fresh-ledger state, not damage. Every other
+    non-object is refused, matching the value space ``_require_ceremony_dict``
+    admits so the two guards cannot disagree about what "malformed" means.
+
+    ``remedy`` is the caller's, because the route differs per field and a
+    refusal naming a remedy that does not work is the dead end this whole
+    defect class keeps producing. Each one passed in here is covered by a
+    test that runs it against the broken shape.
+    """
+    value = container.get(key)
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        raise LedgerError(
+            f"ledger field {label or key!r} is a {type(value).__name__}, not an "
+            f"object (value={value!r}); refusing to read an entry out of it. "
+            "A bare `set` that collapsed the object to a scalar is now refused, "
+            "but a ledger written before that guard can still hold this shape. "
+            f"{remedy}"
+        )
+    return value
+
+
+class _DisplacedMap(NamedTuple):
+    """An accumulating map made usable, plus the malformed value it displaced.
+
+    A named pair rather than a bare tuple because the caller unpacks it at a
+    distance from this definition, and ``usable``/``evidence`` say which is
+    which where a positional tuple would not.
+    """
+
+    usable: dict[str, Any]
+    evidence: dict[str, Any]
+
+
+def _displace_malformed_map(current: Mapping[str, Any], field: str) -> _DisplacedMap:
+    """Return the accumulating map at ``field``, made usable, with any evidence.
+
+    The WRITE half, and it is deliberately NOT the mirror of
+    ``_require_ledger_map``. Both fields that use it -- ``ceremony_history``
+    and ``dispatches`` -- are on paths that must not refuse:
+    ``archive_ceremony`` IS the recovery route every ceremony refusal names,
+    and ``record_dispatch`` is driven by the ``PostToolUse`` hook, which
+    fires without the agent's cooperation and has nobody to show an error to.
+    Refusing on either is the dead end PR 469 shipped, where the remedy a
+    refusal named was itself refused.
+
+    ``dict(current.get(field) or {})`` was the crash: a string or list raised
+    ``ValueError: dictionary update sequence element #0 has length 1; 2 is
+    required``, and a number raised ``TypeError: 'int' object is not
+    iterable``. Neither message named the field or a way out, and the
+    ``TypeError`` escaped as a traceback because the CLI handlers catch only
+    ``ValueError`` and ``LedgerError``.
+
+    The malformed value is returned as EVIDENCE rather than dropped, on the
+    same reasoning ``archive_ceremony`` preserves a scalar ``ceremony``: it is
+    the record of what the ledger held, and this is the one path that gets to
+    see it. The caller folds it under a ``prior_<field>`` key INSIDE the new
+    entry, where a scalar cannot corrupt the map it was displaced from. The
+    falsy shapes were previously swallowed by ``or {}`` and lost silently,
+    which is the same erasure without the crash to notice it by.
+    """
+    value = current.get(field)
+    if isinstance(value, dict):
+        return _DisplacedMap(dict(value), {})
+    if value is None:
+        return _DisplacedMap({}, {})
+    return _DisplacedMap({}, {f"prior_{field}": value})
+
+
 def _require_ceremony_dict(current: Mapping[str, Any]) -> dict[str, Any]:
     """Return the stored ``ceremony`` object, refusing a non-object shape.
 
@@ -736,7 +835,8 @@ def archive_ceremony(
             "Archiving is for superseding an existing selection."
         )
     stamp = timestamp or _utc_now()
-    history = dict(current.get("ceremony_history") or {})
+    prior = _displace_malformed_map(current, "ceremony_history")
+    history = dict(prior.usable)
     # Two archives in the same second would collide on the map key and the
     # earlier one would vanish -- silently, and only in the audit trail. Key
     # collisions get a suffix so append-only holds regardless of clock
@@ -754,6 +854,7 @@ def archive_ceremony(
         "reason": reason.strip(),
         "archived_at": stamp,
         "ceremony": ceremony,
+        **prior.evidence,
     }
     updated = dict(current)
     updated["ceremony_history"] = history
@@ -848,7 +949,20 @@ def record_blocker(
     stamp = timestamp or _utc_now()
     if close:
         current = read_ledger(path)
-        existing = (current.get("blockers") or {}).get(blocker_id)
+        existing = _require_ledger_map(
+            current,
+            "blockers",
+            # Every backticked command is LITERAL, down to the argument:
+            # `--type decision/work/external` reads as a helpful alternation
+            # and is a spelling argparse rejects, so the alternatives sit
+            # OUTSIDE the backticks.
+            remedy=(
+                "Read it with `show --field blockers` first -- the repair "
+                "DISCARDS it -- then re-establish the map by opening a "
+                f"blocker: `blocker <id> --type {BLOCKER_TYPES[0]}` "
+                f"(or {'/'.join(BLOCKER_TYPES[1:])})."
+            ),
+        ).get(blocker_id)
         if not existing:
             raise LedgerError(
                 f"no open blocker {blocker_id!r} to close. Closing a blocker "
@@ -971,13 +1085,14 @@ def record_dispatch(
     target = path or ledger_path()
     current = read_ledger(target)
     stamp = timestamp or _utc_now()
-    dispatches = dict(current.get("dispatches") or {})
+    prior = _displace_malformed_map(current, "dispatches")
+    dispatches = dict(prior.usable)
     key = stamp
     n = 2
     while key in dispatches:
         key = f"{stamp}#{n:03d}"
         n += 1
-    entry: dict[str, Any] = {"recorded_at": stamp}
+    entry: dict[str, Any] = {"recorded_at": stamp, **prior.evidence}
     if subagent_type and subagent_type.strip():
         entry["subagent_type"] = subagent_type.strip()[:DESCRIPTION_MAX]
     if description and description.strip():
@@ -1019,14 +1134,44 @@ def find_dispatches(
     return sorted(found, key=lambda e: str(e.get("recorded_at") or ""))
 
 
+# Every backticked command here is LITERAL, argument alternations included: a
+# remedy is spelled the way the reader will type it, and
+# `--status passed/failed/n_a` is a spelling argparse rejects.
+_WAVE_REMEDY = (
+    "Read it with `show --field waves` first -- the repair DISCARDS it -- "
+    "then re-establish the map by recording a check: "
+    "`wave-discipline <wave> --status passed` (or failed/n_a)."
+)
+
+
 def wave_discipline_status(
     wave_id: str, *, path: Path | None = None
 ) -> dict[str, Any] | None:
-    """Return the recorded §24.6 entry for a wave, or None if absent."""
+    """Return the recorded §24.6 entry for a wave, or None if absent.
+
+    Refuses a malformed ``waves`` rather than reading through it. This
+    read is what ``is_wave_done_claimable`` decides on, so a shape it
+    cannot parse must not be answered with a verdict -- see
+    ``_require_ledger_map``. The guard repeats at EVERY level the walk
+    descends: guarding only the top would have moved the
+    ``AttributeError`` one ``.get`` deeper instead of removing it.
+    """
     current = read_ledger(path)
-    waves = current.get("waves") or {}
-    wave = waves.get(wave_id) or {}
-    return wave.get("section_24_6_check")
+    waves = _require_ledger_map(current, "waves", remedy=_WAVE_REMEDY)
+    wave = _require_ledger_map(
+        waves, wave_id, remedy=_WAVE_REMEDY, label=f"waves.{wave_id}"
+    )
+    # Absent and explicit null both mean "no check recorded" and return
+    # None, the answer this function has always given for them. Only a
+    # PRESENT non-object is malformed.
+    if wave.get("section_24_6_check") is None:
+        return None
+    return _require_ledger_map(
+        wave,
+        "section_24_6_check",
+        remedy=_WAVE_REMEDY,
+        label=f"waves.{wave_id}.section_24_6_check",
+    )
 
 
 def is_wave_done_claimable(wave_id: str, *, path: Path | None = None) -> bool:

--- a/tests/scripts/test_develop_gate_ledger.py
+++ b/tests/scripts/test_develop_gate_ledger.py
@@ -12,6 +12,7 @@ import ast
 import json
 import logging
 import os
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -2194,3 +2195,275 @@ def test_archive_ceremony_still_refuses_a_genuinely_empty_ceremony(tmp_ledger, r
     _write_raw_ledger(tmp_ledger, f'{{"ceremony": {raw}}}')
     with pytest.raises(ledger.LedgerError, match="no ceremony"):
         ledger.archive_ceremony("aborted the run")
+
+
+# ---- malformed stored map shapes: blockers / waves / ceremony_history ----
+#
+# Same defect class as the malformed-ceremony block above, in the sibling
+# fields left out of that pass. Every one of these shapes is reachable: the
+# shipped CLI wrote `{"blockers": "collapsed"}`, `{"waves": "collapsed"}`,
+# `{"ceremony_history": "collapsed"}` and `{"dispatches": "collapsed"}` at
+# exit 0 before the bare-`set` refusal closed that route, so a ledger written
+# by that code already carries them on disk.
+#
+# The two halves are NOT symmetric, and the asymmetry is the point. A read
+# that gates a claim REFUSES, because operating on a shape it cannot parse
+# would answer the gate question with a guess. A write on the RECOVERY path
+# must never refuse, because refusing there is the dead end PR 469 shipped:
+# a remedy that is itself blocked leaves hand-editing the JSON as the only
+# way out.
+
+_MALFORMED_NON_EMPTY = ['"collapsed"', '["a"]', "7"]
+_MALFORMED_FALSY = ['""', "0", "false", "[]"]
+
+
+@pytest.mark.parametrize("raw", _MALFORMED_NON_EMPTY + _MALFORMED_FALSY)
+def test_record_blocker_close_refuses_a_malformed_blockers(tmp_ledger, raw):
+    """A non-object `blockers` raised AttributeError out of `.get`.
+
+    The falsy shapes did not crash -- `or {}` swallowed them -- but they
+    reported "no open blocker to close", which names a MISSING ENTRY when
+    the real fault is a malformed field. That message sends the reader
+    looking for the wrong thing.
+    """
+    _write_raw_ledger(tmp_ledger, f'{{"blockers": {raw}}}')
+    with pytest.raises(ledger.LedgerError) as exc:
+        ledger.record_blocker("B1", close=True)
+    message = str(exc.value)
+    assert "blockers" in message
+    assert "--type" in message
+
+
+@pytest.mark.parametrize("raw", _MALFORMED_NON_EMPTY + _MALFORMED_FALSY)
+def test_wave_discipline_status_refuses_a_malformed_waves(tmp_ledger, raw):
+    """`waves` gates every "Wave N done" claim through is_wave_done_claimable."""
+    _write_raw_ledger(tmp_ledger, f'{{"waves": {raw}}}')
+    with pytest.raises(ledger.LedgerError) as exc:
+        ledger.wave_discipline_status("W1")
+    message = str(exc.value)
+    assert "waves" in message
+    assert "wave-discipline" in message
+
+
+@pytest.mark.parametrize("raw", _MALFORMED_NON_EMPTY + _MALFORMED_FALSY)
+def test_is_wave_done_claimable_refuses_rather_than_answering(tmp_ledger, raw):
+    """The gate must not answer False on a shape it could not read.
+
+    False and "the ledger is malformed" are different facts. Returning the
+    first for the second is survivable here only because the claim is
+    refused either way -- but the operator is then told the wave did not
+    pass, when what actually happened is that nothing could be read.
+    """
+    _write_raw_ledger(tmp_ledger, f'{{"waves": {raw}}}')
+    with pytest.raises(ledger.LedgerError):
+        ledger.is_wave_done_claimable("W1")
+
+
+@pytest.mark.parametrize("raw", _MALFORMED_NON_EMPTY + _MALFORMED_FALSY)
+def test_archive_ceremony_survives_a_malformed_ceremony_history(tmp_ledger, raw):
+    """The remedy every ceremony refusal names must work, whatever else is broken.
+
+    `dict(current.get("ceremony_history") or {})` raised `ValueError:
+    dictionary update sequence element #0 has length 1; 2 is required` on a
+    string or list, and `TypeError: 'int' object is not iterable` on a
+    number -- a raw traceback, since `_cmd_archive_ceremony` catches neither.
+    Refusing here is not an option: this IS the recovery route.
+    """
+    _write_raw_ledger(
+        tmp_ledger, f'{{"ceremony": {{"selected": "gate-a"}}, "ceremony_history": {raw}}}'
+    )
+    result = ledger.archive_ceremony("repairing a collapsed ledger")
+    history = result["ceremony_history"]
+    assert isinstance(history, dict)
+    assert len(history) == 1
+    entry = next(iter(history.values()))
+    assert entry["ceremony"] == {"selected": "gate-a"}
+    # The malformed value is EVIDENCE of what the ledger held, not litter.
+    assert entry["prior_ceremony_history"] == json.loads(raw)
+    assert result["ceremony"] == {}
+
+
+@pytest.mark.parametrize("raw", _MALFORMED_NON_EMPTY + _MALFORMED_FALSY)
+def test_record_dispatch_survives_a_malformed_dispatches(tmp_ledger, raw):
+    """Same `dict(... or {})` shape, on the path a harness hook drives.
+
+    `record_dispatch` is written by the `PostToolUse` hook, which fires
+    without the agent's cooperation -- a traceback there breaks recording
+    for a party that cannot see the error, so this write must not refuse
+    either.
+    """
+    _write_raw_ledger(tmp_ledger, f'{{"dispatches": {raw}}}')
+    result = ledger.record_dispatch(subagent_type="impl")
+    dispatches = result["dispatches"]
+    assert isinstance(dispatches, dict)
+    assert len(dispatches) == 1
+    entry = next(iter(dispatches.values()))
+    assert entry["subagent_type"] == "impl"
+    assert entry["prior_dispatches"] == json.loads(raw)
+
+
+def test_absent_maps_do_not_gain_a_prior_key(tmp_ledger):
+    """Absent and null are the ORDINARY fresh-ledger case, not malformed."""
+    _write_raw_ledger(tmp_ledger, '{"ceremony": {"selected": "g"}, "dispatches": null}')
+    dispatched = ledger.record_dispatch(subagent_type="impl")
+    assert "prior_dispatches" not in next(iter(dispatched["dispatches"].values()))
+    archived = ledger.archive_ceremony("ordinary supersede")
+    entry = next(iter(archived["ceremony_history"].values()))
+    assert "prior_ceremony_history" not in entry
+
+
+def test_well_formed_maps_are_undisturbed(tmp_ledger):
+    """The guards must not disturb the normal paths they wrap."""
+    ledger.record_blocker("B1", blocker_type="decision")
+    assert ledger.record_blocker("B1", close=True)["blockers"]["B1"]["closed_at"]
+    ledger.record_wave_discipline("W1", status="passed")
+    assert ledger.wave_discipline_status("W1")["status"] == "passed"
+    assert ledger.is_wave_done_claimable("W1") is True
+    assert ledger.wave_discipline_status("W-absent") is None
+    assert ledger.is_wave_done_claimable("W-absent") is False
+
+
+@pytest.mark.allow("subprocess")
+@pytest.mark.parametrize("raw", _MALFORMED_NON_EMPTY)
+def test_cli_blocker_close_on_a_malformed_blockers_refuses_without_a_traceback(
+    tmp_ledger, raw
+):
+    _write_raw_ledger(tmp_ledger, f'{{"blockers": {raw}}}')
+    proc = _run_cli("blocker", "B1", "--close")
+    assert proc.returncode == 2
+    assert "Traceback" not in proc.stderr
+    assert "AttributeError" not in proc.stderr
+    assert "blockers" in proc.stderr
+
+
+@pytest.mark.allow("subprocess")
+@pytest.mark.parametrize("raw", _MALFORMED_NON_EMPTY)
+def test_cli_blocker_open_repairs_a_malformed_blockers(tmp_ledger, raw):
+    """The remedy the refusal names has to work on the shape it was named for."""
+    _write_raw_ledger(tmp_ledger, f'{{"blockers": {raw}}}')
+    assert _run_cli("blocker", "B1", "--type", "decision").returncode == 0
+    assert _run_cli("blocker", "B1", "--close").returncode == 0
+    assert ledger.read_ledger()["blockers"]["B1"]["closed_at"]
+
+
+@pytest.mark.allow("subprocess")
+@pytest.mark.parametrize("raw", _MALFORMED_NON_EMPTY)
+def test_cli_wave_discipline_repairs_a_malformed_waves(tmp_ledger, raw):
+    _write_raw_ledger(tmp_ledger, f'{{"waves": {raw}}}')
+    proc = _run_cli("wave-discipline", "W1", "--status", "passed")
+    assert proc.returncode == 0
+    assert "Traceback" not in proc.stderr
+    assert ledger.is_wave_done_claimable("W1") is True
+
+
+@pytest.mark.allow("subprocess")
+@pytest.mark.parametrize("raw", _MALFORMED_NON_EMPTY)
+def test_cli_archive_ceremony_repairs_a_malformed_ceremony_history(tmp_ledger, raw):
+    _write_raw_ledger(
+        tmp_ledger, f'{{"ceremony": "heavy", "ceremony_history": {raw}}}'
+    )
+    proc = _run_cli("archive-ceremony", "--reason", "repairing a collapsed ledger")
+    assert proc.returncode == 0
+    assert "Traceback" not in proc.stderr
+    assert ledger.read_ledger()["ceremony"] == {}
+    # Normal operation resumes: a fresh Phase 0 may now set the lock.
+    assert _run_cli("set", "ceremony.locked_at", "2026-01-01T00:00:00Z").returncode == 0
+
+
+@pytest.mark.allow("subprocess")
+@pytest.mark.parametrize("raw", _MALFORMED_NON_EMPTY)
+def test_cli_record_dispatch_survives_a_malformed_dispatches(tmp_ledger, raw):
+    _write_raw_ledger(tmp_ledger, f'{{"dispatches": {raw}}}')
+    proc = _run_cli("record-dispatch", "--subagent-type", "impl")
+    assert proc.returncode == 0
+    assert "Traceback" not in proc.stderr
+    assert len(ledger.read_ledger()["dispatches"]) == 1
+
+
+@pytest.mark.parametrize("raw", _MALFORMED_NON_EMPTY)
+def test_wave_discipline_status_refuses_a_malformed_wave_entry(tmp_ledger, raw):
+    """The shape assumption repeats at every level the read walks down.
+
+    Guarding only the top level moves the AttributeError one `.get` deeper
+    instead of removing it -- the reported crash site was not the first one
+    on the ceremony path either.
+    """
+    _write_raw_ledger(tmp_ledger, f'{{"waves": {{"W1": {raw}}}}}')
+    with pytest.raises(ledger.LedgerError) as exc:
+        ledger.wave_discipline_status("W1")
+    assert "waves.W1" in str(exc.value)
+
+
+@pytest.mark.parametrize("raw", _MALFORMED_NON_EMPTY)
+def test_is_wave_done_claimable_refuses_a_malformed_check_entry(tmp_ledger, raw):
+    _write_raw_ledger(
+        tmp_ledger, f'{{"waves": {{"W1": {{"section_24_6_check": {raw}}}}}}}'
+    )
+    with pytest.raises(ledger.LedgerError) as exc:
+        ledger.is_wave_done_claimable("W1")
+    assert "section_24_6_check" in str(exc.value)
+
+
+# ---- the named remedies must be RUNNABLE ---------------------------------
+#
+# PR 469 shipped a refusal whose named remedy was itself refused, and the
+# first draft of the guards above did it again in a smaller way: the message
+# named `show blockers`, which argparse rejects with exit 2 -- the real
+# spelling is `show --field blockers`. Prose review did not catch either one.
+# Extracting the commands from the message and RUNNING them does.
+
+
+def _remedy_commands(message: str) -> list[list[str]]:
+    """The backtick-quoted CLI commands a refusal message names.
+
+    A remedy is only a remedy if the reader can type it. Placeholders in
+    angle brackets are filled with values valid for the command, because
+    what is under test is the SPELLING argparse accepts, not the argument.
+    """
+    commands = []
+    for quoted in re.findall(r"`([^`]+)`", message):
+        parts = quoted.split()
+        if not parts or parts[0] in ("set",):
+            continue
+        filled = []
+        for part in parts:
+            if part == "<id>":
+                filled.append("REMEDY-1")
+            elif part == "<wave>":
+                filled.append("W1")
+            elif part.startswith("<") and part.endswith(">"):
+                filled.append(part.strip("<>").split("/")[0])
+            else:
+                filled.append(part)
+        commands.append(filled)
+    return commands
+
+
+def test_remedy_extractor_finds_and_fills_placeholders():
+    """The extractor must not be vacuous, or the checks below prove nothing."""
+    assert _remedy_commands("run `blocker <id> --type decision/work/external`") == [
+        ["blocker", "REMEDY-1", "--type", "decision/work/external"]
+    ]
+    assert _remedy_commands("no commands here") == []
+
+
+@pytest.mark.allow("subprocess")
+@pytest.mark.parametrize(
+    ("field", "trigger"),
+    [
+        ("blockers", lambda: ledger.record_blocker("B1", close=True)),
+        ("waves", lambda: ledger.wave_discipline_status("W1")),
+    ],
+)
+def test_every_named_remedy_is_a_command_the_cli_accepts(tmp_ledger, field, trigger):
+    _write_raw_ledger(tmp_ledger, f'{{"{field}": "collapsed"}}')
+    with pytest.raises(ledger.LedgerError) as exc:
+        trigger()
+    commands = _remedy_commands(str(exc.value))
+    assert commands, f"the {field!r} refusal names no runnable remedy"
+    for command in commands:
+        proc = _run_cli(*command)
+        assert proc.returncode == 0, (
+            f"refusal for {field!r} names `{' '.join(command)}`, which the CLI "
+            f"rejects with exit {proc.returncode}: {proc.stderr.strip()}"
+        )


### PR DESCRIPTION
## What does this PR do?

Extends the malformed-shape hardening from the ceremony work to the four other ledger maps
that had the same defect and were left out of that PR's scope.

A ledger whose `blockers`, `waves`, `ceremony_history` or `dispatches` is a scalar is
reachable state, not a hypothetical: running the shipped pre-guard script against a temp
ledger wrote `{"blockers":"collapsed"}` and the three others, each at exit 0.

**Reads now refuse instead of tracebacking, and stop lying about the cause.** Before, a
falsy value was silently swallowed by `or {}` — so a malformed `blockers` reported "no open
blocker" and a malformed `waves` reported "wave did not pass", naming a *missing entry*
when the real fault was a corrupt field. A non-empty scalar tracebacked with
`AttributeError`. Both now raise a refusal naming the field, its type, its value, and a
remedy.

**Writes now repair instead of dropping.** A malformed `ceremony_history` or `dispatches`
no longer blocks the write or silently discards it; the operation succeeds and the prior
value is preserved as `prior_<field>` evidence rather than thrown away.

## Findings beyond the reported defects

**A fourth site the sweep found and no report named.** `record_dispatch` carried the
identical `dict(... or {})` bug — cryptic exit 2 for a string, a `TypeError` traceback for
a number. It is driven by the `PostToolUse` hook, which has nobody to show an error to.

**Two deeper crash levels under `waves`.** Guarding only the top-level map moved the crash
one `.get` deeper, then another. `waves.<id>` and `waves.<id>.section_24_6_check` needed
guards of their own.

**One reported symptom was wrong.** `archive_ceremony` on a scalar `ceremony_history` was
described as a clean exit 2 with no traceback. That holds for strings and lists;
`ceremony_history: 7` gives a full `TypeError` traceback.

**The remedy bug from the ceremony PR reproduced, and is now mechanized.** The first draft
of these refusals named `show blockers` and `--status passed/failed/n_a` as remedies —
both rejected by argparse at exit 2. Prose review did not catch it; running the end-to-end
did. `test_every_named_remedy_is_a_command_the_cli_accepts` now extracts every backticked
command out of every refusal message and asserts the CLI accepts it, so a refusal that
names an unrunnable remedy cannot regress by inspection alone.

Seven mutants, zero survivors.

## Related issue

None.

## Checklist

- [x] Tests pass locally — 1958 passed, 2 skipped
- [x] Documentation updated (if applicable) — refusal messages carry the guidance; no
      generated docs affected
