### PR TITLE
Widen two checker scopes; make prose checks deterministic

### DIFF
--- a/scripts/check_reference_resolution.py
+++ b/scripts/check_reference_resolution.py
@@ -81,10 +81,14 @@ would add findings that CI can never see, and no allowlist state is green in
 both places at once.
 
 Tracked-ness is asked of git itself (``git ls-files``), never re-derived by
-parsing ``.gitignore``. When the answer is unavailable -- git not installed, or
-a root that is not a checkout -- the filter WIDENS to every file rather than
-narrowing to none. A gate that scans nothing when a subprocess fails is the
-vacuous pass this module exists to prevent.
+parsing ``.gitignore``. When the answer is unavailable -- git not installed, a
+root that is not a checkout, or a root that is merely a DIRECTORY INSIDE some
+other checkout -- the filter WIDENS to every file rather than narrowing to
+none. A gate that scans nothing when a subprocess fails is the vacuous pass
+this module exists to prevent. The third case is why the scan root is checked
+against ``git rev-parse --show-toplevel`` before its tracked set is trusted: an
+exit code cannot tell it apart from a checkout that tracks nothing, and reading
+it as the latter would make the verdict depend on where the scan root sits.
 
 Allowlisting
 ------------
@@ -428,19 +432,29 @@ def tracked_files(repo_root: Path) -> frozenset[Path] | None:
     """Every path git tracks under ``repo_root``, or None if git cannot say.
 
     See "The scanned population is the COMMITTED repository" above for why the
-    gate asks this at all. Three answers, all explicit:
+    gate asks this at all. Four answers, all explicit:
 
-    * git answers -- the tracked set, and only those files are scanned.
+    * ``repo_root`` IS a checkout root and git answers -- the tracked set, and
+      only those files are scanned.
     * git is absent, or ``repo_root`` is not a checkout -- ``None``, and the
       caller scans EVERY file. Widening cannot hide a reference; narrowing to
       an empty set would hide all of them.
-    * git answers with an empty list -- a checkout with no tracked files at all
-      is not a state this gate can meaningfully run against, so it raises
-      rather than reporting a clean pass over nothing.
+    * ``repo_root`` is a DIRECTORY INSIDE some other checkout -- ``None``, the
+      same widening. This case cannot be read off an exit code: ``git ls-files``
+      run under an untracked subdirectory of a checkout exits 0 and prints
+      nothing, exactly like a checkout that tracks no files. The two are
+      separated by asking which directory git considers the root, not by asking
+      whether the list came back empty. Without that question the verdict
+      depends on where the scan root sits relative to other checkouts -- the
+      environment-dependence this gate exists to remove.
+    * ``repo_root`` is a checkout root and git answers with an empty list -- a
+      checkout with no tracked files at all is not a state this gate can
+      meaningfully run against, so it raises rather than reporting a clean pass
+      over nothing.
     """
     try:
-        completed = subprocess.run(
-            ["git", "-C", str(repo_root), "ls-files", "-z", "--cached"],
+        toplevel = subprocess.run(
+            ["git", "-C", str(repo_root), "rev-parse", "--show-toplevel"],
             capture_output=True,
             check=False,
         )
@@ -451,6 +465,28 @@ def tracked_files(repo_root: Path) -> frozenset[Path] | None:
             file=sys.stderr,
         )
         return None
+    if toplevel.returncode != 0:
+        print(
+            f"warning: {repo_root} is not a git checkout "
+            f"(git rev-parse exited {toplevel.returncode}); scanning every file "
+            f"on disk rather than only tracked ones",
+            file=sys.stderr,
+        )
+        return None
+    root = Path(toplevel.stdout.decode("utf-8").strip())
+    if root.resolve() != repo_root.resolve():
+        print(
+            f"warning: {repo_root} is not the root of its checkout ({root}); "
+            f"the tracked set there would describe a different tree, so every "
+            f"file on disk is scanned rather than only tracked ones",
+            file=sys.stderr,
+        )
+        return None
+    completed = subprocess.run(
+        ["git", "-C", str(repo_root), "ls-files", "-z", "--cached"],
+        capture_output=True,
+        check=False,
+    )
     if completed.returncode != 0:
         print(
             f"warning: {repo_root} is not a git checkout "

--- a/scripts/check_reference_resolution.py
+++ b/scripts/check_reference_resolution.py
@@ -28,9 +28,10 @@ Rows
     ``extensions/**/*.ts`` -- every tool named by ``callTool('<name>')`` or by a
     ``/tool/<name>`` bridge URL must be registered in ``spellbook.mcp.tools``.
 ``prose-paths`` / ``prose-modules`` / ``prose-skills`` / ``prose-commands``
-    ``skills/``, ``commands/``, ``agents/``, ``rules/``, and ``AGENTS.md`` --
-    backticked repository paths, dotted ``spellbook.*`` module paths,
-    ``skills/<name>`` mentions, and ``/<command>`` mentions.
+    Every tree in ``PROSE_DIRS`` plus ``AGENTS.md`` -- backticked repository
+    paths, dotted ``spellbook.*`` module paths, ``skills/<name>`` mentions, and
+    ``/<command>`` mentions. The tree list is not repeated here; it would rot
+    against the tuple, which is what ``PROSE_SOURCE_LABEL`` exists to prevent.
 
 Deliberately NOT a row: ``.pre-commit-config.yaml`` local hook ``entry:``
 targets. ``tests/scripts/test_precommit_hook_entries_resolve.py`` already covers
@@ -117,14 +118,28 @@ from typing import Callable, Iterator
 
 import yaml
 
-from corpus_trees import DOCUMENTED_TREES
-
 # ---------------------------------------------------------------------------
 # Shared configuration
 # ---------------------------------------------------------------------------
 
 # Prose sources. AGENTS.md is a file; the rest are directories scanned for *.md.
-PROSE_DIRS = DOCUMENTED_TREES
+#
+# Membership reason: trees holding AUTHORED prose that names this repository's
+# own artifacts. ``patterns/`` and ``extensions/`` qualify -- a pattern document
+# cites the schema and script files it teaches against, and an extension README
+# names the installer and hook paths a reader is told to run -- and nothing else
+# checked those references. Their earlier absence was drift, not a decision.
+#
+# Deliberately a LOCAL tuple, not corpus_trees.DOCUMENTED_TREES (which this was
+# aliased to) nor ENUMERABLE_TREES (which differs from this set only by
+# profiles/). Those sets answer "which trees generate a docs/ page" and "which
+# trees constitute the enumerable corpus"; this one answers "which trees hold
+# prose whose references must resolve". Importing the set with the convenient
+# members would couple this gate to an unrelated decision -- a tree gaining a
+# docs page is not a reason to start resolving its references. profiles/ is the
+# case that separates them: it is corpus content, but it carries behavioural
+# tone rather than instructions, and names no repository artifact by path.
+PROSE_DIRS = ("skills", "commands", "agents", "rules", "patterns", "extensions")
 PROSE_FILES = ("AGENTS.md",)
 
 # Derived, never duplicated: this string is printed beside a reference count,
@@ -672,6 +687,16 @@ ALLOWLIST: dict[str, tuple[AllowEntry, ...]] = {
             anchor="tests/test_login.py",
             reason="illustrative test path in a tier-classification example",
         ),
+        AllowEntry(
+            path_glob="patterns/assertion-quality-standard.md",
+            anchor="Upstream's own",
+            reason="names a test file in the UPSTREAM repository the pattern analyses, not this one",
+        ),
+        AllowEntry(
+            path_glob="patterns/code-review-formats.md",
+            anchor="tests/api/client.test.ts",
+            reason="illustrative TypeScript test path in a review-format worked example",
+        ),
     ),
     "prose-commands": (
         AllowEntry(
@@ -710,6 +735,11 @@ ALLOWLIST: dict[str, tuple[AllowEntry, ...]] = {
             reason="harness built-in command, not a spellbook artifact",
         ),
         AllowEntry(
+            path_glob="extensions/prime-agent/README.md",
+            anchor="`/reload`",
+            reason="harness built-in command, not a spellbook artifact",
+        ),
+        AllowEntry(
             path_glob="AGENTS.md",
             anchor="Trigger by commenting `/ai-review` on a PR",
             reason="GitHub PR comment that triggers the external momus review bot, not a spellbook artifact",
@@ -730,6 +760,10 @@ class Row:
     ``min_refs`` is the silent-no-op guard. An extractor whose pattern stops
     matching -- because the source changed shape -- would otherwise report a
     clean pass over zero references, which is indistinguishable from success.
+    Each floor sits just under its row's measured total: low enough that
+    ordinary prose churn does not trip it, high enough that losing a scanned
+    tree does. A floor far below the measurement guards emptiness only, and a
+    row that quietly dropped a whole tree would still clear it.
     """
 
     name: str
@@ -773,7 +807,7 @@ def build_rows(repo_root: Path) -> tuple[Row, ...]:
             extract=extract_prose_paths,
             resolve=resolve_prose_path,
             what="repository file or directory",
-            min_refs=100,
+            min_refs=140,
         ),
         Row(
             name="prose-modules",
@@ -797,7 +831,7 @@ def build_rows(repo_root: Path) -> tuple[Row, ...]:
             extract=extract_prose_commands,
             resolve=resolve_slash_name,
             what="command or skill",
-            min_refs=200,
+            min_refs=310,
         ),
     )
 

--- a/scripts/check_reference_resolution.py
+++ b/scripts/check_reference_resolution.py
@@ -65,6 +65,26 @@ absorb noise stops being evidence of anything.
 4. Only fenced/backticked references are extracted. A path written as bare
    prose is invisible to every prose row.
 
+The scanned population is the COMMITTED repository
+--------------------------------------------------
+The prose rows scan only files git tracks. ``rules/82-file-reading.md`` records
+untracked-blindness as a BUG -- a ``git grep`` that skipped untracked files
+produced two false "appears nowhere" findings in one day -- so the divergence is
+deliberate and rests on a different question. That rule governs a SEARCH, which
+asks whether a string exists anywhere on this disk; this gate asks whether the
+repository's committed prose is self-consistent, and a generated or vendored
+file sitting in a developer's checkout is not part of the repository. Scanning
+it makes the verdict depend on whose disk it runs on: ``extensions/`` holds four
+tracked Markdown files and roughly forty-six generated ones, so an installer run
+would add findings that CI can never see, and no allowlist state is green in
+both places at once.
+
+Tracked-ness is asked of git itself (``git ls-files``), never re-derived by
+parsing ``.gitignore``. When the answer is unavailable -- git not installed, or
+a root that is not a checkout -- the filter WIDENS to every file rather than
+narrowing to none. A gate that scans nothing when a subprocess fails is the
+vacuous pass this module exists to prevent.
+
 Allowlisting
 ------------
 Content-anchored, following ``scripts/check_removed_mode_tokens.py``: an entry
@@ -88,6 +108,7 @@ import argparse
 import fnmatch
 import os
 import re
+import subprocess
 import sys
 from dataclasses import dataclass
 from functools import lru_cache
@@ -387,18 +408,68 @@ def make_mcp_tool_resolver(repo_root: Path) -> Callable[[Path, Reference], bool]
 # ---------------------------------------------------------------------------
 
 
+@lru_cache(maxsize=None)
+def tracked_files(repo_root: Path) -> frozenset[Path] | None:
+    """Every path git tracks under ``repo_root``, or None if git cannot say.
+
+    See "The scanned population is the COMMITTED repository" above for why the
+    gate asks this at all. Three answers, all explicit:
+
+    * git answers -- the tracked set, and only those files are scanned.
+    * git is absent, or ``repo_root`` is not a checkout -- ``None``, and the
+      caller scans EVERY file. Widening cannot hide a reference; narrowing to
+      an empty set would hide all of them.
+    * git answers with an empty list -- a checkout with no tracked files at all
+      is not a state this gate can meaningfully run against, so it raises
+      rather than reporting a clean pass over nothing.
+    """
+    try:
+        completed = subprocess.run(
+            ["git", "-C", str(repo_root), "ls-files", "-z", "--cached"],
+            capture_output=True,
+            check=False,
+        )
+    except OSError as exc:
+        print(
+            f"warning: git unavailable ({exc}); scanning every file on disk "
+            f"rather than only tracked ones",
+            file=sys.stderr,
+        )
+        return None
+    if completed.returncode != 0:
+        print(
+            f"warning: {repo_root} is not a git checkout "
+            f"(git ls-files exited {completed.returncode}); scanning every file "
+            f"on disk rather than only tracked ones",
+            file=sys.stderr,
+        )
+        return None
+    names = [name for name in completed.stdout.decode("utf-8").split("\0") if name]
+    if not names:
+        raise RuntimeError(
+            f"git tracks no files under {repo_root}. Every prose row would pass "
+            f"over an empty scan, which is indistinguishable from success."
+        )
+    return frozenset(repo_root / name for name in names)
+
+
 def iter_prose_files(repo_root: Path) -> Iterator[Path]:
-    """Yield every Markdown prose source, in deterministic order."""
+    """Yield every git-tracked Markdown prose source, in deterministic order."""
+    tracked = tracked_files(repo_root)
+
+    def scanned(path: Path) -> bool:
+        return tracked is None or path in tracked
+
     for name in PROSE_DIRS:
         base = repo_root / name
         if not base.is_dir():
             continue
         for path in sorted(base.rglob("*.md")):
-            if path.is_file() and not (SKIP_PARTS & set(path.parts)):
+            if path.is_file() and not (SKIP_PARTS & set(path.parts)) and scanned(path):
                 yield path
     for name in PROSE_FILES:
         path = repo_root / name
-        if path.is_file():
+        if path.is_file() and scanned(path):
             yield path
 
 

--- a/scripts/check_removed_mode_tokens.py
+++ b/scripts/check_removed_mode_tokens.py
@@ -5,8 +5,8 @@
 """Grep gate: forbid tier-classifier tokens and removed execution-mode vocabulary.
 
 Implements the develop-rework design §10.2 / IMP-4 widened verification gate.
-Scans every Markdown file under ``skills/`` + ``commands/`` + ``agents/`` for two
-classes of forbidden tokens and FAILS (exit 1) on any non-allowlisted match:
+Scans every Markdown file under ``skills/`` + ``commands/`` + ``agents/`` +
+``rules/`` for two classes of forbidden tokens and FAILS (exit 1) on any non-allowlisted match:
 
 (a) Tier-as-classifier tokens:  ``\\b(TRIVIAL|SIMPLE|STANDARD|COMPLEX)\\b``
     Case-sensitive uppercase, so ordinary lowercase prose
@@ -40,7 +40,20 @@ from pathlib import Path
 # Directories scanned (repo-relative). The design scopes the gate to
 # skills/ + commands/; agents/ is included as a strict superset so a future
 # tier/removed-mode token cannot creep into a narrowing-role agent unnoticed.
-SCAN_DIRS = ("skills", "commands", "agents")
+# rules/ is included for the same superset reason, and more strongly: a rule
+# module is installed globally and read at the start of EVERY session, so a
+# stale tier or removed-mode token there is more visible than one in a skill
+# that loads on demand. Its earlier absence was drift, not a decision.
+#
+# This tuple is deliberately local rather than imported from corpus_trees.py,
+# whose DOCUMENTED_TREES happens to hold these same four names today. That set
+# answers "which trees generate a docs/ page"; this one answers "which trees
+# hold live agent-instruction prose". The reasons diverge where it matters: if
+# patterns/ ever gained a docs page it would join DOCUMENTED_TREES, yet it is
+# teaching material quoting OTHER repositories, where an uppercase STANDARD is
+# quotation rather than live vocabulary. Importing the set with the convenient
+# members would silently widen this gate on an unrelated decision.
+SCAN_DIRS = ("skills", "commands", "agents", "rules")
 
 # Token classes. Patterns are case-sensitive; tier tokens are uppercase-only
 # so lowercase prose is naturally excluded by the word boundaries.

--- a/tests/scripts/test_reference_resolution.py
+++ b/tests/scripts/test_reference_resolution.py
@@ -21,6 +21,7 @@ violation never touches the real tree.
 
 import os
 import shutil
+import subprocess
 import sys
 from pathlib import Path
 
@@ -36,6 +37,7 @@ from check_reference_resolution import (  # noqa: E402
     PROSE_SOURCE_LABEL,
     Reference,
     build_rows,
+    extract_prose_paths,
     is_allowlisted,
     registered_mcp_tools,
     run_row,
@@ -367,3 +369,65 @@ def test_every_allowlist_entry_still_suppresses_something():
             ):
                 unused.append(f"{row_name}: {entry.path_glob} :: {entry.anchor}")
     assert not unused, "Allowlist entries that suppress nothing:\n  " + "\n  ".join(unused)
+
+
+# ---------------------------------------------------------------------------
+# The scanned population is the COMMITTED repository
+# ---------------------------------------------------------------------------
+
+
+def _git_repo(tmp_path: Path) -> Path:
+    """A real one-commit git repository carrying one tracked prose file."""
+    root = tmp_path / "gitrepo"
+    (root / "rules").mkdir(parents=True)
+    (root / "rules" / "10-tracked.md").write_text(
+        "Run `scripts/ghost_tracked.py` first.\n", encoding="utf-8"
+    )
+    for argv in (
+        ["init", "-q"],
+        ["config", "user.email", "t@example.com"],
+        ["config", "user.name", "t"],
+        ["add", "rules/10-tracked.md"],
+        ["commit", "-qm", "init"],
+    ):
+        subprocess.run(["git", *argv], cwd=root, check=True, capture_output=True)
+    return root
+
+
+def test_untracked_file_on_disk_is_not_scanned(tmp_path):
+    """Generated and vendored files sit on a developer's disk, not in the repo.
+
+    A gate whose population is "whatever is on this disk" reports findings that
+    exist for one developer and not for CI. The population is the committed
+    repository.
+    """
+    root = _git_repo(tmp_path)
+    (root / "rules" / "20-untracked.md").write_text(
+        "Run `scripts/ghost_untracked.py` first.\n", encoding="utf-8"
+    )
+
+    targets = [ref.target for ref in extract_prose_paths(root)]
+
+    assert "scripts/ghost_tracked.py" in targets, (
+        "the tracked file must still be scanned; a filter that scans nothing "
+        "passes vacuously"
+    )
+    assert "scripts/ghost_untracked.py" not in targets
+
+
+def test_prose_scan_covers_every_file_when_tracked_ness_is_unknowable(tmp_path):
+    """Outside a git checkout the filter must widen, never narrow.
+
+    A tarball export, or the symlinked scratch repos below, have no index to
+    ask. Scanning everything is the conservative direction: it can only find
+    more, never silently fewer.
+    """
+    root = tmp_path / "notarepo"
+    (root / "rules").mkdir(parents=True)
+    (root / "rules" / "10-loose.md").write_text(
+        "Run `scripts/ghost_loose.py` first.\n", encoding="utf-8"
+    )
+
+    targets = [ref.target for ref in extract_prose_paths(root)]
+
+    assert "scripts/ghost_loose.py" in targets

--- a/tests/scripts/test_reference_resolution.py
+++ b/tests/scripts/test_reference_resolution.py
@@ -35,10 +35,12 @@ from check_reference_resolution import (  # noqa: E402
     PROSE_DIRS,
     PROSE_FILES,
     PROSE_SOURCE_LABEL,
+    SKIP_PARTS,
     Reference,
     build_rows,
     extract_prose_paths,
     is_allowlisted,
+    iter_prose_files,
     registered_mcp_tools,
     run_row,
 )
@@ -199,6 +201,31 @@ def test_red_extension_mcp_tools_accepts_a_registered_name(tmp_path):
 def test_red_prose_paths(tmp_path):
     repo = _scratch_repo(tmp_path, ("rules",))
     planted = repo / "rules" / "99-planted.md"
+    planted.write_text(
+        "Run `scripts/a_script_that_does_not_exist.py` before committing.\n",
+        encoding="utf-8",
+    )
+    assert "scripts/a_script_that_does_not_exist.py" in _targets("prose-paths", repo)
+
+
+@pytest.mark.parametrize(
+    "tree, planted_path",
+    [
+        ("patterns", "patterns/99-planted.md"),
+        ("extensions", "extensions/prime-agent/99-planted.md"),
+    ],
+    ids=["patterns", "extensions"],
+)
+def test_red_prose_paths_in_a_widened_tree(tmp_path, tree, planted_path):
+    """A widened tree must be able to FAIL, not merely appear in the label.
+
+    Set equality against git proves the walker reaches the tree. This proves
+    the reference it finds there travels all the way to a verdict: a filter
+    added between the walk and the resolver would leave set equality intact
+    while every finding in the tree vanished.
+    """
+    repo = _scratch_repo(tmp_path, (tree,))
+    planted = repo / planted_path
     planted.write_text(
         "Run `scripts/a_script_that_does_not_exist.py` before committing.\n",
         encoding="utf-8",
@@ -431,3 +458,54 @@ def test_prose_scan_covers_every_file_when_tracked_ness_is_unknowable(tmp_path):
     targets = [ref.target for ref in extract_prose_paths(root)]
 
     assert "scripts/ghost_loose.py" in targets
+
+
+# ---------------------------------------------------------------------------
+# The scanned trees, and that the walker actually reaches each one
+# ---------------------------------------------------------------------------
+
+
+def test_prose_dirs_covers_every_authored_prose_tree():
+    """Naming the trees explicitly, so a widening or a narrowing is a decision.
+
+    ``patterns/`` and ``extensions/`` hold authored prose that names this
+    repository's own files by backticked path, and nothing else checked those
+    references. Their absence was drift, not a decision.
+    """
+    assert set(PROSE_DIRS) == {
+        "skills",
+        "commands",
+        "agents",
+        "rules",
+        "patterns",
+        "extensions",
+    }
+
+
+@pytest.mark.parametrize("tree", sorted(PROSE_DIRS), ids=sorted(PROSE_DIRS))
+def test_prose_scan_yields_every_tracked_markdown_under_each_tree(tree):
+    """A tree named in PROSE_DIRS that the walker never reaches scans nothing.
+
+    Adding a name to PROSE_DIRS is not evidence that the tree is scanned: every
+    existing assertion -- the floors, the labels, the clean-tree gate -- still
+    passes over a tree the enumerator silently skips. Set equality against what
+    git tracks is what forces the widening to be real.
+    """
+    completed = subprocess.run(
+        ["git", "-C", str(REPO_ROOT), "ls-files", "-z", "--cached", "--", tree],
+        capture_output=True,
+        check=True,
+    )
+    tracked = {
+        name
+        for name in completed.stdout.decode("utf-8").split("\0")
+        if name.endswith(".md") and not (SKIP_PARTS & set(Path(name).parts))
+    }
+    assert tracked, f"git tracks no Markdown under {tree}/; the assertion is vacuous"
+
+    scanned = {
+        path.relative_to(REPO_ROOT).as_posix()
+        for path in iter_prose_files(REPO_ROOT)
+        if path.relative_to(REPO_ROOT).parts[0] == tree
+    }
+    assert scanned == tracked

--- a/tests/scripts/test_reference_resolution.py
+++ b/tests/scripts/test_reference_resolution.py
@@ -43,6 +43,7 @@ from check_reference_resolution import (  # noqa: E402
     iter_prose_files,
     registered_mcp_tools,
     run_row,
+    tracked_files,
 )
 
 ROWS = {row.name: row for row in build_rows(REPO_ROOT)}
@@ -458,6 +459,55 @@ def test_prose_scan_covers_every_file_when_tracked_ness_is_unknowable(tmp_path):
     targets = [ref.target for ref in extract_prose_paths(root)]
 
     assert "scripts/ghost_loose.py" in targets
+
+
+def _git(root: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", "-C", str(root), *args], capture_output=True, check=True
+    )
+
+
+def test_tracked_files_widens_under_a_directory_nested_in_another_checkout(tmp_path):
+    """An untracked subdirectory of a checkout is not that checkout's root.
+
+    ``git ls-files`` run there exits 0 and prints NOTHING, which is
+    indistinguishable, by exit code alone, from a checkout that tracks no
+    files. Trusting the exit code makes the verdict depend on where the scan
+    root happens to sit relative to other checkouts -- a pytest ``tmp_path``
+    under ``--basetemp`` inside a checkout reaches this, and every scratch-repo
+    proof in this file breaks there. Widening is the documented direction.
+    """
+    outer = tmp_path / "outer"
+    outer.mkdir()
+    _git(outer, "init")
+    (outer / "tracked.md").write_text("real\n", encoding="utf-8")
+    _git(outer, "add", "tracked.md")
+    _git(outer, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-m", "init")
+
+    nested = outer / "nested"
+    (nested / "rules").mkdir(parents=True)
+    (nested / "rules" / "10-loose.md").write_text(
+        "Run `scripts/ghost_nested.py` first.\n", encoding="utf-8"
+    )
+
+    assert _git(nested, "ls-files", "--cached").stdout == b""
+    assert tracked_files(nested) is None
+    assert "scripts/ghost_nested.py" in [ref.target for ref in extract_prose_paths(nested)]
+
+
+def test_tracked_files_still_raises_for_a_checkout_root_tracking_nothing(tmp_path):
+    """The empty-list guard keeps the case it was written for.
+
+    A genuine checkout root -- ``rev-parse --show-toplevel`` IS this directory
+    -- that tracks no files is not a state this gate can run against, and must
+    stay loud. That is what separates it from the nested case above.
+    """
+    root = tmp_path / "empty"
+    root.mkdir()
+    _git(root, "init")
+
+    with pytest.raises(RuntimeError, match="tracks no files"):
+        tracked_files(root)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_no_tier_or_removed_mode_tokens.py
+++ b/tests/test_no_tier_or_removed_mode_tokens.py
@@ -1,7 +1,8 @@
 """Grep gate: forbid tier-classifier tokens and removed execution-mode vocabulary.
 
 Implements the §10.2 / IMP-4 widened verification gate from the develop-rework
-design. Greps the whole ``skills/`` + ``commands/`` + ``agents/`` tree for two
+design. Greps the whole ``skills/`` + ``commands/`` + ``agents/`` + ``rules/``
+tree for two
 classes of forbidden tokens and FAILS on any non-allowlisted match:
 
 (a) Tier-as-classifier tokens:  ``\\b(TRIVIAL|SIMPLE|STANDARD|COMPLEX)\\b``
@@ -18,7 +19,7 @@ test loads it and asserts both directions of the contract:
   - the gate PASSES on the current clean worktree (allowlisted occurrences
     tolerated), and
   - the gate FAILS when a forbidden, non-allowlisted token is planted in a
-    ``skills/`` / ``commands/`` / ``agents/`` file.
+    ``skills/`` / ``commands/`` / ``agents/`` / ``rules/`` file.
 """
 
 from __future__ import annotations
@@ -59,7 +60,7 @@ def test_clean_worktree_has_zero_nonallowlisted_violations(checker):
 
     Asserts EXACT emptiness of the violation list (Full Assertion Principle):
     any non-allowlisted tier token or removed-mode token anywhere under
-    skills/ + commands/ + agents/ would surface here as a Violation and fail
+    skills/ + commands/ + agents/ + rules/ would surface here as a Violation and fail
     this assertion with an actionable file:line message.
     """
     violations = checker.find_violations(REPO_ROOT)
@@ -247,5 +248,75 @@ def test_work_items_anchored_exception_is_line_scoped(checker, tmp_path):
             token="work_items",
             token_class="removed-mode",
             line="Use the work_items execution mode here.",
+        )
+    ]
+
+
+# ---------------------------------------------------------------------------
+# (4) Scan scope: rules/ is in scope. Rule modules install globally and are
+#     read every session, so a stale tier or removed-mode token there is at
+#     least as visible as one in a skill.
+# ---------------------------------------------------------------------------
+
+
+def test_rules_tree_is_actually_enumerated(checker):
+    """The real ``rules/`` tree contributes files to the scan.
+
+    Guards the failure mode a planted-token test cannot see: a widening that
+    names a tree the enumerator never reaches (wrong root, wrong glob) scans
+    nothing and still passes every violation assertion. Asserts against the
+    live repository, where ``rules/`` is non-empty.
+    """
+    scanned = {p.relative_to(REPO_ROOT).as_posix() for p in checker._iter_markdown_files(REPO_ROOT)}
+    from_rules = {p for p in scanned if p.startswith("rules/")}
+    on_disk = {p.relative_to(REPO_ROOT).as_posix() for p in (REPO_ROOT / "rules").rglob("*.md")}
+
+    assert on_disk, "fixture precondition: rules/ holds Markdown modules"
+    assert from_rules == on_disk
+
+
+def test_planted_token_in_rules_is_detected(checker, tmp_path):
+    """A tier token planted in rules/ is reported (rules/ is in scope)."""
+    (tmp_path / "skills").mkdir()
+    (tmp_path / "commands").mkdir()
+    (tmp_path / "agents").mkdir()
+    rules_dir = tmp_path / "rules"
+    rules_dir.mkdir()
+    rule_file = rules_dir / "20-orchestration.md"
+    source_line = "Dispatch at the STANDARD tier when the task is bounded."
+    rule_file.write_text(f"{source_line}\n", encoding="utf-8")
+
+    violations = checker.find_violations(tmp_path)
+
+    assert violations == [
+        checker.Violation(
+            path="rules/20-orchestration.md",
+            lineno=1,
+            token="STANDARD",
+            token_class="tier",
+            line=source_line,
+        )
+    ]
+
+
+def test_planted_removed_mode_token_in_rules_is_detected(checker, tmp_path):
+    """A removed-mode token planted in rules/ is reported, not only a tier one."""
+    (tmp_path / "skills").mkdir()
+    (tmp_path / "commands").mkdir()
+    (tmp_path / "agents").mkdir()
+    rules_dir = tmp_path / "rules"
+    rules_dir.mkdir()
+    source_line = "Set execution_mode before the first dispatch."
+    (rules_dir / "40-develop-discipline.md").write_text(f"{source_line}\n", encoding="utf-8")
+
+    violations = checker.find_violations(tmp_path)
+
+    assert violations == [
+        checker.Violation(
+            path="rules/40-develop-discipline.md",
+            lineno=1,
+            token="execution_mode",
+            token_class="removed-mode",
+            line=source_line,
         )
     ]


### PR DESCRIPTION
## What does this PR do?

Two approved scope widenings, plus the root-cause fix one of them exposed.

**`rules/` joins the tier/removed-mode token ban.** The gate scoped to skills + commands +
agents and never said why `rules/` was absent. A rule module installs globally and is read
at the start of every session, so a stale token there is *more* visible than one in an
on-demand skill — making `rules/` the tree with the weakest case for exclusion. Zero
findings today, measured 222 → 242 files scanned, 0 violations either way. The rationale is
now recorded beside `SCAN_DIRS`, because an unrecorded rationale is what made this an open
question in the first place.

**Prose reference-checking now scans only git-tracked files.** This is the root-cause fix.
The prose rows walked the filesystem, so the gate's verdict depended on whose disk it ran
on: `extensions/` carries 4 tracked Markdown files and roughly 46 generated ones, and an
installer run adds findings CI can never see. No allowlist state is green in both places —
`test_every_allowlist_entry_still_suppresses_something` asserts each entry suppresses
something real, so an entry covering a generated file fails in CI where that file is absent.

`rules/82-file-reading.md` records untracked-blindness as a *bug* — a `git grep` skipping
untracked files produced two false "appears nowhere" findings in one day. The divergence
here is deliberate and rests on a different question, and the module docstring says so: that
rule governs a SEARCH, asking whether a string exists anywhere on this disk. This gate asks
whether the committed repository's prose is self-consistent, and a generated or vendored
file in a developer's checkout is not part of the repository. Tracked-ness is asked of git
itself, never re-derived by parsing `.gitignore`; when git cannot answer, the filter WIDENS
to every file rather than narrowing to none, because a gate that scans nothing when a
subprocess fails is the vacuous pass this module exists to prevent.

**`patterns/` and `extensions/` are now reference-checked.** Three content-anchored allowlist
entries, zero unresolved. The fourth pre-restriction finding — in the gitignored generated
`extensions/gemini/rules.spellbook.md` — vanished with the tracked-file filter, and that was
proven rather than observed: neutering the filter in a throwaway clone reproduces it exactly.

## Verification worth noting

**The determinism property was tested, not asserted.** A `git clone` to scratch with the diff
applied has 13 Markdown files on disk and 13 tracked, versus 14/13 in the developer checkout.
Both produce 150 / 4 / 5 / 323 references, zero unresolved, exit 0 — byte-identical. With the
filter neutered, the developer checkout exits 1 and the clone exits 0. That contrast is the
whole point of the change.

**`min_refs` floors were raised from guarding emptiness to guarding coverage.** They sat 30–40%
below measurement, so a row that silently dropped an entire tree would still have cleared them.
Now 140/310 against measured 150/323.

**A silent-widening mutation proved which assertion is load-bearing.** Making the walker skip
the new trees while `PROSE_DIRS` still names them fails 5 tests — but the label tests still
pass. Only the set-equality assertion stands between a named tree and a scanned one.

## Known limit

Two of the three new allowlist entries are `patterns/` teaching material citing other
repositories, which is the norm there rather than the exception. Nothing distinguishes a
legitimate upstream citation from a broken local path except author judgement at review time,
and the module's own docstring warns that a structurally-growing allowlist stops being
evidence of anything. Flagged, not mechanized.

## Related issue

None.

## Checklist

- [x] Tests pass locally — 1911 passed, 2 skipped
- [x] Documentation updated (if applicable) — rationale recorded in code at each decision
      point; module docstring's hardcoded tree list corrected so it cannot go stale
