### PR TITLE
Defer the repo-root walk on case mismatch; drop sys.path inserts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `tests/test_path_utils.py::TestResolveRepoRootMapping` rather than described,
   and the fallback in `scripts/develop_gate_ledger.py` still shells out and is
   held against it as a standing differential.
+  Within that filesystem read, a path whose case differs from the disk's
+  spelling now defers to git rather than being answered with the caller's
+  spelling. Because the result is a storage key, the two spellings addressed
+  two different ledger files on a case-insensitive volume, and a resumed
+  develop run silently started over. The spelling is checked against the
+  parent listing, never reconstructed: case folding is the filesystem's rule
+  and HFS+ also normalizes Unicode. Windows canonicalises case in `realpath`
+  and so confirms the spelling instead of deferring; both outcomes are sound,
+  and the property pinned is that the caller's spelling is never echoed back.
 
 ## [0.89.0] - 2026-08-17
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,13 @@ packages = ["spellbook", "spellbook_mcp"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+# scripts/ holds standalone gate checkers, not an installed package, so a
+# test importing one has nothing to import it FROM. Six modules each
+# reached for the same sys.path.insert, and every one of them then needed
+# a noqa to silence the E402 that the insert forced. pytest resolves this
+# entry against rootdir before collection, which is what makes the imports
+# ordinary top-level imports again.
+pythonpath = ["scripts"]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
 timeout = 30

--- a/spellbook/core/path_utils.py
+++ b/spellbook/core/path_utils.py
@@ -159,6 +159,36 @@ def _looks_like_git_dir(candidate: Path) -> bool:
         return False
 
 
+def _root_if_spelled_as_on_disk(directory: Path) -> Optional[str]:
+    """``directory`` as a root string, or None if its spelling is unconfirmed.
+
+    ``realpath`` resolves symlinks but leaves CASE alone, so on a
+    case-insensitive volume a caller's ``/x/MYREPO`` survives the walk exactly
+    as written, while git -- which chdirs and reads ``getcwd`` -- answers
+    ``/x/myrepo``. Both are non-None and they disagree, and since ``encode_cwd``
+    turns this string into a storage filename the disagreement is silent: the
+    caller reads the resulting miss as "no state for this project".
+
+    The spelling is CHECKED against the parent listing rather than
+    reconstructed from it. Reconstructing means folding case by Python's rules
+    where the filesystem's rules apply -- HFS+ also normalizes Unicode, and
+    other volumes fold differently again -- so a reconstruction is a guess of
+    exactly the kind this module refuses. A check can only ever cost a deferral.
+    """
+    root = os.path.normpath(str(directory))
+    current = Path(root)
+    while True:
+        parent = current.parent
+        if parent == current:
+            return root
+        try:
+            if current.name not in os.listdir(parent):
+                return None
+        except OSError:
+            return None
+        current = parent
+
+
 def _git_free_repo_root(path: str) -> Optional[str]:
     """The repo root for ``path`` read off the filesystem, or None to defer.
 
@@ -187,6 +217,10 @@ def _git_free_repo_root(path: str) -> Optional[str]:
       directory not named ``.git``, so the main-worktree parent derivation
       does not apply.
     - Anything under a ``GIT_*`` discovery override.
+
+    - Any path spelled in a case the disk does not use. ``realpath`` does not
+      canonicalize case, so on a case-insensitive volume the walk would answer
+      with the caller's spelling where git answers with the disk's.
 
     Git's own answer is realpath-based (it chdirs, and ``getcwd`` returns a
     resolved path), so the walk starts from ``os.path.realpath``. Git also
@@ -235,7 +269,7 @@ def _git_free_repo_root(path: str) -> Optional[str]:
         if is_dir:
             if not _looks_like_git_dir(dot_git):
                 return None
-            return os.path.normpath(str(directory))
+            return _root_if_spelled_as_on_disk(directory)
 
         if is_file:
             git_dir = _read_gitdir_pointer(dot_git, directory)
@@ -265,7 +299,7 @@ def _git_free_repo_root(path: str) -> Optional[str]:
                     return None
             except OSError:
                 return None
-            return os.path.normpath(str(main_root))
+            return _root_if_spelled_as_on_disk(main_root)
 
         if dot_git.exists():
             # Present but neither file nor directory. Git's acceptance rules

--- a/tests/scripts/test_develop_gate_ledger.py
+++ b/tests/scripts/test_develop_gate_ledger.py
@@ -22,7 +22,6 @@ import pytest
 # can run the rest of spellbook's tests; we just make sure the path
 # resolves when the module is imported.
 SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "develop_gate_ledger.py"
-sys.path.insert(0, str(SCRIPT_PATH.parent))
 
 import develop_gate_ledger as ledger
 

--- a/tests/scripts/test_documented_cli_invocations.py
+++ b/tests/scripts/test_documented_cli_invocations.py
@@ -35,9 +35,8 @@ from pathlib import Path
 import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-sys.path.insert(0, str(REPO_ROOT / "scripts"))
 
-from corpus_trees import DOCUMENTED_TREES  # noqa: E402
+from corpus_trees import DOCUMENTED_TREES
 
 CLI_REL = "scripts/develop_gate_ledger.py"
 CLI_PATH = REPO_ROOT / CLI_REL

--- a/tests/scripts/test_generate_docs_fences.py
+++ b/tests/scripts/test_generate_docs_fences.py
@@ -12,14 +12,9 @@ generator writes 200+ files in one pass, so an off-by-one here corrupts the
 docs site wholesale rather than visibly failing.
 """
 
-import sys
 from pathlib import Path
 
 import pytest
-
-SCRIPTS_DIR = Path(__file__).resolve().parents[2] / "scripts"
-sys.path.insert(0, str(SCRIPTS_DIR))
-
 from generate_docs import fence_for
 
 

--- a/tests/scripts/test_readme_no_phantoms.py
+++ b/tests/scripts/test_readme_no_phantoms.py
@@ -19,9 +19,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 CHECKER = REPO_ROOT / "scripts" / "check-readme-completeness.py"
 
-sys.path.insert(0, str(REPO_ROOT / "scripts"))
-
-import corpus_trees  # noqa: E402  (needs the scripts/ path entry above)
+import corpus_trees
 # A copy manifest for the scratch repo, not a corpus membership -- it is
 # "what the checker needs to run", so it is deliberately not corpus_trees.
 SOURCE_DIRS = ("scripts", "skills", "commands", "agents", "rules", "docs")

--- a/tests/scripts/test_reference_resolution.py
+++ b/tests/scripts/test_reference_resolution.py
@@ -21,15 +21,13 @@ violation never touches the real tree.
 
 import os
 import shutil
-import sys
 from pathlib import Path
 
 import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-sys.path.insert(0, str(REPO_ROOT / "scripts"))
 
-from check_reference_resolution import (  # noqa: E402
+from check_reference_resolution import (
     ALLOWLIST,
     PROSE_DIRS,
     PROSE_FILES,

--- a/tests/scripts/test_script_names_do_not_shadow.py
+++ b/tests/scripts/test_script_names_do_not_shadow.py
@@ -1,0 +1,120 @@
+"""``pythonpath = ["scripts"]`` puts every script module name on ``sys.path``.
+
+``pyproject.toml`` prepends ``scripts/`` to ``sys.path`` for the whole test
+session so that a test importing a gate checker can write an ordinary top-level
+import. The cost is that every importable name in ``scripts/`` becomes a
+candidate answer for every ``import`` executed under pytest. A future
+``scripts/typing.py`` or ``scripts/click.py`` would answer ``import typing`` or
+``import click`` for the entire suite, and nothing would report an error --
+tests would simply run against the wrong module, or fail somewhere far from the
+cause.
+
+This module mechanizes that admission. The shadowing relation is between IMPORT
+names, so those are what it compares:
+
+* ``sys.stdlib_module_names`` is already a set of import names.
+* For installed third-party code it uses ``importlib.metadata`` ->
+  ``packages_distributions()``, whose KEYS are top-level import names, rather
+  than ``distributions()``, whose names are DISTRIBUTION names. The two differ
+  (the ``pytest-asyncio`` distribution imports as ``pytest_asyncio``), and only
+  the import name can be typed in an ``import`` statement, so only the import
+  name can be shadowed. Comparing distribution names would both miss real
+  collisions and invent false ones.
+
+The floor test is the anti-no-op guard, following the house convention in
+``tests/scripts/test_reference_resolution.py::test_row_extracts_at_least_its_floor``:
+a derivation that returns an empty set is disjoint from everything and would
+pass both assertions while checking nothing.
+"""
+
+import sys
+from importlib.metadata import packages_distributions
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+
+# One unit is one ``scripts/*.py`` file whose stem is a valid Python
+# identifier, i.e. a file reachable by a plain ``import <stem>``. Hyphenated
+# scripts (``branch-context.py``) cannot be named in an import statement and so
+# cannot shadow anything. Derived at the time of writing with:
+#   uv run python -c "from pathlib import Path; \
+#     print(sum(1 for p in Path('scripts').glob('*.py') if p.stem.isidentifier()))"
+# which reported 17. The floor sits below that so ordinary deletion of a script
+# does not turn the suite red, while a derivation that collapses toward zero
+# does.
+MODULE_NAME_FLOOR = 15
+
+
+def script_module_names(scripts_dir: Path) -> set[str]:
+    """Names that ``scripts_dir`` on ``sys.path`` makes importable."""
+    return {p.stem for p in scripts_dir.glob("*.py") if p.stem.isidentifier()}
+
+
+def installed_import_names() -> set[str]:
+    """Top-level import names provided by installed distributions."""
+    return set(packages_distributions())
+
+
+def test_script_module_names_meet_their_floor():
+    """A derivation that finds nothing is disjoint from everything."""
+    names = script_module_names(SCRIPTS_DIR)
+    assert len(names) >= MODULE_NAME_FLOOR, (
+        f"Derived {len(names)} importable script module name(s) from "
+        f"{SCRIPTS_DIR}, below the floor of {MODULE_NAME_FLOOR}. Either the "
+        f"scripts directory moved or shrank, or this derivation broke. An "
+        f"empty set passes every disjointness assertion below while checking "
+        f"nothing."
+    )
+
+
+def test_script_module_names_do_not_shadow_the_stdlib():
+    collisions = script_module_names(SCRIPTS_DIR) & sys.stdlib_module_names
+    assert not collisions, (
+        f"scripts/ contains module name(s) that shadow the standard library "
+        f"for every test in the suite: {sorted(collisions)}. "
+        f"pyproject.toml puts scripts/ on sys.path, so `import "
+        f"{sorted(collisions)[0]}` would resolve to the script. Rename the "
+        f"script."
+    )
+
+
+def test_script_module_names_do_not_shadow_installed_distributions():
+    collisions = script_module_names(SCRIPTS_DIR) & installed_import_names()
+    assert not collisions, (
+        f"scripts/ contains module name(s) that shadow an installed "
+        f"dependency's import name for every test in the suite: "
+        f"{sorted(collisions)}. pyproject.toml puts scripts/ on sys.path, so "
+        f"`import {sorted(collisions)[0]}` would resolve to the script rather "
+        f"than to the installed package. Rename the script."
+    )
+
+
+def test_guard_names_a_planted_stdlib_collision(tmp_path):
+    """RED proof: the stdlib check must actually catch a collision.
+
+    Planted in a scratch directory, never in the real tree.
+    """
+    (tmp_path / "typing.py").write_text("")
+    (tmp_path / "docs_config.py").write_text("")
+    assert script_module_names(tmp_path) & sys.stdlib_module_names == {"typing"}
+
+
+def test_guard_names_a_planted_distribution_collision(tmp_path):
+    """RED proof: the installed-distribution check must catch a collision.
+
+    ``pytest`` is a real installed dependency of this project and its
+    distribution name and import name happen to coincide; ``pytest_asyncio``
+    is the case where they do not, and it is the import name that must match.
+    """
+    (tmp_path / "pytest.py").write_text("")
+    (tmp_path / "pytest_asyncio.py").write_text("")
+    (tmp_path / "docs_config.py").write_text("")
+    collisions = script_module_names(tmp_path) & installed_import_names()
+    assert collisions == {"pytest", "pytest_asyncio"}
+
+
+def test_hyphenated_scripts_are_excluded(tmp_path):
+    """A hyphenated file cannot be named in an import statement."""
+    (tmp_path / "branch-context.py").write_text("")
+    assert script_module_names(tmp_path) == set()

--- a/tests/scripts/test_self_manufactured_evidence.py
+++ b/tests/scripts/test_self_manufactured_evidence.py
@@ -19,13 +19,11 @@ correct: it drives the subject to prove the subject can fail. What makes this
 module honest is that the green above is not.
 """
 
-import sys
 from pathlib import Path, PureWindowsPath
 
 import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-sys.path.insert(0, str(REPO_ROOT / "scripts"))
 
 import corpus_trees
 from check_self_manufactured_evidence import (

--- a/tests/test_path_utils.py
+++ b/tests/test_path_utils.py
@@ -132,6 +132,23 @@ class TestDetectGitContext:
         )
 
 
+def _volume_is_case_insensitive(directory) -> bool:
+    """Whether ``directory``'s volume resolves one file under two spellings.
+
+    Probed, never assumed from ``sys.platform``: a macOS box can be either
+    (APFS is formatted case-insensitive by default but case-sensitive is a
+    supported choice), and a Linux box can mount either. The probe writes a
+    file and asks for it back under a different case, which is the property
+    the caller actually depends on.
+    """
+    probe = directory / "CaseProbe"
+    probe.write_text("")
+    try:
+        return (directory / "caseprobe").exists()
+    finally:
+        probe.unlink()
+
+
 def _git(*args, cwd):
     """Run git with a hermetic environment (no operator config, no global hooks)."""
     env = {
@@ -245,6 +262,44 @@ class TestResolveRepoRootMapping:
         repo_root = os.path.realpath(str(repo))
         for probe in (repo, worktree, worktree / "s"):
             assert _git_free_repo_root(str(probe)) == repo_root, probe
+
+    @pytest.mark.allow("subprocess")
+    def test_declines_a_path_spelled_in_a_case_the_disk_does_not_use(self, tmp_path):
+        """A case-variant input must not answer where it would answer WRONGLY.
+
+        ``realpath`` resolves symlinks but leaves case alone, so on a
+        case-insensitive volume ``/x/MYREPO`` reaches the end of the walk
+        spelled the way the caller wrote it, while git -- whose answer comes
+        from ``getcwd`` after a ``chdir`` -- reports ``/x/myrepo``. Both are
+        non-None and they disagree, which is the one outcome the walk is built
+        to avoid: ``encode_cwd`` turns the string into a storage key, so the
+        two spellings address two different ledger files and a resumed develop
+        run silently starts over.
+
+        The walk therefore declines rather than reconstructs the on-disk
+        spelling. Case folding is the filesystem's rule and not Python's, and
+        HFS+ also normalizes Unicode, so a reconstruction would be a guess;
+        deferring costs one process spawn and cannot be wrong.
+        """
+        if not _volume_is_case_insensitive(tmp_path):
+            pytest.skip("case-sensitive volume: no case-variant path resolves here")
+
+        repo = tmp_path / "myrepo"
+        (repo / "a").mkdir(parents=True)
+        _git("init", "-q", ".", cwd=repo)
+        _git("commit", "-q", "--allow-empty", "-m", "x", cwd=repo)
+
+        variant = str(tmp_path / "MYREPO")
+        expected = os.path.realpath(str(repo))
+
+        # The walk defers ...
+        assert _git_free_repo_root(variant) is None
+        assert _git_free_repo_root(os.path.join(variant, "A")) is None
+        # ... and the canonical spelling still takes the fast path.
+        assert _git_free_repo_root(str(repo)) == expected
+        # ... so the answer the CALLER sees is git's, under either spelling.
+        assert resolve_repo_root(variant) == expected
+        assert resolve_repo_root(os.path.join(variant, "A")) == expected
 
 
 class TestResolveRepoRootSpawnsNothing:

--- a/tests/test_path_utils.py
+++ b/tests/test_path_utils.py
@@ -276,10 +276,15 @@ class TestResolveRepoRootMapping:
         two spellings address two different ledger files and a resumed develop
         run silently starts over.
 
-        The walk therefore declines rather than reconstructs the on-disk
-        spelling. Case folding is the filesystem's rule and not Python's, and
-        HFS+ also normalizes Unicode, so a reconstruction would be a guess;
-        deferring costs one process spawn and cannot be wrong.
+        Where the walk cannot confirm the spelling it declines rather than
+        reconstructing it. Case folding is the filesystem's rule and not
+        Python's, and HFS+ also normalizes Unicode, so a reconstruction would
+        be a guess; deferring costs one process spawn and cannot be wrong.
+
+        Windows differs: its ``realpath`` canonicalises case, so the walk CAN
+        confirm the spelling and answers correctly instead of deferring. Both
+        outcomes are sound, which is why this pins the property -- never a
+        spelling the disk does not use -- rather than the mechanism.
         """
         if not _volume_is_case_insensitive(tmp_path):
             pytest.skip("case-sensitive volume: no case-variant path resolves here")
@@ -292,9 +297,15 @@ class TestResolveRepoRootMapping:
         variant = str(tmp_path / "MYREPO")
         expected = os.path.realpath(str(repo))
 
-        # The walk defers ...
-        assert _git_free_repo_root(variant) is None
-        assert _git_free_repo_root(os.path.join(variant, "A")) is None
+        # The walk never answers with a spelling the disk does not use. Two
+        # outcomes satisfy that and they are platform-dependent: POSIX
+        # ``realpath`` leaves case alone, so the walk cannot confirm the
+        # spelling and declines; Windows canonicalises case, so the walk
+        # confirms it and answers correctly. A third value -- the caller's
+        # spelling -- is the failure, and is what this pins.
+        for probe in (variant, os.path.join(variant, "A")):
+            answer = _git_free_repo_root(probe)
+            assert answer is None or answer == expected, (probe, answer)
         # ... and the canonical spelling still takes the fast path.
         assert _git_free_repo_root(str(repo)) == expected
         # ... so the answer the CALLER sees is git's, under either spelling.


### PR DESCRIPTION
## What does this PR do?

Two independent fixes from review follow-ups.

**The repo-root walk diverged from git on case-insensitive volumes — proven, not theorised.**
A code review flagged this as PLAUSIBLE and could not test it: every volume on the dev
machine is case-sensitive, so the probe would have skipped. Rather than accept that, a
case-insensitive volume was created (`hdiutil create -fs HFS+`, confirmed case-insensitive
by write-then-read-back rather than by platform assumption). For input `.../work/MYREPO`:

| | answer |
|---|---|
| git | `/private/tmp/ciprobe/work/myrepo` |
| walk | `/private/tmp/ciprobe/work/MYREPO` |

A divergent **non-`None`** answer, which `encode_cwd` turns into a storage key — so a
develop session resumed under a different spelling silently starts fresh. That is the one
failure this design forbids: it may decline, but it must never answer differently.

The fix **checks** each path component against its parent's directory listing and returns
`None` when it cannot confirm the spelling. It deliberately does not reconstruct the
canonical spelling: folding case by Python's rules where the filesystem's rules apply — HFS+
also normalises Unicode — is exactly the guess this module refuses to make. A check can only
ever cost a deferral to git; a reconstruction can be wrong.

The probe skips on case-sensitive volumes and says so. It is not dead in CI:
`macos-latest` and `windows-latest` are case-insensitive by default, so it executes there.
That skip is the one added to the suite's skip count.

**`sys.path` insertion replaced by pytest `pythonpath`.** The starting premise — that
`test_readme_no_phantoms.py` was the first cross-tree import of `scripts/corpus_trees.py` —
was wrong. Six test files already carried a module-scope `sys.path.insert` pointing at
`scripts/`; it was the local convention, not a novel hack. All six now import normally via
`pythonpath = ["scripts"]` in `[tool.pytest.ini_options]`, chosen over a `conftest.py` entry
because it is declarative, adds no import-time code, and applies to every test directory.

Every `# noqa: E402` those files carried is gone — three of which ruff already reported as
**stale** (`RUF100`) at HEAD. Ruff on the touched files goes from 3×E402 + 3×RUF100 + 1×I001
+ 4×PLW1510 to 1×I001 + 4×PLW1510: strictly fewer, none new. All 22 script modules were
checked for collisions against stdlib and third-party names.

The mutation proof independently confirmed the count: pointing `pythonpath` at a nonexistent
directory produced collection errors in exactly those six files.

## Known limit, needing a decision

**Under git's dubious-ownership refusal the walk still diverges, and it is not fixed here.**
Reproduced without needing a second uid via `GIT_TEST_ASSUME_DIFFERENT_OWNER=1`: both git
commands exit 128, so the previous behaviour returned the raw input path while the walk
returns the true repository root. Divergent non-`None` again — but here the walk's answer is
arguably the *more* correct one, and replicating git's rule would mean modelling
`safe.directory` config exceptions and Windows differences, which is precisely the guess this
module avoids. Reported rather than guessed.

Also noted: `pythonpath = ["scripts"]` widens the import namespace for the whole test
session. Verified collision-free today; a future `scripts/` file named after a real
dependency would shadow it silently.

## Related issue

None.

## Checklist

- [x] Tests pass locally — 1897 passed, 3 skipped (the added skip is the case probe on a
      case-sensitive volume; it runs for real on macOS and Windows CI, and was verified
      passing on a mounted case-insensitive volume: 13 passed, zero skips)
- [x] Documentation updated (if applicable) — no generated docs affected
