### PR TITLE
Mechanize the missing-tool rule instead of restating it

### DIFF
--- a/commands/feature-research.md
+++ b/commands/feature-research.md
@@ -99,6 +99,11 @@ Task:
     4. FLAG any ambiguities or conflicting patterns
     5. EXPLICITLY state 'UNKNOWN' if evidence is insufficient
 
+    A MISSING TOOL IS NOT A CONSTRAINT TO DESIGN AROUND. If a tool you need is
+    absent, install it, or propose the installation to the operator — see
+    `rules/60-autonomy.md`. Either way, record it in `tooling` below. Research
+    built on an unrecorded missing tool rests on a premise nobody can re-check.
+
     CRITICAL: Mark confidence level for each answer:
     - HIGH: Direct evidence found (specific file references)
     - MEDIUM: Inferred from related code
@@ -126,8 +131,22 @@ Task:
           "description": "..."
         }
       ],
-      "unknowns": ["..."]
+      "unknowns": ["..."],
+      "tooling": {
+        "checked": true,
+        "none_missing": false,
+        "missing": [
+          {
+            "tool": "hg",
+            "resolution": "installed | installation_proposed | operator_declined | alternative_found",
+            "detail": "what was run, proposed, or declined",
+            "alternative": "named replacement — REQUIRED for alternative_found"
+          }
+        ]
+      }
     }
+
+    When no tool was missing, that is `"none_missing": true` with `"missing": []`.
 ```
 
 **ERROR HANDLING:**
@@ -354,6 +373,7 @@ Before proceeding to Phase 1.5, verify:
 - [ ] All ambiguities extracted and categorized
 - [ ] Findings stored in SESSION_CONTEXT.research_findings
 - [ ] `SESSION_CONTEXT.design_context.project_standards` populated whenever the §1.2.5 sweep ran
+- [ ] Every tool that was missing during §1.2 is recorded in `tooling` with its resolution
 
 If ANY unchecked: Complete Phase 1. Do NOT proceed.
 

--- a/docs/commands/feature-research.md
+++ b/docs/commands/feature-research.md
@@ -99,6 +99,11 @@ Task:
     4. FLAG any ambiguities or conflicting patterns
     5. EXPLICITLY state 'UNKNOWN' if evidence is insufficient
 
+    A MISSING TOOL IS NOT A CONSTRAINT TO DESIGN AROUND. If a tool you need is
+    absent, install it, or propose the installation to the operator — see
+    `rules/60-autonomy.md`. Either way, record it in `tooling` below. Research
+    built on an unrecorded missing tool rests on a premise nobody can re-check.
+
     CRITICAL: Mark confidence level for each answer:
     - HIGH: Direct evidence found (specific file references)
     - MEDIUM: Inferred from related code
@@ -126,8 +131,22 @@ Task:
           "description": "..."
         }
       ],
-      "unknowns": ["..."]
+      "unknowns": ["..."],
+      "tooling": {
+        "checked": true,
+        "none_missing": false,
+        "missing": [
+          {
+            "tool": "hg",
+            "resolution": "installed | installation_proposed | operator_declined | alternative_found",
+            "detail": "what was run, proposed, or declined",
+            "alternative": "named replacement — REQUIRED for alternative_found"
+          }
+        ]
+      }
     }
+
+    When no tool was missing, that is `"none_missing": true` with `"missing": []`.
 ```
 
 **ERROR HANDLING:**
@@ -354,6 +373,7 @@ Before proceeding to Phase 1.5, verify:
 - [ ] All ambiguities extracted and categorized
 - [ ] Findings stored in SESSION_CONTEXT.research_findings
 - [ ] `SESSION_CONTEXT.design_context.project_standards` populated whenever the §1.2.5 sweep ran
+- [ ] Every tool that was missing during §1.2 is recorded in `tooling` with its resolution
 
 If ANY unchecked: Complete Phase 1. Do NOT proceed.
 

--- a/scripts/check_research_quality.py
+++ b/scripts/check_research_quality.py
@@ -212,8 +212,12 @@ def _tooling_record_failures(tooling: object) -> tuple[list[str], list[str]]:
         return [f"tooling sweep not recorded as run (checked: {tooling.get('checked')!r})"], []
 
     entries = tooling.get("missing")
-    if not isinstance(entries, list):
+    if entries is None:
         entries = []
+    elif not isinstance(entries, list):
+        # Coercing this to [] would let `none_missing: true` below certify a
+        # record nobody can audit -- the exact shape this check exists to stop.
+        return [f"tooling record malformed: `missing` is not a list -- {entries!r}"], []
     if not entries:
         if tooling.get("none_missing") is True:
             return [], []
@@ -259,21 +263,50 @@ def check_tooling_blockers_resolved(data: dict) -> list[str]:
     return _tooling_record_failures(data.get("tooling"))[0]
 
 
+def _without_verbatim_quotes(data: dict) -> dict:
+    """Blank the two `binding_rules` fields §1.2.5 fills with quoted governance text.
+
+    Those two fields alone carry someone else's words. Everything else the
+    artifact holds -- `sources[].summary` included -- is the session reporting
+    on itself, which is what the advisory reads. Scoping the exclusion to the
+    quote fields rather than to all of `project_standards` costs one blind
+    spot: a session that misfiles its own narrative into a `rule` string is not
+    advised on it. The mandatory `tooling` record still blocks that session.
+
+    The replacement is blank rather than a deletion so reported line numbers
+    keep matching a plain dump of the artifact.
+    """
+    standards = data.get("project_standards")
+    rules = standards.get("binding_rules") if isinstance(standards, dict) else None
+    if not isinstance(rules, list):
+        return data
+    scrubbed = dict(data)
+    scrubbed["project_standards"] = dict(standards)
+    scrubbed["project_standards"]["binding_rules"] = [
+        {**rule, **{f: "" for f in ("rule", "context") if isinstance(rule.get(f), str)}}
+        if isinstance(rule, dict)
+        else rule
+        for rule in rules
+    ]
+    return scrubbed
+
+
 def advise_tooling_blockers(data: dict) -> list[str]:
     """Point at blocker-shaped prose the `tooling` record does not account for.
 
-    ADVISORY, not blocking. Measured against the research artifacts on this
-    machine the patterns flagged two lines, of which one -- "nvidia-smi is not
-    on PATH", cited as evidence that the hardware is absent -- is a finding
-    rather than a blocker. A non-zero false-positive rate on real material may
-    not decide a gate, so this warns and the mandatory record blocks. The
-    reported session is still caught: it carried no `tooling` record at all.
+    ADVISORY, not blocking. Re-measured against the research artifacts on this
+    machine, every line the patterns flag is a finding rather than a blocker --
+    "nvidia-smi is not on PATH" cited as evidence that the hardware is absent,
+    and a survey of which libraries are not installed and what would install
+    them. A non-zero false-positive rate on real material may not decide a
+    gate, so this warns and the mandatory record blocks. The reported session
+    is still caught: it carried no `tooling` record at all.
     """
     _, names = _tooling_record_failures(data.get("tooling"))
     accounted = [re.compile(rf"\b{re.escape(name)}\b", re.IGNORECASE) for name in names]
 
     advisories = []
-    text = json.dumps(data, indent=2)
+    text = json.dumps(_without_verbatim_quotes(data), indent=2)
     for number, line in enumerate(text.splitlines(), start=1):
         if not any(pattern.search(line) for pattern in TOOLING_BLOCKER_PATTERNS):
             continue

--- a/scripts/check_research_quality.py
+++ b/scripts/check_research_quality.py
@@ -45,23 +45,36 @@ TOOL_RESOLUTIONS = (
     "alternative_found",
 )
 
-# Every pattern is anchored to a token that only a TOOL invocation produces.
-# The bare vocabulary of unavailability -- "not available", "unavailable",
-# "is missing", "couldn't find" -- is deliberately absent: those words carry no
-# tooling signal, and "the config option is not available in v2" is a finding,
-# not a blocker. "not installed" is admitted only alongside an installer or
-# PATH token on the same line, which is what separates "ripgrep was not
-# installed, so brew install ripgrep" from "not installed into site-packages".
-_INSTALLER = r"brew|apt|apt-get|yum|dnf|pacman|pip|pipx|uv|npm|pnpm|yarn|cargo|gem|go get|winget|choco|nix-env|asdf|mise"
+# A tool that is absent is NOT the signal. A survey legitimately reports what is
+# on the machine ("nng: NOT installed, but bottled in Homebrew; nothing was
+# installed"), and flagging that is noise -- measured against the research
+# artifacts on this machine, every advisory the tool-absence patterns produced
+# was a survey answer. The signal is a session saying its OWN findings are
+# WEAKER because something was absent: a survey says what is on the machine, a
+# blocker says what the session could not do.
+#
+# Two families, both kept:
+#   INVOCATION FAILURE -- a command the session actually ran and that failed.
+#     Only a tool invocation produces these tokens; prose does not.
+#   SELF-DOWNGRADE -- the session naming its own evidence as the weaker form.
+# "not installed" and "not on PATH" are deliberately absent from both: they
+# describe the machine, not the session, and the mandatory `tooling` record is
+# what blocks a session that hit a missing tool and stayed silent.
+_WEAKER = r"verif\w+|test\w+|measur\w+|benchmark\w+|reproduc\w+|run|execute\w*"
+_STRONGER = r"runtime|empirical\w*|actual\w*|direct\w*|hands-on|executed|observed|measured|tested"
 TOOLING_BLOCKER_PATTERNS = (
     re.compile(r"[\w.+-]{2,}\s*:\s*command not found", re.IGNORECASE),
     re.compile(r"command not found\s*:\s*[\w.+-]{2,}", re.IGNORECASE),
     re.compile(r"no such command\s*:\s*[\w.+-]{2,}", re.IGNORECASE),
     re.compile(r"is not recognized as an internal or external command", re.IGNORECASE),
     re.compile(r"executable (?:file )?not found", re.IGNORECASE),
-    re.compile(r"not (?:on|in|found on|found in) (?:the |your )?PATH\b"),
-    re.compile(rf"(?:is|was|are|were|it)?\s*not installed\b.*\b(?:{_INSTALLER})\b", re.IGNORECASE),
-    re.compile(rf"\b(?:{_INSTALLER})\b.*\bnot installed\b", re.IGNORECASE),
+    # "so this is source reading, not runtime verification"
+    re.compile(rf"\bnot\s+(?:a\s+|an\s+)?(?:{_STRONGER})[\s-]*(?:{_WEAKER})", re.IGNORECASE),
+    # "could not verify", "couldn't be measured", "unable to run"
+    re.compile(rf"\b(?:could|can|would)\s*(?:not|n't)\s+(?:be\s+)?(?:{_WEAKER})\b", re.IGNORECASE),
+    re.compile(rf"\bunable to\s+(?:be\s+)?(?:{_WEAKER})\b", re.IGNORECASE),
+    re.compile(r"\bunverified\b[^.]*\bbecause\b", re.IGNORECASE),
+    re.compile(rf"\bassumed\s+rather\s+than\s+(?:{_STRONGER})\b", re.IGNORECASE),
 )
 
 
@@ -185,6 +198,58 @@ def check_no_deferrals(data: dict) -> list[str]:
     return failures
 
 
+RULE_KINDS = ("testing", "style", "architecture", "process", "ci")
+RULE_SEVERITIES = ("MUST", "SHOULD")
+
+
+def _usable(entry: object) -> bool:
+    """A sources/globs element that actually names something.
+
+    `patterns_discovered.files` already validates its elements this way, so a
+    `sources: [null]` that certified the sweep was weaker than its own
+    neighbour. A source may be recorded as a bare path or as the
+    `{path, kind, summary}` object §1.2.5 specifies; both must name a path.
+    """
+    if isinstance(entry, dict):
+        return not _blank(entry.get("path"))
+    return not _blank(entry)
+
+
+def _binding_rule_failures(rules: object) -> list[str]:
+    """Validate `binding_rules` against the §1.2.5 RETURN FORMAT contract.
+
+    The contract fixes `kind` and `severity` to closed enums and requires the
+    rule text VERBATIM with its source. `applies_to` is required to be present
+    and non-blank but its value is NOT held to the contract's code/tests/both:
+    real artifacts scope rules to other audiences (`agents`), and rejecting
+    those would fail the sweep over a vocabulary gap in the contract rather
+    than over an unauditable record.
+    """
+    if rules is None:
+        return []
+    if not isinstance(rules, list):
+        return [f"standards sweep malformed: `binding_rules` is not a list -- {rules!r}"]
+    failures = []
+    for index, rule in enumerate(rules, start=1):
+        if not isinstance(rule, dict):
+            failures.append(f"binding rule {index}: not an object")
+            continue
+        for field in ("rule", "context", "source_path", "applies_to"):
+            if _blank(rule.get(field)):
+                failures.append(f"binding rule {index}: field missing or blank -- {field}")
+        if rule.get("kind") not in RULE_KINDS:
+            failures.append(
+                f"binding rule {index}: kind not one of "
+                f"{'/'.join(RULE_KINDS)} -- {rule.get('kind')!r}"
+            )
+        if rule.get("severity") not in RULE_SEVERITIES:
+            failures.append(
+                f"binding rule {index}: severity not one of "
+                f"{'/'.join(RULE_SEVERITIES)} -- {rule.get('severity')!r}"
+            )
+    return failures
+
+
 def check_standards_sweep_recorded(data: dict) -> list[str]:
     """The §1.2.5 governance sweep result is present and auditable."""
     standards = data.get("project_standards")
@@ -192,15 +257,22 @@ def check_standards_sweep_recorded(data: dict) -> list[str]:
         return ["standards sweep unrecorded: `project_standards` object missing"]
     if standards.get("searched") is not True:
         return [f"standards sweep not recorded as run (searched: {standards.get('searched')!r})"]
+    rule_failures = _binding_rule_failures(standards.get("binding_rules"))
     sources = standards.get("sources")
-    if isinstance(sources, list) and sources:
-        return []
+    if isinstance(sources, list) and [s for s in sources if _usable(s)]:
+        return rule_failures
     globs = standards.get("search_globs_used")
-    if standards.get("none_found") is True and isinstance(globs, list) and globs:
-        return []
-    return [
-        "standards sweep result unauditable: needs a non-empty `sources`, or "
-        "`none_found: true` together with a non-empty `search_globs_used`"
+    if (
+        standards.get("none_found") is True
+        and isinstance(globs, list)
+        and [g for g in globs if _usable(g)]
+    ):
+        return rule_failures
+    return rule_failures + [
+        (
+            "standards sweep result unauditable: needs a non-empty `sources`, or "
+            "`none_found: true` together with a non-empty `search_globs_used`"
+        )
     ]
 
 
@@ -294,13 +366,10 @@ def _without_verbatim_quotes(data: dict) -> dict:
 def advise_tooling_blockers(data: dict) -> list[str]:
     """Point at blocker-shaped prose the `tooling` record does not account for.
 
-    ADVISORY, not blocking. Re-measured against the research artifacts on this
-    machine, every line the patterns flag is a finding rather than a blocker --
-    "nvidia-smi is not on PATH" cited as evidence that the hardware is absent,
-    and a survey of which libraries are not installed and what would install
-    them. A non-zero false-positive rate on real material may not decide a
-    gate, so this warns and the mandatory record blocks. The reported session
-    is still caught: it carried no `tooling` record at all.
+    ADVISORY, not blocking. The patterns read prose, and prose about tools is
+    ambiguous in a way a gate should not arbitrate, so this warns and the
+    mandatory `tooling` record blocks. The reported session is still caught by
+    the record: it carried none at all.
     """
     _, names = _tooling_record_failures(data.get("tooling"))
     accounted = [re.compile(rf"\b{re.escape(name)}\b", re.IGNORECASE) for name in names]

--- a/scripts/check_research_quality.py
+++ b/scripts/check_research_quality.py
@@ -38,6 +38,32 @@ DEFERRAL_PATTERNS = (
 
 PLACEHOLDER = re.compile(r"^\s*(\[\s*(\.\.\.|)\s*\]|\.\.\.)\s*$")
 
+TOOL_RESOLUTIONS = (
+    "installed",
+    "installation_proposed",
+    "operator_declined",
+    "alternative_found",
+)
+
+# Every pattern is anchored to a token that only a TOOL invocation produces.
+# The bare vocabulary of unavailability -- "not available", "unavailable",
+# "is missing", "couldn't find" -- is deliberately absent: those words carry no
+# tooling signal, and "the config option is not available in v2" is a finding,
+# not a blocker. "not installed" is admitted only alongside an installer or
+# PATH token on the same line, which is what separates "ripgrep was not
+# installed, so brew install ripgrep" from "not installed into site-packages".
+_INSTALLER = r"brew|apt|apt-get|yum|dnf|pacman|pip|pipx|uv|npm|pnpm|yarn|cargo|gem|go get|winget|choco|nix-env|asdf|mise"
+TOOLING_BLOCKER_PATTERNS = (
+    re.compile(r"[\w.+-]{2,}\s*:\s*command not found", re.IGNORECASE),
+    re.compile(r"command not found\s*:\s*[\w.+-]{2,}", re.IGNORECASE),
+    re.compile(r"no such command\s*:\s*[\w.+-]{2,}", re.IGNORECASE),
+    re.compile(r"is not recognized as an internal or external command", re.IGNORECASE),
+    re.compile(r"executable (?:file )?not found", re.IGNORECASE),
+    re.compile(r"not (?:on|in|found on|found in) (?:the |your )?PATH\b"),
+    re.compile(rf"(?:is|was|are|were|it)?\s*not installed\b.*\b(?:{_INSTALLER})\b", re.IGNORECASE),
+    re.compile(rf"\b(?:{_INSTALLER})\b.*\bnot installed\b", re.IGNORECASE),
+)
+
 
 def _blank(value: object) -> bool:
     return not isinstance(value, str) or not value.strip() or bool(PLACEHOLDER.match(value))
@@ -178,6 +204,88 @@ def check_standards_sweep_recorded(data: dict) -> list[str]:
     ]
 
 
+def _tooling_record_failures(tooling: object) -> tuple[list[str], list[str]]:
+    """Validate the `tooling` record. Returns (failures, names of missing tools)."""
+    if not isinstance(tooling, dict):
+        return ["tooling blockers unrecorded: `tooling` object missing"], []
+    if tooling.get("checked") is not True:
+        return [f"tooling sweep not recorded as run (checked: {tooling.get('checked')!r})"], []
+
+    entries = tooling.get("missing")
+    if not isinstance(entries, list):
+        entries = []
+    if not entries:
+        if tooling.get("none_missing") is True:
+            return [], []
+        return [
+            "tooling result unauditable: needs a non-empty `missing` list, or "
+            "`none_missing: true` when no tool was missing"
+        ], []
+
+    failures = []
+    names = []
+    for index, entry in enumerate(entries, start=1):
+        if not isinstance(entry, dict):
+            failures.append(f"missing tool {index}: not an object")
+            continue
+        tool = entry.get("tool")
+        if _blank(tool):
+            failures.append(f"missing tool {index}: field missing or blank -- tool")
+        else:
+            names.append(tool.strip())
+        if _blank(entry.get("detail")):
+            failures.append(f"missing tool {index}: field missing or blank -- detail")
+        resolution = entry.get("resolution")
+        if resolution not in TOOL_RESOLUTIONS:
+            failures.append(
+                f"missing tool {index}: resolution not one of "
+                f"{'/'.join(TOOL_RESOLUTIONS)} -- {resolution!r}"
+            )
+        elif resolution == "alternative_found" and _blank(entry.get("alternative")):
+            failures.append(
+                f"missing tool {index}: resolution alternative_found must name "
+                f"the alternative -- alternative"
+            )
+    return failures, names
+
+
+def check_tooling_blockers_resolved(data: dict) -> list[str]:
+    """A tool that was missing is installed or escalated, never designed around.
+
+    `rules/60-autonomy.md` already requires this. The rule was not followed, so
+    this is its mechanical form: the record is mandatory, which is what blocks
+    a session that hit a missing tool and stayed silent about it.
+    """
+    return _tooling_record_failures(data.get("tooling"))[0]
+
+
+def advise_tooling_blockers(data: dict) -> list[str]:
+    """Point at blocker-shaped prose the `tooling` record does not account for.
+
+    ADVISORY, not blocking. Measured against the research artifacts on this
+    machine the patterns flagged two lines, of which one -- "nvidia-smi is not
+    on PATH", cited as evidence that the hardware is absent -- is a finding
+    rather than a blocker. A non-zero false-positive rate on real material may
+    not decide a gate, so this warns and the mandatory record blocks. The
+    reported session is still caught: it carried no `tooling` record at all.
+    """
+    _, names = _tooling_record_failures(data.get("tooling"))
+    accounted = [re.compile(rf"\b{re.escape(name)}\b", re.IGNORECASE) for name in names]
+
+    advisories = []
+    text = json.dumps(data, indent=2)
+    for number, line in enumerate(text.splitlines(), start=1):
+        if not any(pattern.search(line) for pattern in TOOLING_BLOCKER_PATTERNS):
+            continue
+        if any(pattern.search(line) for pattern in accounted):
+            continue
+        advisories.append(
+            f"possible tooling blocker on line {number}, absent from the "
+            f"`tooling` record: {line.strip()}"
+        )
+    return advisories
+
+
 CHECKS = (
     ("schema-shape", check_schema_shape),
     ("finding-fields", check_finding_fields),
@@ -186,7 +294,11 @@ CHECKS = (
     ("patterns-sourced", check_patterns_sourced),
     ("no-deferrals", check_no_deferrals),
     ("standards-sweep-recorded", check_standards_sweep_recorded),
+    ("tooling-blockers-resolved", check_tooling_blockers_resolved),
 )
+
+# Warnings only: printed, never scored, never part of the exit status.
+ADVISORIES = (("tooling-blockers-mentioned", advise_tooling_blockers),)
 
 
 def run_checks(data: dict) -> list[tuple[str, list[str]]]:
@@ -218,6 +330,11 @@ def main(argv: list[str] | None = None) -> int:
         for failure in failures:
             print(f"        {failure}")
         failed += bool(failures)
+
+    for name, advisories in ((name, advise(data)) for name, advise in ADVISORIES):
+        for advisory in advisories:
+            print(f"WARN  {name}")
+            print(f"        {advisory}")
 
     print(f"\n{len(results) - failed}/{len(results)} mechanical checks passed")
     if failed:

--- a/tests/scripts/test_check_research_quality.py
+++ b/tests/scripts/test_check_research_quality.py
@@ -376,3 +376,108 @@ def test_a_non_list_missing_is_rejected_rather_than_coerced_to_empty():
     broken = copy.deepcopy(COMPLETE)
     broken["tooling"] = {"checked": True, "none_missing": True, "missing": "hg"}
     assert any("`missing` is not a list" in f for f in failures_for(broken, "tooling-blockers-resolved"))
+
+
+def test_a_finding_downgraded_because_a_tool_was_absent_is_advised():
+    """The reported shape: absence, no install, and findings weakened because of it.
+
+    `probe-mlx-metal.json` carries this verbatim and the tool-absence patterns
+    miss it -- the sentence names no installer, so it reads as ordinary prose.
+    """
+    artifact = copy.deepcopy(COMPLETE)
+    artifact["findings"][0]["answer"] = (
+        "mlx-lm is not installed locally, so this is source reading, "
+        "not runtime verification."
+    )
+    assert any("runtime verification" in a for a in advisories_for(artifact))
+
+
+@pytest.mark.parametrize(
+    "prose",
+    [
+        "Could not verify the flag's effect: the harness has no fixture for it.",
+        "The throughput figure is unverified because nothing ran the benchmark.",
+        "The ordering is assumed rather than measured.",
+        "Findings are not runtime-verified.",
+    ],
+)
+def test_each_self_downgrade_phrasing_is_advised(prose):
+    artifact = copy.deepcopy(COMPLETE)
+    artifact["findings"][0]["answer"] = prose
+    assert advisories_for(artifact)
+
+
+@pytest.mark.parametrize(
+    "prose",
+    [
+        (
+            "NOT installed, but available as a bottled Homebrew formula. "
+            "`brew list --formula` returned only mlx. Nothing was installed."
+        ),
+        (
+            "NO. Confirmed, not assumed. nvidia-smi is not on PATH. "
+            "SPDisplaysDataType lists exactly one GPU, the built-in Apple M4 Pro."
+        ),
+    ],
+)
+def test_a_survey_of_what_is_on_the_machine_is_not_advised(prose):
+    """A survey reports the machine's state; it does not weaken its own answer."""
+    artifact = copy.deepcopy(COMPLETE)
+    artifact["findings"][0]["answer"] = prose
+    assert not advisories_for(artifact)
+
+
+def test_standards_sources_holding_only_blank_elements_is_rejected():
+    for element in (None, "", {}, {"path": "   "}):
+        broken = copy.deepcopy(COMPLETE)
+        broken["project_standards"]["sources"] = [element]
+        assert failures_for(broken, "standards-sweep-recorded"), element
+
+
+def test_empty_sweep_globs_holding_only_blank_elements_is_rejected():
+    broken = copy.deepcopy(COMPLETE)
+    broken["project_standards"]["sources"] = []
+    broken["project_standards"]["none_found"] = True
+    broken["project_standards"]["search_globs_used"] = [None]
+    assert failures_for(broken, "standards-sweep-recorded")
+
+
+def _rule(**overrides) -> dict:
+    rule = {
+        "rule": "Tests MUST run through the public entry point.",
+        "context": "Testing section of AGENTS.md.",
+        "source_path": "AGENTS.md",
+        "kind": "testing",
+        "severity": "MUST",
+        "applies_to": "tests",
+    }
+    rule.update(overrides)
+    return rule
+
+
+def test_a_well_formed_binding_rule_passes():
+    repaired = copy.deepcopy(COMPLETE)
+    repaired["project_standards"]["binding_rules"] = [_rule()]
+    assert not failures_for(repaired, "standards-sweep-recorded")
+
+
+@pytest.mark.parametrize(
+    "rule,marker",
+    [
+        (_rule(rule=""), "rule"),
+        (_rule(source_path=None), "source_path"),
+        (_rule(severity="CRITICAL"), "severity"),
+        (_rule(kind="vibes"), "kind"),
+        ("AGENTS.md says tests must run headless", "not an object"),
+    ],
+)
+def test_a_binding_rule_off_the_contract_is_rejected(rule, marker):
+    broken = copy.deepcopy(COMPLETE)
+    broken["project_standards"]["binding_rules"] = [rule]
+    assert any(marker in f for f in failures_for(broken, "standards-sweep-recorded"))
+
+
+def test_binding_rules_that_is_not_a_list_is_rejected():
+    broken = copy.deepcopy(COMPLETE)
+    broken["project_standards"]["binding_rules"] = {"rule": "tests MUST pass"}
+    assert any("binding_rules" in f for f in failures_for(broken, "standards-sweep-recorded"))

--- a/tests/scripts/test_check_research_quality.py
+++ b/tests/scripts/test_check_research_quality.py
@@ -61,6 +61,11 @@ COMPLETE = {
         "sources": [{"path": "AGENTS.md", "kind": "process", "summary": "run pytest"}],
         "binding_rules": [],
     },
+    "tooling": {
+        "checked": True,
+        "none_missing": True,
+        "missing": [],
+    },
 }
 
 
@@ -192,3 +197,143 @@ def test_no_percentage_is_printed(tmp_path, capsys):
     path.write_text(json.dumps(COMPLETE), encoding="utf-8")
     checker.main([str(path)])
     assert "%" not in capsys.readouterr().out
+
+
+def blocked_session() -> dict:
+    """The reported session: `hg: command not found`, then design around it."""
+    broken = copy.deepcopy(COMPLETE)
+    del broken["tooling"]
+    broken["findings"][0]["answer"] = (
+        "Could not compare against the upstream history: hg: command not found, "
+        "so the design assumes a git-only workflow."
+    )
+    return broken
+
+
+def test_missing_tool_mentioned_without_a_tooling_record_is_rejected():
+    failures = failures_for(blocked_session(), "tooling-blockers-resolved")
+    assert any("`tooling` object missing" in f for f in failures)
+
+
+def test_the_blocked_session_is_advised_on_the_line_that_names_the_tool():
+    advisories = dict(
+        (name, advise(blocked_session())) for name, advise in checker.ADVISORIES
+    )["tooling-blockers-mentioned"]
+    assert any("command not found" in a for a in advisories)
+
+
+def test_the_detector_is_advisory_and_does_not_change_exit_status(tmp_path, capsys):
+    artifact = copy.deepcopy(COMPLETE)
+    artifact["findings"][0]["answer"] = "The probe reported: hg: command not found."
+    path = tmp_path / "advisory.json"
+    path.write_text(json.dumps(artifact), encoding="utf-8")
+    assert checker.main([str(path)]) == 0
+    out = capsys.readouterr().out
+    assert "WARN  tooling-blockers-mentioned" in out
+    assert "Phase 1 gate: BLOCKED" not in out
+
+
+def test_tooling_record_missing_is_rejected_even_with_no_blocker_prose():
+    broken = copy.deepcopy(COMPLETE)
+    del broken["tooling"]
+    assert failures_for(broken, "tooling-blockers-resolved")
+
+
+def test_tooling_not_checked_is_rejected():
+    broken = copy.deepcopy(COMPLETE)
+    broken["tooling"]["checked"] = False
+    assert any("not recorded as run" in f for f in failures_for(broken, "tooling-blockers-resolved"))
+
+
+def test_nothing_missing_needs_the_affirmative_none_missing_branch():
+    broken = copy.deepcopy(COMPLETE)
+    broken["tooling"]["none_missing"] = False
+    assert failures_for(broken, "tooling-blockers-resolved")
+
+
+@pytest.mark.parametrize(
+    "resolution,extra",
+    [
+        ("installed", {}),
+        ("installation_proposed", {}),
+        ("operator_declined", {}),
+        ("alternative_found", {"alternative": "git-remote-hg"}),
+    ],
+)
+def test_each_accepted_resolution_passes(resolution, extra):
+    repaired = copy.deepcopy(COMPLETE)
+    repaired["findings"][0]["answer"] = "hg: command not found, so mercurial was installed."
+    repaired["tooling"] = {
+        "checked": True,
+        "none_missing": False,
+        "missing": [
+            {"tool": "hg", "resolution": resolution, "detail": "brew install mercurial", **extra}
+        ],
+    }
+    assert not failures_for(repaired, "tooling-blockers-resolved")
+
+
+def test_designed_around_is_not_an_accepted_resolution():
+    broken = copy.deepcopy(COMPLETE)
+    broken["tooling"] = {
+        "checked": True,
+        "none_missing": False,
+        "missing": [{"tool": "hg", "resolution": "designed_around", "detail": "used git only"}],
+    }
+    assert any("resolution not one of" in f for f in failures_for(broken, "tooling-blockers-resolved"))
+
+
+def test_alternative_found_must_name_the_alternative():
+    broken = copy.deepcopy(COMPLETE)
+    broken["tooling"] = {
+        "checked": True,
+        "none_missing": False,
+        "missing": [{"tool": "hg", "resolution": "alternative_found", "detail": "used a plugin"}],
+    }
+    assert any("alternative" in f for f in failures_for(broken, "tooling-blockers-resolved"))
+
+
+def test_missing_entry_needs_a_named_tool_and_detail():
+    broken = copy.deepcopy(COMPLETE)
+    broken["tooling"] = {
+        "checked": True,
+        "none_missing": False,
+        "missing": [{"tool": "   ", "resolution": "installed", "detail": ""}],
+    }
+    failures = failures_for(broken, "tooling-blockers-resolved")
+    assert any("tool" in f for f in failures)
+    assert any("detail" in f for f in failures)
+
+
+def advisories_for(data: dict) -> list[str]:
+    return dict((n, a(data)) for n, a in checker.ADVISORIES)["tooling-blockers-mentioned"]
+
+
+def test_blocker_prose_is_accepted_once_the_tooling_record_accounts_for_it():
+    repaired = copy.deepcopy(COMPLETE)
+    repaired["findings"][0]["answer"] = "ripgrep was not installed; installed it with brew."
+    repaired["tooling"] = {
+        "checked": True,
+        "none_missing": False,
+        "missing": [{"tool": "ripgrep", "resolution": "installed", "detail": "brew install ripgrep"}],
+    }
+    assert not failures_for(repaired, "tooling-blockers-resolved")
+    assert not advisories_for(repaired)
+
+
+@pytest.mark.parametrize(
+    "prose",
+    [
+        "The `strict` config option is not available in v2 of the parser.",
+        "The upstream mirror is currently unavailable, per the status page.",
+        "The `retries` field is missing from the serialized payload.",
+        "We couldn't find any caller of this helper outside the tests.",
+        "No such command exists in the CLI's public surface, per docs/cli.md.",
+        "The vendored copy is not installed into site-packages by the build.",
+    ],
+)
+def test_prose_findings_are_not_read_as_tooling_blockers(prose):
+    """Legitimate findings that use blocker-shaped words are not flagged."""
+    artifact = copy.deepcopy(COMPLETE)
+    artifact["findings"][0]["answer"] = prose
+    assert not advisories_for(artifact)

--- a/tests/scripts/test_check_research_quality.py
+++ b/tests/scripts/test_check_research_quality.py
@@ -337,3 +337,42 @@ def test_prose_findings_are_not_read_as_tooling_blockers(prose):
     artifact = copy.deepcopy(COMPLETE)
     artifact["findings"][0]["answer"] = prose
     assert not advisories_for(artifact)
+
+
+def test_a_governance_rule_quoted_verbatim_is_not_read_as_this_session_blocker():
+    """`binding_rules[].rule` is someone else's words, not a session report.
+
+    `rules/60-autonomy.md` states the self-unblocking rule by quoting a shell
+    error, so a session that records that rule faithfully was being advised
+    about its own correct quotation of the rule this check enforces.
+    """
+    artifact = copy.deepcopy(COMPLETE)
+    artifact["project_standards"]["binding_rules"] = [
+        {
+            "rule": "Missing system tool (`hg: command not found`) -> install it "
+            "(`brew install mercurial`)",
+            "context": "Self-unblocking before declaring constraints; also `hg: command not found`.",
+            "source_path": "rules/60-autonomy.md",
+            "kind": "process",
+            "severity": "MUST",
+            "applies_to": "agents",
+        }
+    ]
+    assert not advisories_for(artifact)
+    assert not failures_for(artifact, "tooling-blockers-resolved")
+
+
+def test_a_blocker_elsewhere_in_project_standards_is_still_advised():
+    """The exclusion is the verbatim-quote fields, not the whole subtree."""
+    artifact = copy.deepcopy(COMPLETE)
+    artifact["project_standards"]["sources"] = [
+        {"path": "AGENTS.md", "kind": "process", "summary": "Could not read it: bat: command not found."}
+    ]
+    assert any("command not found" in a for a in advisories_for(artifact))
+
+
+def test_a_non_list_missing_is_rejected_rather_than_coerced_to_empty():
+    """A malformed `missing` must not pass as an audited nothing-found result."""
+    broken = copy.deepcopy(COMPLETE)
+    broken["tooling"] = {"checked": True, "none_missing": True, "missing": "hg"}
+    assert any("`missing` is not a list" in f for f in failures_for(broken, "tooling-blockers-resolved"))


### PR DESCRIPTION
## What does this PR do?

Mechanizes a rule that already existed and was not followed.

A develop research session hit a missing tool and concluded it could not proceed, then
designed around the absence. `rules/60-autonomy.md:33` already says to install it. The rule
was fine; nothing checked it. So this adds a check rather than another paragraph — the
corpus was just measured to hold 16 claims asserting an invariant that nothing enforces,
and restating this one would have made 17.

**A blocking record.** `scripts/check_research_quality.py` gains
`tooling-blockers-resolved`, requiring a `tooling` object shaped like the existing
`project_standards` check: an affirmative "I looked" flag, plus an auditable nothing-found
branch. Each missing tool needs a `resolution` from a closed enum — installed, installation
proposed, operator declined, or a named alternative. **`designed_around` is deliberately
not in the enum.** `alternative_found` additionally requires naming the alternative, so a
workaround cannot be a bare assertion.

**An advisory detector.** Patterns anchored to tokens only a tool invocation produces —
`command not found`, `executable not found`, `not on PATH`, and `not installed` only when an
installer token appears on the same line. Candidate patterns carrying no tooling signal
(`not available`, `unavailable`, `is missing`, `couldn't find`) were dropped and are pinned
as must-not-flag tests, because "the `strict` config option is not available in v2" is a
finding, not a blocker.

**Why the detector is advisory and the record is blocking.** Measured against real research
artifacts: 6 files, 1,633 rendered lines, 2 flagged. One is a true positive — the reported
session, verbatim: "NOT installed, but both are available as bottled Homebrew formulae…
Nothing was installed." The other is a false positive: `nvidia-smi is not on PATH`, cited as
evidence that no discrete GPU exists, where installing it would not help. A non-zero
false-positive rate may not decide a gate, and a noisy gate gets muted. Nothing is lost —
the reported session carried no `tooling` record at all, so the blocking half rejects it and
the advisory names the line.

**Delivery.** The instruction is recited in the `feature-research` dispatch template, not
only left ambient. This repo has the measurement for why: the same carried-figure rule
caught six errors when re-pasted verbatim into every dispatch and failed seven times as an
always-loaded rule. `rules/60-autonomy.md` is cited, not restated, and is unmodified.

## Known limits

- Every existing research artifact now fails the gate — 6 of 6 lack a `tooling` key,
  exactly as they lacked `project_standards` when that check landed. New artifacts get it
  from the template. Whether old ones are backfilled is undecided.
- The record's truthfulness is self-reported. The gate checks its shape, not its accuracy.
- Only the `feature-research` template recites the line. A research path entered from
  `feature-discover` or `advanced-code-review-context` gets the ambient rule only — the
  same delivery-channel gap this PR exists to close, in adjacent entry points.

## Related issue

None.

## Checklist

- [x] Tests pass locally — 1917 passed, 2 skipped
- [x] Documentation updated (if applicable) — `docs/` mirror regenerated and the new line
      verified present at `docs/commands/feature-research.md:102`, not merely a clean exit
