### PR TITLE
Move the ledger CLI reference out of SKILL.md and document it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and the fallback in `scripts/develop_gate_ledger.py` still shells out and is
   held against it as a standing differential.
 
+### Fixed
+
+- `scripts/develop_gate_ledger.py` now applies its documented exit-code split
+  on every subcommand. `1` means the STORED ledger is not what the operation
+  needs, `2` means the CALLER asked for something the ledger does not accept.
+  Five recorders -- `archive-ceremony`, `wave-discipline`, `blocker`,
+  `group-gate`, `record-dispatch` -- collapsed both into a single exit `2`, so
+  a corrupt ledger reached through `blocker` reported "fix the command" while
+  the ledger needed repair. A convention holding on three of eight subcommands
+  is not one a caller can branch on. This is a user-visible CLI contract
+  change: an invocation that hit a stored-state refusal on those five now exits
+  `1` where it exited `2`. Verified end to end against a corrupt ledger on each
+  of the five, with the true exit status captured directly rather than through
+  a pipe.
+
 ## [0.89.0] - 2026-08-17
 
 ### Added

--- a/docs/skills/develop.md
+++ b/docs/skills/develop.md
@@ -1741,136 +1741,27 @@ Commands share state via these session variables:
 
 ### Ledger Writes (workflow_state — accountability + compaction recovery)
 
-<CRITICAL>
-develop records its own phase/gate progress in a persistent state file so the work
-survives context compaction and a resumed session can re-assert the remaining
-gates instead of declaring "done" prematurely. This is design §5 (C4).
+develop records its own phase/gate progress in a persistent state file so the
+work survives context compaction and a resumed session can re-assert the
+remaining gates instead of declaring "done" prematurely (design §5, C4).
 
-**MERGE-ONLY, NEVER overwrite.** develop writes via deep-merge and MUST NEVER
-use full overwrite. The hooks (`_handle_pre_compact`) write `compaction_flag` and
-`stint_stack` into the SAME state row; an overwrite from develop would clobber
-them, and vice versa. `_deep_merge` preserves sibling keys, so disjoint-key writes
-never lose a field (design §5.2/§5.5). An overwrite here is a Risk §13 regression
-— do not do it.
+<CRITICAL>
+**Writes go through `scripts/develop_gate_ledger.py`. MERGE-ONLY, NEVER
+overwrite.** Hand-writing the JSON is a full overwrite and clobbers sibling keys
+written by other develop writes or by the spellbook hooks' `workflow_state` row.
+When the skill tells you to "write the ledger", it means call this CLI.
 </CRITICAL>
 
-**The ledger shape (`develop_gate_ledger`, design §5.3):**
+| Need | Where |
+|------|-------|
+| The `develop_gate_ledger` shape — every field, and why each is a scalar, a map, or a list | `skills/develop/references/ledger-cli.md` |
+| The CLI surface — every subcommand and flag | `skills/develop/references/ledger-cli.md` |
+| Every refusal, its exit code, and the remedy it names | `skills/develop/references/ledger-cli.md` |
 
-```typescript
-develop_gate_ledger: {
-  current_phase: string;        // "0" | "1" | "1.5" | "2" | "3" | "4" | "fast-path"
-  need_flags: { needs_research: boolean; needs_design: boolean; needs_infrastructure: boolean };
-  remaining_gates: string;      // NEWLINE-JOINED SCALAR (NOT a list), e.g.
-                                // "design review\ncode review\ngreen-mirage\ntest suite"
-  plan_pointer: string;         // absolute path to impl plan / design doc / understanding doc
-  ceremony: {                   // the ONE-TIME ceremony selection (feature-config §0.8)
-    locked_at: string;          // ISO 8601. Its PRESENCE is the lock. Never rewritten.
-    source: string;             // "operator_selected" | "recommendation_accepted" | "default_full"
-    assessment: string;         // newline-joined "D{n} {dimension}={low|high}: {evidence}" (§0.7.5)
-    core: string;               // newline-joined non-negotiable gates — never were selectable
-    selected: string;           // newline-joined optional gates chosen to RUN
-    declined: string;           // newline-joined optional gates chosen to SKIP (recorded, not absent)
-    promotions: string;         // newline-joined "{gate} <- {reason} ({ISO ts})" escalation record
-    gate_position: string;      // "per_task" | "per_group", default "per_task". "per_group" is
-                                 // offered only when SESSION_PREFERENCES.task_granularity ==
-                                 // "capability" (feature-config §0.7 Step 2.5) — that answer is
-                                 // recorded in Phase 0, before any plan exists. Locked with the
-                                 // rest of ceremony at locked_at; never changed mid-run.
-  };
-  ceremony_history: {            // archive of superseded `ceremony` blocks, keyed by ISO archive
-                                  // timestamp. Written only on a deliberate re-invocation over an
-                                  // existing ledger — the old `ceremony` block is archived here
-                                  // with a reason before a new Phase 0 sets `ceremony` fresh.
-    [archived_at: string]: {
-      ceremony: object;          // the full superseded ceremony block, verbatim
-      reason: string;            // why the operator re-invoked and re-selected
-      archived_at: string;       // ISO 8601; also written INTO the entry by archive_ceremony,
-                                  // duplicating the key this entry is stored under
-    };
-  };
-  blockers: {                    // open blockers keyed by id; each row carries a type so the
-                                  // orchestrator can count them at phase/wave boundaries
-    [blocker_id: string]: {
-      type: "decision" | "work" | "external";
-      description?: string;      // omitted by record_blocker when --description is blank or absent
-      opened_at: string;         // ISO 8601
-      closed_at?: string;        // ISO 8601. `_deep_merge` never deletes keys, so a blocker row
-                                  // is permanent once written — closure is a FIELD, never an
-                                  // absence. A blocker is OPEN iff it has no `closed_at`.
-    };
-  };
-  waves: {                      // §24.6 wave-discipline check records, keyed by wave id
-    [wave_id: string]: {
-      section_24_6_check: {
-        status: "passed" | "failed" | "n_a";
-        open_rows: string[];    // the W<n>- ids still open; written on EVERY status, empty
-                                // included. `_deep_merge` replaces lists but never deletes
-                                // keys, so an omitted key cannot SHRINK -- a passing
-                                // re-record would inherit the prior failure's rows.
-                                // status=failed is REFUSED with an empty list.
-        timestamp?: string;     // ISO 8601; the develop skill writes it on each entry
-        reason?: string;        // free-form context; records WHY on status=n_a
-      };
-    };
-  };
-  groups: {                     // gate_position: per_group boundary-gate check records, keyed by
-                                 // group id. Without this record, "the boundary gate stack ran"
-                                 // and "it never ran" are indistinguishable — the same
-                                 // mechanism-vs-discipline gap §24.6 closes for waves.
-    [group_id: string]: {
-      gate_stack: {
-        status: "passed" | "failed" | "n_a";
-        gates: string[];           // the gates run at this group boundary
-        open_findings: string[];   // the findings still open at this boundary
-                                   // Both lists follow the `open_rows` shrink rule: written on
-                                   // EVERY status, empty included, because a conditionally
-                                   // written field can never shrink. A re-record that omitted
-                                   // them would retain stale findings on a pass, or a coverage
-                                   // claim the re-record never asserted.
-                                   // status=failed is REFUSED with an empty open_findings.
-        timestamp?: string;        // ISO 8601
-      };
-    };
-  };
-}
-```
-
-**Defect register rows carry a `class:` tag.** The tag lives in the defect
-register (plan/ledger-adjacent, not a `develop_gate_ledger` field), and the
-orchestrator reads it to detect a recurring-defect shape: two open rows
-sharing one `class:` tag.
-
-**Writes go through `scripts/develop_gate_ledger.py`.** The Python
-implementation is the only path that respects the merge contract --
-it deep-merges, and refuses `section_24_6_check.status=failed` without
-open rows. Ordinary `set` refuses to rewrite `ceremony.locked_at`; the
-ONLY sanctioned path that supersedes a lock is `archive-ceremony`, which
-archives the old `ceremony` block into `ceremony_history` before writing
-a new one, and cannot run without a `--reason`. Hand-writing the
-JSON is a full overwrite and will clobber sibling keys written by
-other develop writes or by the spellbook hooks' `workflow_state` row;
-do not do it. The CLI surface is intentionally narrow:
-
-- `python3 scripts/develop_gate_ledger.py show [--field ceremony.locked_at]`
-- `python3 scripts/develop_gate_ledger.py set <field> <value>` (top-level or `ceremony.*`,
-  including `set ceremony.gate_position per_task|per_group` — refused once `locked_at`
-  is set and a different position is already recorded; use `archive-ceremony` to reposition)
-- `python3 scripts/develop_gate_ledger.py wave-discipline <wave_id> --status {passed|failed|n_a} [--open-rows W3a-2,W3a-5] [--timestamp ISO]`
-- `python3 scripts/develop_gate_ledger.py archive-ceremony --reason "<text>" [--timestamp ISO]`
-- `python3 scripts/develop_gate_ledger.py blocker <id> --type decision|work|external [--description "<text>"] [--close]`
-- `python3 scripts/develop_gate_ledger.py group-gate <group_id> --status passed|failed|n_a [--gates ...] [--open-findings ...]` —
-  writes `develop_gate_ledger.groups.<group_id>.gate_stack`; `status=failed` requires
-  `--open-findings`, mirroring the wave-discipline guard.
-
-When the skill tells you to "write the ledger", it means call this
-CLI, not write the JSON yourself. The contract is enforced in Python
-because it is enforced in Python; the LLM-side discipline is just
-the trigger.
-
-**Every `ceremony` field is a newline-joined SCALAR, for the same CRIT-1 reason as
-`remaining_gates`: `_deep_merge` APPENDS lists but REPLACES scalars, so a list-valued
-`declined` would accumulate forever and a list-valued `selected` could never shrink.
-Write each as the authoritative full scalar; the merge replaces it wholesale.**
+Read `skills/develop/references/ledger-cli.md` before your first ledger write. The CLI REFUSES
+a bare `set` on the six structured fields, refuses a blank or rewritten
+`ceremony.locked_at`, and refuses de-escalation of the locked gate set — a write
+that assumes otherwise exits non-zero, and the reference is where the remedy is.
 
 ### Ceremony Ledger
 

--- a/scripts/develop_gate_ledger.py
+++ b/scripts/develop_gate_ledger.py
@@ -1043,6 +1043,14 @@ def is_wave_done_claimable(wave_id: str, *, path: Path | None = None) -> bool:
 
 
 # ---- CLI ----------------------------------------------------------------
+#
+# Every handler splits its failures the same way: a LedgerError exits 1 ("the
+# STORED ledger is not what this operation needs -- repair it") and a
+# ValueError exits 2 ("the CALLER asked for something the ledger does not
+# accept -- fix the command"). A caller can only branch on that split if it
+# holds on every subcommand; where five recorders collapsed both into exit 2,
+# a corrupt ledger reached through `blocker` sent the reader to inspect
+# arguments that were already correct.
 
 
 def _cmd_show(args: argparse.Namespace) -> int:
@@ -1101,9 +1109,7 @@ def _cmd_set(args: argparse.Namespace) -> int:
         print(f"error: {exc}", file=sys.stderr)
         return 1
     except ValueError as exc:
-        # Value guards (e.g. ceremony.gate_position) raise ValueError. Exit 2
-        # to match the unknown-field path: both are "the caller asked for
-        # something the ledger does not accept", not a ledger I/O failure.
+        # The unknown-field path above returns 2 directly for the same reason.
         print(f"error: {exc}", file=sys.stderr)
         return 2
     print(f"set {args.field}={args.value!r}")
@@ -1114,7 +1120,10 @@ def _cmd_archive_ceremony(args: argparse.Namespace) -> int:
     path = Path(args.path) if args.path else None
     try:
         archive_ceremony(args.reason, timestamp=args.timestamp, path=path)
-    except (ValueError, LedgerError) as exc:
+    except LedgerError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    except ValueError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 2
     print(
@@ -1136,7 +1145,10 @@ def _cmd_wave_discipline(args: argparse.Namespace) -> int:
             reason=args.reason,
             path=path,
         )
-    except (ValueError, LedgerError) as exc:
+    except LedgerError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    except ValueError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 2
     claimable = is_wave_done_claimable(args.wave, path=path)
@@ -1158,7 +1170,10 @@ def _cmd_blocker(args: argparse.Namespace) -> int:
             timestamp=args.timestamp,
             path=path,
         )
-    except (ValueError, LedgerError) as exc:
+    except LedgerError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    except ValueError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 2
     print(
@@ -1185,7 +1200,10 @@ def _cmd_group_gate(args: argparse.Namespace) -> int:
             timestamp=args.timestamp,
             path=path,
         )
-    except (ValueError, LedgerError) as exc:
+    except LedgerError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    except ValueError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 2
     print(f"group {args.group_id}: gate_stack status={args.status}")
@@ -1206,7 +1224,10 @@ def _cmd_record_dispatch(args: argparse.Namespace) -> int:
             timestamp=args.timestamp,
             path=path,
         )
-    except (ValueError, LedgerError) as exc:
+    except LedgerError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    except ValueError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 2
     print(f"dispatch recorded (skills: {', '.join(skills) or 'none recognized'})")

--- a/scripts/size_ceilings.json
+++ b/scripts/size_ceilings.json
@@ -18,8 +18,8 @@
       "lines": 225
     },
     "skills/develop/SKILL.md": {
-      "bytes": 111268,
-      "lines": 2116
+      "bytes": 103975,
+      "lines": 2001
     },
     "skills/dispatching-parallel-agents/SKILL.md": {
       "bytes": 40941,

--- a/skills/develop/SKILL.md
+++ b/skills/develop/SKILL.md
@@ -1739,136 +1739,27 @@ Commands share state via these session variables:
 
 ### Ledger Writes (workflow_state — accountability + compaction recovery)
 
-<CRITICAL>
-develop records its own phase/gate progress in a persistent state file so the work
-survives context compaction and a resumed session can re-assert the remaining
-gates instead of declaring "done" prematurely. This is design §5 (C4).
+develop records its own phase/gate progress in a persistent state file so the
+work survives context compaction and a resumed session can re-assert the
+remaining gates instead of declaring "done" prematurely (design §5, C4).
 
-**MERGE-ONLY, NEVER overwrite.** develop writes via deep-merge and MUST NEVER
-use full overwrite. The hooks (`_handle_pre_compact`) write `compaction_flag` and
-`stint_stack` into the SAME state row; an overwrite from develop would clobber
-them, and vice versa. `_deep_merge` preserves sibling keys, so disjoint-key writes
-never lose a field (design §5.2/§5.5). An overwrite here is a Risk §13 regression
-— do not do it.
+<CRITICAL>
+**Writes go through `scripts/develop_gate_ledger.py`. MERGE-ONLY, NEVER
+overwrite.** Hand-writing the JSON is a full overwrite and clobbers sibling keys
+written by other develop writes or by the spellbook hooks' `workflow_state` row.
+When the skill tells you to "write the ledger", it means call this CLI.
 </CRITICAL>
 
-**The ledger shape (`develop_gate_ledger`, design §5.3):**
+| Need | Where |
+|------|-------|
+| The `develop_gate_ledger` shape — every field, and why each is a scalar, a map, or a list | `skills/develop/references/ledger-cli.md` |
+| The CLI surface — every subcommand and flag | `skills/develop/references/ledger-cli.md` |
+| Every refusal, its exit code, and the remedy it names | `skills/develop/references/ledger-cli.md` |
 
-```typescript
-develop_gate_ledger: {
-  current_phase: string;        // "0" | "1" | "1.5" | "2" | "3" | "4" | "fast-path"
-  need_flags: { needs_research: boolean; needs_design: boolean; needs_infrastructure: boolean };
-  remaining_gates: string;      // NEWLINE-JOINED SCALAR (NOT a list), e.g.
-                                // "design review\ncode review\ngreen-mirage\ntest suite"
-  plan_pointer: string;         // absolute path to impl plan / design doc / understanding doc
-  ceremony: {                   // the ONE-TIME ceremony selection (feature-config §0.8)
-    locked_at: string;          // ISO 8601. Its PRESENCE is the lock. Never rewritten.
-    source: string;             // "operator_selected" | "recommendation_accepted" | "default_full"
-    assessment: string;         // newline-joined "D{n} {dimension}={low|high}: {evidence}" (§0.7.5)
-    core: string;               // newline-joined non-negotiable gates — never were selectable
-    selected: string;           // newline-joined optional gates chosen to RUN
-    declined: string;           // newline-joined optional gates chosen to SKIP (recorded, not absent)
-    promotions: string;         // newline-joined "{gate} <- {reason} ({ISO ts})" escalation record
-    gate_position: string;      // "per_task" | "per_group", default "per_task". "per_group" is
-                                 // offered only when SESSION_PREFERENCES.task_granularity ==
-                                 // "capability" (feature-config §0.7 Step 2.5) — that answer is
-                                 // recorded in Phase 0, before any plan exists. Locked with the
-                                 // rest of ceremony at locked_at; never changed mid-run.
-  };
-  ceremony_history: {            // archive of superseded `ceremony` blocks, keyed by ISO archive
-                                  // timestamp. Written only on a deliberate re-invocation over an
-                                  // existing ledger — the old `ceremony` block is archived here
-                                  // with a reason before a new Phase 0 sets `ceremony` fresh.
-    [archived_at: string]: {
-      ceremony: object;          // the full superseded ceremony block, verbatim
-      reason: string;            // why the operator re-invoked and re-selected
-      archived_at: string;       // ISO 8601; also written INTO the entry by archive_ceremony,
-                                  // duplicating the key this entry is stored under
-    };
-  };
-  blockers: {                    // open blockers keyed by id; each row carries a type so the
-                                  // orchestrator can count them at phase/wave boundaries
-    [blocker_id: string]: {
-      type: "decision" | "work" | "external";
-      description?: string;      // omitted by record_blocker when --description is blank or absent
-      opened_at: string;         // ISO 8601
-      closed_at?: string;        // ISO 8601. `_deep_merge` never deletes keys, so a blocker row
-                                  // is permanent once written — closure is a FIELD, never an
-                                  // absence. A blocker is OPEN iff it has no `closed_at`.
-    };
-  };
-  waves: {                      // §24.6 wave-discipline check records, keyed by wave id
-    [wave_id: string]: {
-      section_24_6_check: {
-        status: "passed" | "failed" | "n_a";
-        open_rows: string[];    // the W<n>- ids still open; written on EVERY status, empty
-                                // included. `_deep_merge` replaces lists but never deletes
-                                // keys, so an omitted key cannot SHRINK -- a passing
-                                // re-record would inherit the prior failure's rows.
-                                // status=failed is REFUSED with an empty list.
-        timestamp?: string;     // ISO 8601; the develop skill writes it on each entry
-        reason?: string;        // free-form context; records WHY on status=n_a
-      };
-    };
-  };
-  groups: {                     // gate_position: per_group boundary-gate check records, keyed by
-                                 // group id. Without this record, "the boundary gate stack ran"
-                                 // and "it never ran" are indistinguishable — the same
-                                 // mechanism-vs-discipline gap §24.6 closes for waves.
-    [group_id: string]: {
-      gate_stack: {
-        status: "passed" | "failed" | "n_a";
-        gates: string[];           // the gates run at this group boundary
-        open_findings: string[];   // the findings still open at this boundary
-                                   // Both lists follow the `open_rows` shrink rule: written on
-                                   // EVERY status, empty included, because a conditionally
-                                   // written field can never shrink. A re-record that omitted
-                                   // them would retain stale findings on a pass, or a coverage
-                                   // claim the re-record never asserted.
-                                   // status=failed is REFUSED with an empty open_findings.
-        timestamp?: string;        // ISO 8601
-      };
-    };
-  };
-}
-```
-
-**Defect register rows carry a `class:` tag.** The tag lives in the defect
-register (plan/ledger-adjacent, not a `develop_gate_ledger` field), and the
-orchestrator reads it to detect a recurring-defect shape: two open rows
-sharing one `class:` tag.
-
-**Writes go through `scripts/develop_gate_ledger.py`.** The Python
-implementation is the only path that respects the merge contract --
-it deep-merges, and refuses `section_24_6_check.status=failed` without
-open rows. Ordinary `set` refuses to rewrite `ceremony.locked_at`; the
-ONLY sanctioned path that supersedes a lock is `archive-ceremony`, which
-archives the old `ceremony` block into `ceremony_history` before writing
-a new one, and cannot run without a `--reason`. Hand-writing the
-JSON is a full overwrite and will clobber sibling keys written by
-other develop writes or by the spellbook hooks' `workflow_state` row;
-do not do it. The CLI surface is intentionally narrow:
-
-- `python3 scripts/develop_gate_ledger.py show [--field ceremony.locked_at]`
-- `python3 scripts/develop_gate_ledger.py set <field> <value>` (top-level or `ceremony.*`,
-  including `set ceremony.gate_position per_task|per_group` — refused once `locked_at`
-  is set and a different position is already recorded; use `archive-ceremony` to reposition)
-- `python3 scripts/develop_gate_ledger.py wave-discipline <wave_id> --status {passed|failed|n_a} [--open-rows W3a-2,W3a-5] [--timestamp ISO]`
-- `python3 scripts/develop_gate_ledger.py archive-ceremony --reason "<text>" [--timestamp ISO]`
-- `python3 scripts/develop_gate_ledger.py blocker <id> --type decision|work|external [--description "<text>"] [--close]`
-- `python3 scripts/develop_gate_ledger.py group-gate <group_id> --status passed|failed|n_a [--gates ...] [--open-findings ...]` —
-  writes `develop_gate_ledger.groups.<group_id>.gate_stack`; `status=failed` requires
-  `--open-findings`, mirroring the wave-discipline guard.
-
-When the skill tells you to "write the ledger", it means call this
-CLI, not write the JSON yourself. The contract is enforced in Python
-because it is enforced in Python; the LLM-side discipline is just
-the trigger.
-
-**Every `ceremony` field is a newline-joined SCALAR, for the same CRIT-1 reason as
-`remaining_gates`: `_deep_merge` APPENDS lists but REPLACES scalars, so a list-valued
-`declined` would accumulate forever and a list-valued `selected` could never shrink.
-Write each as the authoritative full scalar; the merge replaces it wholesale.**
+Read `skills/develop/references/ledger-cli.md` before your first ledger write. The CLI REFUSES
+a bare `set` on the six structured fields, refuses a blank or rewritten
+`ceremony.locked_at`, and refuses de-escalation of the locked gate set — a write
+that assumes otherwise exits non-zero, and the reference is where the remedy is.
 
 ### Ceremony Ledger
 

--- a/skills/develop/references/ledger-cli.md
+++ b/skills/develop/references/ledger-cli.md
@@ -1,0 +1,143 @@
+# Develop Gate Ledger: Writes and CLI Reference
+
+Canonical reference for the `develop_gate_ledger` state shape, the merge
+contract every write obeys, and the `scripts/develop_gate_ledger.py` CLI
+surface — including every refusal the CLI raises and the remedy each one
+names. `skills/develop/SKILL.md` and the commands that write the ledger
+(`/feature-config`, `/feature-implement`, `/feature-implement-execute`)
+resolve field names, subcommand spellings, and refusal semantics here
+rather than restating them.
+
+## Ledger Writes (workflow_state — accountability + compaction recovery)
+
+<CRITICAL>
+develop records its own phase/gate progress in a persistent state file so the work
+survives context compaction and a resumed session can re-assert the remaining
+gates instead of declaring "done" prematurely. This is design §5 (C4).
+
+**MERGE-ONLY, NEVER overwrite.** develop writes via deep-merge and MUST NEVER
+use full overwrite. The hooks (`_handle_pre_compact`) write `compaction_flag` and
+`stint_stack` into the SAME state row; an overwrite from develop would clobber
+them, and vice versa. `_deep_merge` preserves sibling keys, so disjoint-key writes
+never lose a field (design §5.2/§5.5). An overwrite here is a Risk §13 regression
+— do not do it.
+</CRITICAL>
+
+**The ledger shape (`develop_gate_ledger`, design §5.3):**
+
+```typescript
+develop_gate_ledger: {
+  current_phase: string;        // "0" | "1" | "1.5" | "2" | "3" | "4" | "fast-path"
+  need_flags: { needs_research: boolean; needs_design: boolean; needs_infrastructure: boolean };
+  remaining_gates: string;      // NEWLINE-JOINED SCALAR (NOT a list), e.g.
+                                // "design review\ncode review\ngreen-mirage\ntest suite"
+  plan_pointer: string;         // absolute path to impl plan / design doc / understanding doc
+  ceremony: {                   // the ONE-TIME ceremony selection (feature-config §0.8)
+    locked_at: string;          // ISO 8601. Its PRESENCE is the lock. Never rewritten.
+    source: string;             // "operator_selected" | "recommendation_accepted" | "default_full"
+    assessment: string;         // newline-joined "D{n} {dimension}={low|high}: {evidence}" (§0.7.5)
+    core: string;               // newline-joined non-negotiable gates — never were selectable
+    selected: string;           // newline-joined optional gates chosen to RUN
+    declined: string;           // newline-joined optional gates chosen to SKIP (recorded, not absent)
+    promotions: string;         // newline-joined "{gate} <- {reason} ({ISO ts})" escalation record
+    gate_position: string;      // "per_task" | "per_group", default "per_task". "per_group" is
+                                 // offered only when SESSION_PREFERENCES.task_granularity ==
+                                 // "capability" (feature-config §0.7 Step 2.5) — that answer is
+                                 // recorded in Phase 0, before any plan exists. Locked with the
+                                 // rest of ceremony at locked_at; never changed mid-run.
+  };
+  ceremony_history: {            // archive of superseded `ceremony` blocks, keyed by ISO archive
+                                  // timestamp. Written only on a deliberate re-invocation over an
+                                  // existing ledger — the old `ceremony` block is archived here
+                                  // with a reason before a new Phase 0 sets `ceremony` fresh.
+    [archived_at: string]: {
+      ceremony: object;          // the full superseded ceremony block, verbatim
+      reason: string;            // why the operator re-invoked and re-selected
+      archived_at: string;       // ISO 8601; also written INTO the entry by archive_ceremony,
+                                  // duplicating the key this entry is stored under
+    };
+  };
+  blockers: {                    // open blockers keyed by id; each row carries a type so the
+                                  // orchestrator can count them at phase/wave boundaries
+    [blocker_id: string]: {
+      type: "decision" | "work" | "external";
+      description?: string;      // omitted by record_blocker when --description is blank or absent
+      opened_at: string;         // ISO 8601
+      closed_at?: string;        // ISO 8601. `_deep_merge` never deletes keys, so a blocker row
+                                  // is permanent once written — closure is a FIELD, never an
+                                  // absence. A blocker is OPEN iff it has no `closed_at`.
+    };
+  };
+  waves: {                      // §24.6 wave-discipline check records, keyed by wave id
+    [wave_id: string]: {
+      section_24_6_check: {
+        status: "passed" | "failed" | "n_a";
+        open_rows: string[];    // the W<n>- ids still open; written on EVERY status, empty
+                                // included. `_deep_merge` replaces lists but never deletes
+                                // keys, so an omitted key cannot SHRINK -- a passing
+                                // re-record would inherit the prior failure's rows.
+                                // status=failed is REFUSED with an empty list.
+        timestamp?: string;     // ISO 8601; the develop skill writes it on each entry
+        reason?: string;        // free-form context; records WHY on status=n_a
+      };
+    };
+  };
+  groups: {                     // gate_position: per_group boundary-gate check records, keyed by
+                                 // group id. Without this record, "the boundary gate stack ran"
+                                 // and "it never ran" are indistinguishable — the same
+                                 // mechanism-vs-discipline gap §24.6 closes for waves.
+    [group_id: string]: {
+      gate_stack: {
+        status: "passed" | "failed" | "n_a";
+        gates: string[];           // the gates run at this group boundary
+        open_findings: string[];   // the findings still open at this boundary
+                                   // Both lists follow the `open_rows` shrink rule: written on
+                                   // EVERY status, empty included, because a conditionally
+                                   // written field can never shrink. A re-record that omitted
+                                   // them would retain stale findings on a pass, or a coverage
+                                   // claim the re-record never asserted.
+                                   // status=failed is REFUSED with an empty open_findings.
+        timestamp?: string;        // ISO 8601
+      };
+    };
+  };
+}
+```
+
+**Defect register rows carry a `class:` tag.** The tag lives in the defect
+register (plan/ledger-adjacent, not a `develop_gate_ledger` field), and the
+orchestrator reads it to detect a recurring-defect shape: two open rows
+sharing one `class:` tag.
+
+**Writes go through `scripts/develop_gate_ledger.py`.** The Python
+implementation is the only path that respects the merge contract --
+it deep-merges, and refuses `section_24_6_check.status=failed` without
+open rows. Ordinary `set` refuses to rewrite `ceremony.locked_at`; the
+ONLY sanctioned path that supersedes a lock is `archive-ceremony`, which
+archives the old `ceremony` block into `ceremony_history` before writing
+a new one, and cannot run without a `--reason`. Hand-writing the
+JSON is a full overwrite and will clobber sibling keys written by
+other develop writes or by the spellbook hooks' `workflow_state` row;
+do not do it. The CLI surface is intentionally narrow:
+
+- `python3 scripts/develop_gate_ledger.py show [--field ceremony.locked_at]`
+- `python3 scripts/develop_gate_ledger.py set <field> <value>` (top-level or `ceremony.*`,
+  including `set ceremony.gate_position per_task|per_group` — refused once `locked_at`
+  is set and a different position is already recorded; use `archive-ceremony` to reposition)
+- `python3 scripts/develop_gate_ledger.py wave-discipline <wave_id> --status {passed|failed|n_a} [--open-rows W3a-2,W3a-5] [--timestamp ISO]`
+- `python3 scripts/develop_gate_ledger.py archive-ceremony --reason "<text>" [--timestamp ISO]`
+- `python3 scripts/develop_gate_ledger.py blocker <id> --type decision|work|external [--description "<text>"] [--close]`
+- `python3 scripts/develop_gate_ledger.py group-gate <group_id> --status passed|failed|n_a [--gates ...] [--open-findings ...]` —
+  writes `develop_gate_ledger.groups.<group_id>.gate_stack`; `status=failed` requires
+  `--open-findings`, mirroring the wave-discipline guard.
+
+When the skill tells you to "write the ledger", it means call this
+CLI, not write the JSON yourself. The contract is enforced in Python
+because it is enforced in Python; the LLM-side discipline is just
+the trigger.
+
+**Every `ceremony` field is a newline-joined SCALAR, for the same CRIT-1 reason as
+`remaining_gates`: `_deep_merge` APPENDS lists but REPLACES scalars, so a list-valued
+`declined` would accumulate forever and a list-valued `selected` could never shrink.
+Write each as the authoritative full scalar; the merge replaces it wholesale.**
+

--- a/skills/develop/references/ledger-cli.md
+++ b/skills/develop/references/ledger-cli.md
@@ -101,6 +101,29 @@ develop_gate_ledger: {
       };
     };
   };
+  dispatches: {                 // subagent dispatch records, keyed by ISO-8601 timestamp.
+                                 // A MAP, not a list, for the same reason ceremony_history
+                                 // is: the merge replaces lists wholesale, so a list would
+                                 // lose every prior dispatch on the next sibling write --
+                                 // in precisely the audit trail that proves a dispatch ran.
+                                 // Collisions within one second (ordinary in parallel
+                                 // waves) take a zero-padded `#NNN` suffix on the key.
+                                 // The intended writer is the PostToolUse hook on the Task
+                                 // tool, NOT the agent: a record authored by the party that
+                                 // would have skipped the step is a checkbox with extra
+                                 // steps. Every field but `recorded_at` and `skills` is
+                                 // optional -- the hook records what the payload carried.
+    [recorded_at: string]: {
+      recorded_at: string;      // ISO 8601; duplicates the key this entry is stored under
+      skills: string[];         // recognized DISPATCH_SKILLS names, sorted; always written
+      subagent_type?: string;   // from the Task call; truncated to DESCRIPTION_MAX (200)
+      description?: string;     // short description; truncated to DESCRIPTION_MAX
+      source?: string;          // what wrote the record (default "cli"); truncated likewise
+                                // The dispatch PROMPT is never stored -- it can carry file
+                                // contents, credentials, and operator text. Only the skill
+                                // names recognized out of it are.
+    };
+  };
 }
 ```
 
@@ -130,6 +153,20 @@ do not do it. The CLI surface is intentionally narrow:
 - `python3 scripts/develop_gate_ledger.py group-gate <group_id> --status passed|failed|n_a [--gates ...] [--open-findings ...]` —
   writes `develop_gate_ledger.groups.<group_id>.gate_stack`; `status=failed` requires
   `--open-findings`, mirroring the wave-discipline guard.
+- `python3 scripts/develop_gate_ledger.py wave-discipline <wave_id> --status n_a --reason "<text>"` —
+  `n_a` without a reason records only that the check did not apply, never why, so
+  the reason is what separates "the operator established this does not apply" from
+  "nobody ran it".
+- `python3 scripts/develop_gate_ledger.py record-dispatch [--subagent-type <text>] [--description "<text>"] [--prompt "<text>"] [--skill <skill>] [--source <text>] [--timestamp ISO]` —
+  `--skill` is repeatable.
+  writes `develop_gate_ledger.dispatches.<timestamp>`. `--prompt` is SCANNED for known
+  skill names and then discarded; the prompt itself is never stored. Normally written
+  by the `PostToolUse` hook on the `Task` tool, not by hand.
+- `python3 scripts/develop_gate_ledger.py dispatches [--skill <skill>] [--since ISO]` —
+  prints matching records as JSON and **exits 1 when none match**, so the invocation
+  can BE a phase-verification checkbox rather than something the agent ticks itself.
+  Pass `--since` for a per-task gate: without a lower bound, one dispatch recorded in
+  task 1 satisfies the same query for every task after it.
 
 When the skill tells you to "write the ledger", it means call this
 CLI, not write the JSON yourself. The contract is enforced in Python
@@ -141,3 +178,127 @@ the trigger.
 `declined` would accumulate forever and a list-valued `selected` could never shrink.
 Write each as the authoritative full scalar; the merge replaces it wholesale.**
 
+
+## Refusals
+
+The CLI refuses rather than warns, because a warning the caller never reads
+leaves the write exactly as done as no warning at all. Every refusal below
+prints `error: <message>` to stderr and names the route to use instead. Each
+named remedy is a real subcommand — a refusal pointing at a command argparse
+rejects tells the reader to run something that cannot run.
+
+**Exit codes.** `1` means the STORED ledger is not what the operation needs
+(a `LedgerError`: corrupt file, malformed shape, a lock already set). `2` means
+the CALLER asked for something the ledger does not accept (a `ValueError`:
+unknown field, invalid value, a missing required argument). The split matters
+when a caller branches on the result: `1` is "repair the ledger", `2` is "fix
+the command".
+
+### `set` refuses six structured fields
+
+`set <field> <value>` writes a top-level scalar. Six top-level fields are JSON
+objects that ACCUMULATE entries, and a bare `set` does not edit such an object —
+it REPLACES it, discarding every entry under it at once, which is the audit
+trail that exists to prove those entries were recorded. Each is refused and
+routed to the recorder that owns it:
+
+| Field | Use instead |
+|-------|-------------|
+| `ceremony` | `set ceremony.<field>` (or `archive-ceremony` to supersede it) |
+| `ceremony_history` | the `archive-ceremony` command |
+| `blockers` | the `blocker` command |
+| `waves` | the `wave-discipline` command |
+| `groups` | the `group-gate` command |
+| `dispatches` | the `record-dispatch` command |
+
+The refusal is UNCONDITIONAL — it does not depend on whether the ceremony is
+locked. Collapsing one of these objects to a scalar is not a narrower version of
+a legitimate operation; it is not one at all, and a guard that fired only after
+the lock would leave the Phase-0 window wide open. Membership is exactly "has
+another route": `need_flags` is an object too and is deliberately NOT refused,
+because it has no dedicated recorder and refusing it would leave it unwritable
+rather than write it correctly.
+
+`set` also refuses any `field` containing `/` or `.` other than a `ceremony.*`
+name, and refuses a `ceremony.<name>` that is not a known ceremony field.
+
+### The ceremony lock
+
+`ceremony.locked_at` is the lock, and its PRESENCE is what locks — never its
+truthiness. A ledger holding `locked_at: ""` is locked; only an absent or `null`
+stamp is unlocked. Testing truthiness once made a blank stamp a master key that
+disengaged every guard at once.
+
+- **A blank `locked_at` is refused on write** (exit 2). A stamp whose value is
+  blank is a lock in name only: nothing can read it, and it would disengage the
+  guards it is supposed to arm.
+- **Rewriting `locked_at` to a different value is refused** (exit 1). The lock is
+  set once and never rewritten. `archive-ceremony` is the only sanctioned path
+  that supersedes it.
+- **Repositioning `ceremony.gate_position` after the lock is refused** (exit 1).
+  Re-asserting the SAME value is allowed, and a first write after the lock is
+  allowed — the guard refuses a reposition, not the recording of the original
+  selection. An invalid value (anything but `per_task`/`per_group`) is refused
+  at exit 2 whether or not the ceremony is locked.
+
+### The gate set may only escalate
+
+After the lock, `selected`, `core` and `declined` stay writable in ONE DIRECTION
+only — "the lock is a floor, not a ceiling":
+
+- **`ceremony.selected` and `ceremony.core` may not SHRINK.** A write that drops
+  an element is refused (exit 1) naming the dropped elements.
+- **`ceremony.declined` may not GROW.** A write that adds an element is refused
+  (exit 1) naming the added ones, because growing `declined` removes a gate from
+  the run by the back door. `declined` shrinks legitimately on promotion.
+
+The comparison is unconditional, not guarded on a truthy prior value. Locking
+with NOTHING declined is the DEFAULT path (`source = "default_full"`), so a
+guard that skipped an empty prior value would let a single post-lock
+`set ceremony.declined <gate>` drop a gate in the most common configuration.
+One element is one non-blank stripped line; order and blank lines carry no
+meaning, so a reordering does not read as a change. `promotions` and the
+remaining fields are unrestricted — they record history rather than the gate set.
+
+De-escalation mid-run is not a thing. Every one of these refusals names the same
+remedy: `archive-ceremony` and re-select in a fresh Phase 0.
+
+### A malformed ledger shape is refused with a remedy, not a traceback
+
+A ledger on disk can hold the wrong type where the shape says object or string —
+an older ledger written through the `set ceremony <value>` bypass now closed, or
+a hand edit, which this module's own docstring invites. This is the RECOVERY
+path, and a traceback is most expensive exactly there: the reader is already
+holding a broken ledger and trying to repair it.
+
+- `ceremony` stored as a non-object → refused (exit 1) rather than raising
+  `AttributeError`, naming `archive-ceremony` to move it to `ceremony_history`
+  and clear it, then re-select in a fresh Phase 0.
+- A ceremony field stored as a non-string where a newline-joined scalar belongs →
+  refused (exit 1), naming which field is malformed, with the same remedy.
+- The ledger file is not valid JSON → refused, rather than silently overwritten;
+  rename the corrupt file aside and start a new ledger.
+- The ledger file is valid JSON but not an object → refused.
+- No home directory resolvable and the default path is needed → refused, naming
+  the remedy: set `$SPELLBOOK_DEV_DIR`, or pass `--path`. It does NOT fall back
+  to a directory under the cwd; that would exit 0 while reading and writing a
+  ledger that is not the project's.
+
+### False-pass guards on the recorders
+
+A failure with nothing to fix reads exactly like a pass, so both status
+recorders refuse one:
+
+- `wave-discipline --status failed` with no `--open-rows` → refused (exit 2).
+- `group-gate --status failed` with no `--open-findings` → refused (exit 2).
+- Any `--status` outside `passed`/`failed`/`n_a` → refused (exit 2).
+
+`archive-ceremony` refuses a blank or missing `--reason` (an archive with no
+stated reason is exactly the unaudited supersede the lock prevents), and refuses
+to run when there is no ceremony to archive.
+
+`blocker` refuses to open without `--type` (the kind of a blocker is recorded at
+open time and has no default), refuses `--close` on an id that was never opened
+(closing a blocker that never opened would record a gate that never ran), and
+refuses a `--type` on close that disagrees with the stored type — either the id
+or the `--type` is wrong; omit `--type` to close.

--- a/tests/scripts/test_develop_gate_ledger.py
+++ b/tests/scripts/test_develop_gate_ledger.py
@@ -2210,31 +2210,147 @@ def _cli_subcommands() -> set[str]:
     return set(action.choices)
 
 
-def test_every_named_remedy_is_a_command_the_cli_accepts():
+LEDGER_DOC_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "skills"
+    / "develop"
+    / "references"
+    / "ledger-cli.md"
+)
+
+# A backticked span is treated as an invocation only through its FIRST
+# whitespace-separated token, and only when that token has the shape of a
+# hyphenated subcommand: lowercase alphanumeric words joined by hyphens. That
+# rule is what separates a remedy from the rest of the backticked text in these
+# files. It excludes flags (`--open-rows` starts with a dash), paths
+# (`scripts/develop_gate_ledger.py` contains a slash), dotted and underscored
+# field names (`ceremony.locked_at`, `ceremony_history`, `open_rows`), literal
+# values (`per_group` is underscored, `passed` has no hyphen), and exception
+# class names (`LedgerError` is not lowercase). It also excludes the
+# non-hyphenated subcommands, which cannot be told apart from field names by
+# shape alone -- `blocker` the command and `blockers` the field differ by one
+# letter. Those are covered by the "Use instead" table check below, which knows
+# from position that a cell holds a remedy.
+_COMMAND_TOKEN = re.compile(r"[a-z][a-z0-9]*(?:-[a-z0-9]+)+")
+
+
+def _hyphenated_command_tokens(text: str) -> set[str]:
+    tokens = set()
+    for span in re.findall(r"`+([^`\n]+)`+", text):
+        parts = span.split()
+        if parts and _COMMAND_TOKEN.fullmatch(parts[0]):
+            tokens.add(parts[0])
+    return tokens
+
+
+def test_hyphenated_command_token_extractor_is_not_vacuous():
+    """The floor for the extractor itself. An extractor that matched nothing
+    would let every check below pass by finding no work to do."""
+    assert _hyphenated_command_tokens("run `wave-discipline 3a --status passed`") == {
+        "wave-discipline"
+    }
+    # The exclusions are asserted, not assumed: each of these is a real span
+    # from the files under test that must NOT be read as a remedy.
+    assert _hyphenated_command_tokens(
+        "`--open-rows` `scripts/develop_gate_ledger.py` `ceremony.locked_at` "
+        "`ceremony_history` `open_rows` `per_group` `passed` `LedgerError` "
+        "`blockers`"
+    ) == set()
+
+
+def test_every_named_remedy_resolves_to_a_real_subcommand():
     """A refusal that names a command argparse rejects tells the reader to run
     something that cannot run -- the refusal becomes a dead end at exactly the
-    moment the caller is stuck. The remedies are prose inside error strings, so
-    nothing but this test ties them to the parser they name.
+    moment the caller is stuck. The remedies are prose inside error strings and
+    inside the reference doc, so nothing but this test ties them to the parser
+    they name.
 
-    The vocabulary is derived from `_STRUCTURED_FIELD_ROUTES` and from the
-    hyphenated backticked tokens in the module source, not from a hand-written
-    list beside them: a second copy of the remedy set would drift from the
-    messages exactly as silently as the messages drift from the parser.
+    Both sources are scanned. The module's messages and the doc's prose restate
+    the same vocabulary INDEPENDENTLY, so pinning only the Python side leaves a
+    remedy spelled wrong in the doc passing CI -- the hand-written list that
+    drifts, wearing a different hat.
+
+    The vocabulary is derived from the parser and from the text itself, never
+    from a list written beside them: a second copy of the remedy set would
+    drift from the messages exactly as silently as the messages drift from the
+    parser.
     """
     commands = _cli_subcommands()
-    source = Path(ledger.__file__).read_text(encoding="utf-8")
-    named = set(re.findall(r"`{1,2}([a-z][a-z0-9]*(?:-[a-z0-9]+)+)", source))
-    for route in ledger._STRUCTURED_FIELD_ROUTES.values():
-        named |= set(re.findall(r"`([a-z][a-z0-9-]*)", route))
-    # Only tokens that look like a subcommand invocation are in scope; a
-    # backticked field name is not a remedy.
-    candidates = {n for n in named if "-" in n}
-    assert candidates, "no command-shaped remedy tokens found -- regex went stale"
-    unknown = sorted(n for n in candidates if n not in commands)
-    assert not unknown, (
-        f"refusal messages name commands the CLI does not accept: {unknown!r}; "
-        f"accepted subcommands are {sorted(commands)}"
+    hyphenated = {c for c in commands if "-" in c}
+    assert hyphenated, "the parser declares no hyphenated subcommand -- floor gone"
+
+    sources = {
+        "module source": Path(ledger.__file__).read_text(encoding="utf-8"),
+        "reference doc": LEDGER_DOC_PATH.read_text(encoding="utf-8"),
+    }
+    for label, text in sources.items():
+        named = _hyphenated_command_tokens(text)
+        for route in ledger._STRUCTURED_FIELD_ROUTES.values():
+            named |= _hyphenated_command_tokens(route)
+        # Anti-no-op floor, derived from the parser rather than counted by
+        # hand: both files route to every hyphenated recorder, so an extractor
+        # that goes stale drops below this and fails instead of passing empty.
+        assert named >= hyphenated, (
+            f"{label} names only {sorted(named)}; the parser declares "
+            f"{sorted(hyphenated)}. The extractor has gone stale, or the "
+            f"file stopped naming a recorder it must route to."
+        )
+        unknown = sorted(n for n in named if n not in commands)
+        assert not unknown, (
+            f"{label} names commands the CLI does not accept: {unknown!r}; "
+            f"accepted subcommands are {sorted(commands)}"
+        )
+
+
+def _doc_use_instead_rows() -> list[tuple[str, str]]:
+    """The (field, remedy) rows of the doc's `set` refusal table.
+
+    Read by POSITION, not by shape: the second cell of a row under the
+    `Use instead` header is a remedy by construction, which is how the
+    non-hyphenated `blocker` gets covered at all.
+    """
+    lines = LEDGER_DOC_PATH.read_text(encoding="utf-8").splitlines()
+    rows: list[tuple[str, str]] = []
+    for i, line in enumerate(lines):
+        if not re.match(r"\s*\|\s*Field\s*\|\s*Use instead\s*\|", line):
+            continue
+        for row in lines[i + 2:]:
+            if not row.lstrip().startswith("|"):
+                break
+            cells = [c.strip() for c in row.strip().strip("|").split("|")]
+            if len(cells) == 2:
+                rows.append((cells[0].strip("`"), cells[1]))
+    return rows
+
+
+def test_doc_use_instead_table_covers_every_structured_field():
+    """The floor for the table reader. A reader that found no rows -- renamed
+    header, reformatted table -- would let the check below pass vacuously, and
+    the row set is fixed by `_STRUCTURED_FIELD_ROUTES`, not by a count here."""
+    fields = {field for field, _ in _doc_use_instead_rows()}
+    assert fields == set(ledger._STRUCTURED_FIELD_ROUTES), (
+        f"the doc's `Use instead` table covers {sorted(fields)}; the refusals "
+        f"cover {sorted(ledger._STRUCTURED_FIELD_ROUTES)}"
     )
+
+
+def test_every_doc_use_instead_remedy_names_a_real_subcommand():
+    """The doc's table is a second, independent copy of the routes. `blocker`
+    and `set` are not hyphenated, so only reading the cell by position catches
+    a misspelling of them."""
+    commands = _cli_subcommands()
+    rows = _doc_use_instead_rows()
+    assert rows, "no `Use instead` rows found -- the table reader went stale"
+    for field, remedy in rows:
+        tokens = {
+            span.split()[0]
+            for span in re.findall(r"`+([^`\n]+)`+", remedy)
+            if span.split()
+        }
+        assert tokens & commands, (
+            f"the doc routes {field!r} to {remedy!r}, which names no "
+            f"subcommand the CLI accepts; accepted are {sorted(commands)}"
+        )
 
 
 def test_every_structured_field_route_names_a_real_subcommand():

--- a/tests/scripts/test_develop_gate_ledger.py
+++ b/tests/scripts/test_develop_gate_ledger.py
@@ -1590,7 +1590,8 @@ def test_cli_blocker_open_without_type_errors(tmp_ledger):
 def test_cli_blocker_close_with_contradicting_type_errors(tmp_ledger):
     _run_cli("blocker", "B1", "--type", "decision", "--timestamp", "2026-08-11T09:00Z")
     proc = _run_cli("blocker", "B1", "--type", "work", "--close")
-    assert proc.returncode == 2
+    # 1, not 2: the stored blocker's type is what the operation cannot use.
+    assert proc.returncode == 1
     assert "type mismatch" in proc.stderr
     assert "closed_at" not in json.loads(tmp_ledger.read_text())["blockers"]["B1"]
 
@@ -1605,7 +1606,8 @@ def test_cli_blocker_rejects_invalid_type(tmp_ledger):
 @pytest.mark.allow("subprocess")
 def test_cli_blocker_close_nonexistent_errors(tmp_ledger):
     proc = _run_cli("blocker", "B9", "--type", "work", "--close")
-    assert proc.returncode == 2
+    # 1, not 2: the id is well-formed; the ledger holds no blocker under it.
+    assert proc.returncode == 1
     assert "no open blocker" in proc.stderr
 
 
@@ -2245,3 +2247,78 @@ def test_every_structured_field_route_names_a_real_subcommand():
         assert tokens & commands, (
             f"route for {field!r} names no accepted subcommand: {route!r}"
         )
+
+
+# ---- the documented exit-code split, on every subcommand ------------------
+#
+# `references/ledger-cli.md` states the contract: 1 means the STORED ledger is
+# not what the operation needs, 2 means the CALLER asked for something the
+# ledger does not accept. A caller can only branch on that split if it holds
+# everywhere. Five recorders collapsed both exceptions into a single exit 2, so
+# a corrupt ledger reached through `blocker` told the caller "fix the command"
+# while the ledger needed repair -- the wrong half of the split, and the half
+# that sends the reader looking at correct input.
+
+
+CORRUPT_LEDGER = "{not json at all"
+
+
+@pytest.mark.allow("subprocess")
+@pytest.mark.parametrize(
+    ("name", "argv"),
+    [
+        ("archive-ceremony", ("archive-ceremony", "--reason", "re-select")),
+        ("wave-discipline", ("wave-discipline", "W1", "--status", "passed")),
+        ("blocker", ("blocker", "B1", "--type", "work")),
+        ("group-gate", ("group-gate", "G1", "--status", "passed")),
+        (
+            "record-dispatch",
+            ("record-dispatch", "--subagent-type", "impl", "--description", "d"),
+        ),
+    ],
+)
+def test_cli_exits_1_when_the_stored_ledger_is_corrupt(tmp_ledger, name, argv):
+    """A corrupt ledger is a stored-state failure on every route into it."""
+    _write_raw_ledger(tmp_ledger, CORRUPT_LEDGER)
+    proc = _run_cli(*argv)
+    assert proc.returncode == 1, (
+        f"{name!r} exited {proc.returncode} on a corrupt ledger; the documented "
+        f"contract reserves 1 for a stored-ledger failure. stderr: "
+        f"{proc.stderr.strip()}"
+    )
+    assert "not valid JSON" in proc.stderr
+    assert "Traceback" not in proc.stderr
+
+
+@pytest.mark.allow("subprocess")
+@pytest.mark.parametrize(
+    ("name", "argv", "expected_message"),
+    [
+        (
+            "archive-ceremony",
+            ("archive-ceremony", "--reason", "   "),
+            "non-blank reason",
+        ),
+        (
+            "wave-discipline",
+            ("wave-discipline", "W1", "--status", "failed"),
+            "at least one open row",
+        ),
+        ("blocker", ("blocker", "B1",), "requires --type"),
+        (
+            "group-gate",
+            ("group-gate", "G1", "--status", "failed"),
+            "at least one open finding",
+        ),
+    ],
+)
+def test_cli_exits_2_when_the_caller_asked_for_something_invalid(
+    tmp_ledger, name, argv, expected_message
+):
+    """The other half of the split: a well-formed ledger, a bad argument."""
+    proc = _run_cli(*argv)
+    assert proc.returncode == 2, (
+        f"{name!r} exited {proc.returncode} on a caller error; the documented "
+        f"contract reserves 2 for that. stderr: {proc.stderr.strip()}"
+    )
+    assert expected_message in proc.stderr

--- a/tests/scripts/test_develop_gate_ledger.py
+++ b/tests/scripts/test_develop_gate_ledger.py
@@ -8,10 +8,12 @@ skill's usage of the ledger, which is exercised by an actual develop
 run, not a Python test.
 """
 
+import argparse
 import ast
 import json
 import logging
 import os
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -2194,3 +2196,52 @@ def test_archive_ceremony_still_refuses_a_genuinely_empty_ceremony(tmp_ledger, r
     _write_raw_ledger(tmp_ledger, f'{{"ceremony": {raw}}}')
     with pytest.raises(ledger.LedgerError, match="no ceremony"):
         ledger.archive_ceremony("aborted the run")
+
+
+def _cli_subcommands() -> set[str]:
+    """Every subcommand `main` accepts, read off the parser itself."""
+    action = next(
+        a
+        for a in ledger.build_parser()._actions
+        if isinstance(a, argparse._SubParsersAction)
+    )
+    return set(action.choices)
+
+
+def test_every_named_remedy_is_a_command_the_cli_accepts():
+    """A refusal that names a command argparse rejects tells the reader to run
+    something that cannot run -- the refusal becomes a dead end at exactly the
+    moment the caller is stuck. The remedies are prose inside error strings, so
+    nothing but this test ties them to the parser they name.
+
+    The vocabulary is derived from `_STRUCTURED_FIELD_ROUTES` and from the
+    hyphenated backticked tokens in the module source, not from a hand-written
+    list beside them: a second copy of the remedy set would drift from the
+    messages exactly as silently as the messages drift from the parser.
+    """
+    commands = _cli_subcommands()
+    source = Path(ledger.__file__).read_text(encoding="utf-8")
+    named = set(re.findall(r"`{1,2}([a-z][a-z0-9]*(?:-[a-z0-9]+)+)", source))
+    for route in ledger._STRUCTURED_FIELD_ROUTES.values():
+        named |= set(re.findall(r"`([a-z][a-z0-9-]*)", route))
+    # Only tokens that look like a subcommand invocation are in scope; a
+    # backticked field name is not a remedy.
+    candidates = {n for n in named if "-" in n}
+    assert candidates, "no command-shaped remedy tokens found -- regex went stale"
+    unknown = sorted(n for n in candidates if n not in commands)
+    assert not unknown, (
+        f"refusal messages name commands the CLI does not accept: {unknown!r}; "
+        f"accepted subcommands are {sorted(commands)}"
+    )
+
+
+def test_every_structured_field_route_names_a_real_subcommand():
+    """Each `set` refusal routes to a recorder. If that recorder is spelled
+    wrong, the refusal is a dead end for the one operation it exists to
+    redirect."""
+    commands = _cli_subcommands()
+    for field, route in ledger._STRUCTURED_FIELD_ROUTES.items():
+        tokens = set(re.findall(r"`([a-z][a-z0-9-]*)", route))
+        assert tokens & commands, (
+            f"route for {field!r} names no accepted subcommand: {route!r}"
+        )

--- a/tests/scripts/test_develop_gate_ledger.py
+++ b/tests/scripts/test_develop_gate_ledger.py
@@ -1518,9 +1518,9 @@ def test_cli_wave_discipline_failed_refused(tmp_ledger):
 
 @pytest.mark.allow("subprocess")
 def test_cli_wave_discipline_na_with_reason(tmp_ledger):
-    """The documented invocation from skills/develop/SKILL.md must actually
-    work from the CLI -- prose describing a flag that does not exist is the
-    defect this finding raised."""
+    """The documented invocation from skills/develop/references/ledger-cli.md
+    must actually work from the CLI -- prose describing a flag that does not
+    exist is the defect this finding raised."""
     proc = _run_cli(
         "wave-discipline", "plan",
         "--status", "n_a",


### PR DESCRIPTION
## ⚠ Merge-order hazard — read before merging

This branch and [#471](https://github.com/axiomantic/spellbook/pull/471) both define
`test_every_named_remedy_is_a_command_the_cli_accepts` in
`tests/scripts/test_develop_gate_ledger.py`. #471's is parametrized
`(tmp_ledger, field, trigger)`; this one takes no arguments. **If both land, Python keeps
the last definition and the earlier one silently never runs.**

#471's version is the better one — it is parametrized across fields and triggers. **When
#471 merges, drop this branch's copy during reconciliation.** This branch's guard exists
only because the mechanism was genuinely absent from `main` when this work started.

## What does this PR do?

Moves the ledger CLI reference out of `skills/develop/SKILL.md` and documents what the CLI
actually does now.

**The ceiling was blocking a documentation fix.** `SKILL.md` sat at 111,169 bytes / 2,110
lines against a ratchet ceiling of 111,268 / 2,116 — 99 bytes and 6 lines of headroom. Its
CLI reference had gone wrong by omission: recent work added refusals it never mentioned, and
there was no room to describe them in place.

The reference now lives at `skills/develop/references/ledger-cli.md`. That destination was
chosen because `skills/develop/` had no `references/` directory and no `develop-*`
sub-commands, and the CLI's consumers are three separate commands plus another skill — no
single command owns it, so a sub-command would have given shared material an owner it does
not have. `references/` is the established local shape for exactly that case, following
`skills/fractal-thinking/references/mcp-tools.md`.

**The ceiling ratcheted down**, which is the point of the move:

| | bytes | lines |
|---|---|---|
| SKILL.md before | 111,169 | 2,110 |
| SKILL.md after | 103,975 | 2,001 |
| Ceiling before | 111,268 | 2,116 |
| Ceiling after | 103,975 | 2,001 |

**Content moved, nothing dropped** — verified rather than asserted: all 123 non-blank lines
of the moved section are present in the new file, zero missing.

## What the documentation now says, derived from the code

Six structured fields refused by a bare `set`, with `need_flags` deliberately excluded
because it has no recorder. Blank `locked_at` refused; `locked_at` rewrite refused;
`gate_position` reposition refused; `selected`/`core` may not shrink and `declined` may not
grow. Malformed-shape refusals and their remedies. False-pass guards on
`wave-discipline`/`group-gate`, `archive-ceremony --reason`, and the three `blocker` guards.
The exit-code split: 1 means repair the ledger, 2 means fix the command.

**Two things found in the code that no brief mentioned.** The docs listed 6 of the 8
subcommands the parser accepts — `record-dispatch` and `dispatches` were entirely
undocumented. And `dispatches` exits 1 on no match, which is precisely what lets it serve as
a phase-verification check rather than a self-tick; that property appeared nowhere in the
prose.

## Verification worth noting

**The ratchet was proven to still bite at its new, lower value**: appending a marker drove
`validate_schemas.py` red citing `104,009 bytes > 103,975 ceiling`.

**The reference gate was proven, not trusted**: references moved 146 → 150, exactly the four
pointers added, and removing the target turned all four red. This is why the pointer uses the
`skills/`-anchored path — `references/...` is not in `ANCHOR_DIRS`, so a bare relative form
would have been prose no gate reads.

**The two commits split deliberately.** The first is a pure move that changes no test count
(1897 passed / 2 skipped, identical to baseline), which makes "nothing was lost" reviewable
on its own. Folding new content in would have hidden that signal inside a large diff.

## Known limit

`generate_docs.py` walks only `skill_dir/"SKILL.md"`, so `references/*.md` is never mirrored
— `docs/skills/develop.md` carries the pointer but not the CLI detail. This matches existing
precedent (`fractal-thinking/references/mcp-tools.md` is likewise unmirrored). Making
`references/` browsable is a separate change to `generate_docs.py` and was not made here.

## Related issue

None.

## Checklist

- [x] Tests pass locally — 1902 passed, 2 skipped
- [x] Documentation updated (if applicable) — `docs/` mirror regenerated; the pointer is
      present in the mirror, verified as an artifact rather than by exit code
