### PR TITLE
Write every token-bearing config with 0600, not just two

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Every platform installer that copies the MCP bearer token into a harness
+  config file now writes that file with mode 0600, through one shared
+  `installer.components.mcp.write_token_bearing_file`. Measured on a real
+  machine before the fix: `~/.local/spellbook/.mcp-token` is 0600 at its
+  source, but `~/.codex/config.toml`, `~/.config/opencode/opencode.json` and
+  `~/.pi/agent/mcp.json` carried the live token at 0644, readable by any other
+  local account. The `os.open` mode argument applies only to files it creates,
+  so a config file already on disk at 0644 kept that mode through `O_TRUNC`;
+  an explicit `fchmod` on the descriptor is what tightens it, and it runs on
+  the next install for files that already exist. The pattern existed in
+  `installer/platforms/forgecode.py` and `goose.py` since their PR review and
+  was never generalised to the other four token-bearing installers
+  (`antigravity`, `codex`, `opencode`, `pi`). Files that do not carry the token
+  are unchanged. `tests/installer/test_token_file_permissions.py` derives the
+  installer set from `installer/platforms/` rather than a hand list, so a
+  platform added later is covered without anyone extending the test.
+
 ### Changed
 
 - `spellbook.core.path_utils.resolve_repo_root` reads the repository root off

--- a/installer/components/mcp.py
+++ b/installer/components/mcp.py
@@ -678,6 +678,47 @@ def get_mcp_auth_token() -> Optional[str]:
     return None
 
 
+# Mode for any file that carries a copy of the bearer token. TOKEN_PATH itself
+# is 0600; a copy must not be more readable than its source.
+TOKEN_FILE_MODE = 0o600
+
+
+def write_token_bearing_file(path: Path, content: str) -> None:
+    """Write ``content`` to ``path`` with mode 0600, tightening a broader mode.
+
+    Every platform installer that embeds the bearer token in a harness config
+    file writes it through here, so the permission decision lives in one place
+    instead of once per platform.
+
+    The ``mode`` argument to ``os.open`` applies only to files it CREATES. A
+    config file already on disk at 0644 -- written by an older spellbook, or
+    by the harness itself -- keeps its inode and its mode through ``O_TRUNC``,
+    so the token would land in a world-readable file. The explicit ``fchmod``
+    is what closes that; it operates on the descriptor rather than the path so
+    there is no window between the chmod and the write in which the token is
+    present at the broader mode.
+
+    ``hasattr(os, "fchmod")`` guards Windows, where POSIX mode bits do not
+    apply and chmod is effectively a no-op.
+    """
+    fd = os.open(
+        os.fspath(path),
+        os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
+        TOKEN_FILE_MODE,
+    )
+    try:
+        if hasattr(os, "fchmod"):
+            os.fchmod(fd, TOKEN_FILE_MODE)
+        # os.fdopen takes ownership of fd; its context manager closes it.
+        handle = os.fdopen(fd, "w", encoding="utf-8")
+    except BaseException:
+        os.close(fd)
+        raise
+
+    with handle:
+        handle.write(content)
+
+
 def get_launchd_plist_path() -> Path:
     """Get path to launchd plist file."""
     return Path.home() / "Library" / "LaunchAgents" / f"{LAUNCHD_LABEL}.plist"

--- a/installer/platforms/antigravity.py
+++ b/installer/platforms/antigravity.py
@@ -15,7 +15,12 @@ import shutil
 from pathlib import Path
 from typing import TYPE_CHECKING, List, Optional, Tuple
 
-from ..components.mcp import DEFAULT_HOST, DEFAULT_PORT, get_mcp_auth_token
+from ..components.mcp import (
+    DEFAULT_HOST,
+    DEFAULT_PORT,
+    get_mcp_auth_token,
+    write_token_bearing_file,
+)
 from ..components.rule_delivery import INSTALLED_GLOB
 from ..components.rule_modules import PER_FILE_CAP_BYTES
 from ..components.symlinks import create_symlink, remove_symlink
@@ -148,8 +153,10 @@ class AntigravityInstaller(PlatformInstaller):
 
         config["mcpServers"]["spellbook"] = server_config
 
-        content = json.dumps(config, indent=2) + "\n"
-        self.mcp_config_path.write_text(content, encoding="utf-8")
+        # mcp_config.json carries the bearer token in its headers map.
+        write_token_bearing_file(
+            self.mcp_config_path, json.dumps(config, indent=2) + "\n"
+        )
 
         return (True, action)
 
@@ -354,7 +361,10 @@ class AntigravityInstaller(PlatformInstaller):
                     config = json.loads(content)
                     if "mcpServers" in config and "spellbook" in config["mcpServers"]:
                         del config["mcpServers"]["spellbook"]
-                        self.mcp_config_path.write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
+                        write_token_bearing_file(
+                            self.mcp_config_path,
+                            json.dumps(config, indent=2) + "\n",
+                        )
                         results.append(
                             InstallResult(
                                 component="mcp",

--- a/installer/platforms/codex.py
+++ b/installer/platforms/codex.py
@@ -7,7 +7,11 @@ import re
 from pathlib import Path
 from typing import TYPE_CHECKING, List, Tuple
 
-from ..components.mcp import get_mcp_auth_token, get_spellbook_server_url
+from ..components.mcp import (
+    get_mcp_auth_token,
+    get_spellbook_server_url,
+    write_token_bearing_file,
+)
 from ..components.symlinks import (
     create_symlink,
     create_skill_symlinks,
@@ -64,18 +68,18 @@ def _add_mcp_to_config_toml(
                 re.DOTALL,
             )
             new_content = pattern.sub(section, content)
-            config_path.write_text(new_content, encoding="utf-8")
+            write_token_bearing_file(config_path, new_content)
             return (True, "updated MCP server config")
         else:
             # Append new section
             if not content.endswith("\n"):
                 content += "\n"
             content += "\n" + section
-            config_path.write_text(content, encoding="utf-8")
+            write_token_bearing_file(config_path, content)
             return (True, "registered MCP server")
     else:
         # Create new config.toml
-        config_path.write_text(section, encoding="utf-8")
+        write_token_bearing_file(config_path, section)
         return (True, "created config.toml with MCP server")
 
 
@@ -99,7 +103,7 @@ def _remove_mcp_from_config_toml(
         re.DOTALL,
     )
     new_content = pattern.sub("", content)
-    config_path.write_text(new_content, encoding="utf-8")
+    write_token_bearing_file(config_path, new_content)
     return (True, "removed MCP server config")
 
 

--- a/installer/platforms/forgecode.py
+++ b/installer/platforms/forgecode.py
@@ -11,11 +11,8 @@ Config dir resolution priority (per design Section 3):
 3. ~/.forge (default)
 
 The .mcp.json file is written with mode 0600 because it contains a plaintext
-bearer token. We use ``os.open`` with mode 0o600 to set restrictive
-permissions on creation, then ``os.fchmod`` on the fd to also tighten any
-pre-existing file (the ``mode`` arg to ``os.open`` only applies on creation,
-so an existing 0o644 file would otherwise survive ``O_TRUNC`` with broad
-permissions intact). The spellbook server entry sets ``oauth: false`` to
+bearer token; ``installer.components.mcp.write_token_bearing_file`` owns that
+rule for every platform. The spellbook server entry sets ``oauth: false`` to
 disable OAuth auto-detection on the forge client side.
 
 Reference: design doc 2026-04-30-forgecode-support-design.md, Section 3.
@@ -27,7 +24,12 @@ import os
 from pathlib import Path
 from typing import TYPE_CHECKING, List, Optional, Tuple
 
-from ..components.mcp import DEFAULT_HOST, DEFAULT_PORT, get_mcp_auth_token
+from ..components.mcp import (
+    DEFAULT_HOST,
+    DEFAULT_PORT,
+    get_mcp_auth_token,
+    write_token_bearing_file,
+)
 from ..components.rule_bundle import DELIVERY_MARKER_PREFIX
 from ..demarcation import (
     get_installed_version,
@@ -96,37 +98,8 @@ def _load_mcp_config_dict(config_path: Path) -> dict:
 
 
 def _write_mcp_config_secure(config_path: Path, config: dict) -> None:
-    """Write JSON config with mode 0600 atomically (no TOCTOU window).
-
-    ``os.open`` with mode 0o600 only applies to *newly created* files; if
-    ``config_path`` already exists with broader permissions (e.g. 0o644 from
-    a prior installer version), ``O_TRUNC`` preserves the existing mode.
-    We therefore explicitly ``os.fchmod`` the file descriptor after open to
-    tighten any pre-existing mode before writing the bearer token. This
-    closes the gap flagged in PR review (cycle 4): an existing 0o644
-    ``.mcp.json`` would otherwise leak the token to other local users.
-
-    Operating on the fd (not the path) avoids a TOCTOU window between
-    chmod and write. ``hasattr(os, "fchmod")`` guards Windows where chmod
-    is already a no-op.
-    """
-    payload = json.dumps(config, indent=2) + "\n"
-    fd = os.open(
-        os.fspath(config_path),
-        os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
-        0o600,
-    )
-    try:
-        if hasattr(os, "fchmod"):
-            os.fchmod(fd, 0o600)
-        # os.fdopen takes ownership of fd; its context manager closes it.
-        f = os.fdopen(fd, "w", encoding="utf-8")
-    except BaseException:
-        os.close(fd)
-        raise
-
-    with f:
-        f.write(payload)
+    """Write JSON config with mode 0600 (see ``write_token_bearing_file``)."""
+    write_token_bearing_file(config_path, json.dumps(config, indent=2) + "\n")
 
 
 def _update_forgecode_mcp_config(

--- a/installer/platforms/goose.py
+++ b/installer/platforms/goose.py
@@ -44,6 +44,7 @@ from ..components.mcp import (
     DEFAULT_HOST,
     DEFAULT_PORT,
     get_mcp_auth_token,
+    write_token_bearing_file,
 )
 from ..components.symlinks import (
     create_skill_symlinks,
@@ -252,27 +253,8 @@ def _update_goose_mcp_config(
 
     new_text = _insert_spellbook_block(existing, _generate_mcp_yaml_list_item())
 
-    # Atomic write with mode 0600 (config.yaml contains a plaintext bearer token)
-    # BOT-B2 fix: `os.fdopen()` returns a file object that OWNS the fd. When
-    # `with os.fdopen(...)` exits (whether normally or via exception inside the
-    # block), the file object closes the fd. The previous code then called
-    # `os.close(fd)` in the except handler, which double-closed the same fd.
-    # On POSIX this is UB (can close a different fd acquired in the race
-    # window). Just let the context manager own the fd; if `f.write()` raises,
-    # the `with` block already closed fd before re-raising.
-    fd = os.open(
-        os.fspath(config_path),
-        os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
-        0o600,
-    )
-    # BOT-B2 fix: os.fdopen() owns fd. Its context manager closes fd (via the C
-    # extension) on either normal exit OR exception -- including f.write()
-    # raising. No explicit try/except / os.close needed; the original exception
-    # propagates automatically, and we never double-close.
-    if hasattr(os, "fchmod"):
-        os.fchmod(fd, 0o600)
-    with os.fdopen(fd, "w", encoding="utf-8") as f:
-        f.write(new_text)
+    # config.yaml carries a plaintext bearer token, so it is written 0600.
+    write_token_bearing_file(config_path, new_text)
 
     return (True, action)
 
@@ -291,18 +273,7 @@ def _remove_goose_mcp_config(
         return (True, "MCP server was not configured")
 
     new_text = _strip_spellbook_block(existing)
-    # BOT-B2 fix: see _update_goose_mcp_config. fdopen() owns the fd; the
-    # except handler must NOT close fd again.
-    # BOT-B2 fix: see _update_goose_mcp_config. fdopen() owns the fd.
-    fd = os.open(
-        os.fspath(config_path),
-        os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
-        0o600,
-    )
-    if hasattr(os, "fchmod"):
-        os.fchmod(fd, 0o600)
-    with os.fdopen(fd, "w", encoding="utf-8") as f:
-        f.write(new_text)
+    write_token_bearing_file(config_path, new_text)
 
     return (True, "removed MCP server config")
 

--- a/installer/platforms/opencode.py
+++ b/installer/platforms/opencode.py
@@ -33,7 +33,12 @@ import os
 from pathlib import Path
 from typing import TYPE_CHECKING, List, Tuple
 
-from ..components.mcp import DEFAULT_HOST, DEFAULT_PORT, get_mcp_auth_token
+from ..components.mcp import (
+    DEFAULT_HOST,
+    DEFAULT_PORT,
+    get_mcp_auth_token,
+    write_token_bearing_file,
+)
 from ..components.rule_delivery import INSTALLED_GLOB
 from ..components.symlinks import create_symlink, remove_symlink
 from ..demarcation import get_installed_version, remove_demarcated_section
@@ -103,7 +108,7 @@ def _update_opencode_config(
         config["$schema"] = "https://opencode.ai/config.json"
 
     # Write config
-    config_path.write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
+    write_token_bearing_file(config_path, json.dumps(config, indent=2) + "\n")
     return (True, action)
 
 
@@ -158,7 +163,7 @@ def _update_opencode_instructions(
         config["$schema"] = "https://opencode.ai/config.json"
 
     # Write config
-    config_path.write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
+    write_token_bearing_file(config_path, json.dumps(config, indent=2) + "\n")
     return (True, action)
 
 
@@ -202,7 +207,7 @@ def _remove_opencode_instructions(
     config["instructions"] = instructions
 
     # Write config back
-    config_path.write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
+    write_token_bearing_file(config_path, json.dumps(config, indent=2) + "\n")
     return (True, "removed instructions path")
 
 
@@ -229,7 +234,7 @@ def _remove_opencode_mcp_config(
     del config["mcp"]["spellbook"]
 
     # Write config back
-    config_path.write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
+    write_token_bearing_file(config_path, json.dumps(config, indent=2) + "\n")
     return (True, "removed MCP server config")
 
 

--- a/installer/platforms/pi.py
+++ b/installer/platforms/pi.py
@@ -18,7 +18,11 @@ import os
 from pathlib import Path
 from typing import TYPE_CHECKING, List, Tuple
 
-from ..components.mcp import get_mcp_auth_token, get_spellbook_server_url
+from ..components.mcp import (
+    get_mcp_auth_token,
+    get_spellbook_server_url,
+    write_token_bearing_file,
+)
 from ..components.symlinks import (
     cleanup_spellbook_symlinks,
     create_skill_symlinks,
@@ -60,18 +64,24 @@ def _load_mcp_config_dict(config_path: Path) -> dict:
 
 
 def _write_mcp_config(config_path: Path, config: dict) -> None:
-    """Write JSON config atomically.
+    """Write JSON config atomically, with mode 0600.
 
     Writes to a temporary file in the same directory as ``config_path`` (so
     ``os.replace`` is an atomic rename on the same filesystem) and then
     atomically replaces the target. On any failure the temporary file is
     removed so a partial write never lands at ``config_path``.
+
+    The temporary file is written through ``write_token_bearing_file`` because
+    mcp.json carries the bearer token, and ``os.replace`` carries the source
+    inode's mode onto the destination. That also tightens a pre-existing 0644
+    ``config_path``, whose inode is discarded by the rename. The token is
+    never present in a world-readable file, not even in the temporary one.
     """
     config_path.parent.mkdir(parents=True, exist_ok=True)
     payload = json.dumps(config, indent=2) + "\n"
     tmp_path = config_path.with_name(f"{config_path.name}.tmp.{os.getpid()}")
     try:
-        tmp_path.write_text(payload, encoding="utf-8")
+        write_token_bearing_file(tmp_path, payload)
         os.replace(tmp_path, config_path)
     except BaseException:
         try:

--- a/tests/installer/test_token_file_permissions.py
+++ b/tests/installer/test_token_file_permissions.py
@@ -1,0 +1,185 @@
+"""Every installer that writes the MCP bearer token must write mode 0600.
+
+The bearer token at ``~/.local/spellbook/.mcp-token`` is mode 0600 at its
+source. Installers copy it into per-platform config files, and those copies
+must not be readable by other local accounts.
+
+The set of installers under test is DERIVED from ``installer/platforms/``
+rather than hand-listed, so a platform added later is covered without anyone
+remembering to extend this file. Discovery has a floor: a scan that finds
+nothing would report a clean pass over an unchecked tree.
+
+The pre-existing-file case is the one that matters. ``os.open``'s ``mode``
+argument applies only to files it CREATES; a config file already on disk at
+0644 survives ``O_TRUNC`` with its mode intact. Only an explicit ``fchmod``
+tightens it.
+"""
+
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PLATFORMS_DIR = REPO_ROOT / "installer" / "platforms"
+
+# A platform module reads the token only through this accessor, so its
+# presence in the source is what makes a module token-bearing.
+TOKEN_ACCESSOR = "get_mcp_auth_token"
+
+# Measured: 6 modules mention TOKEN_ACCESSOR at the time of writing
+# (antigravity, codex, forgecode, goose, opencode, pi). The floor is the
+# anti-no-op guard, not the exact count -- a new platform raises the real
+# number without touching this constant.
+MODULE_FLOOR = 6
+
+
+def _token_bearing_modules() -> set:
+    """Return the stem of every platform module that reads the bearer token."""
+    found = set()
+    for path in sorted(PLATFORMS_DIR.glob("*.py")):
+        if path.name == "__init__.py":
+            continue
+        if TOKEN_ACCESSOR in path.read_text(encoding="utf-8"):
+            found.add(path.stem)
+    return found
+
+
+DISCOVERED = _token_bearing_modules()
+
+
+# ---------------------------------------------------------------------------
+# Write-path entry points, one per token-bearing platform
+# ---------------------------------------------------------------------------
+
+
+def _run_antigravity(config_dir: Path) -> Path:
+    from installer.platforms.antigravity import AntigravityInstaller
+
+    installer = AntigravityInstaller(
+        spellbook_dir=REPO_ROOT, config_dir=config_dir, version="0.0.0"
+    )
+    installer._update_mcp_config()
+    return installer.mcp_config_path
+
+
+def _run_codex(config_dir: Path) -> Path:
+    from installer.platforms.codex import _add_mcp_to_config_toml
+
+    path = config_dir / "config.toml"
+    _add_mcp_to_config_toml(path)
+    return path
+
+
+def _run_forgecode(config_dir: Path) -> Path:
+    from installer.platforms.forgecode import _update_forgecode_mcp_config
+
+    path = config_dir / ".mcp.json"
+    _update_forgecode_mcp_config(path)
+    return path
+
+
+def _run_goose(config_dir: Path) -> Path:
+    from installer.platforms.goose import _update_goose_mcp_config
+
+    path = config_dir / "config.yaml"
+    _update_goose_mcp_config(path)
+    return path
+
+
+def _run_opencode(config_dir: Path) -> Path:
+    from installer.platforms.opencode import _update_opencode_config
+
+    path = config_dir / "opencode.json"
+    _update_opencode_config(path)
+    return path
+
+
+def _run_pi(config_dir: Path) -> Path:
+    from installer.platforms.pi import _update_pi_mcp_config
+
+    path = config_dir / "mcp.json"
+    _update_pi_mcp_config(path)
+    return path
+
+
+WRITERS = {
+    "antigravity": _run_antigravity,
+    "codex": _run_codex,
+    "forgecode": _run_forgecode,
+    "goose": _run_goose,
+    "opencode": _run_opencode,
+    "pi": _run_pi,
+}
+
+
+# ---------------------------------------------------------------------------
+# Discovery floor and coverage -- the silent-no-op guards
+# ---------------------------------------------------------------------------
+
+
+def test_discovery_finds_at_least_its_floor():
+    """A scan that matched nothing would pass every assertion below."""
+    assert len(DISCOVERED) >= MODULE_FLOOR, (
+        f"Discovered {len(DISCOVERED)} token-bearing platform modules "
+        f"({sorted(DISCOVERED)}), below the floor of {MODULE_FLOOR}. Either "
+        f"{TOKEN_ACCESSOR!r} is no longer how platforms read the token, or "
+        f"{PLATFORMS_DIR} moved. A scan that finds nothing reports a clean "
+        f"pass over an unchecked tree."
+    )
+
+
+def test_every_token_bearing_module_has_a_write_path_under_test():
+    """A new token-bearing platform fails here until its write path is covered."""
+    uncovered = DISCOVERED - set(WRITERS)
+    assert not uncovered, (
+        f"Platform module(s) {sorted(uncovered)} read the bearer token but "
+        f"have no entry in WRITERS, so nothing checks the mode of the config "
+        f"file they write. Add an entry pointing at the module's write path."
+    )
+
+
+# ---------------------------------------------------------------------------
+# The permission assertions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.posix_only
+@pytest.mark.parametrize("platform", sorted(WRITERS), ids=sorted(WRITERS))
+def test_pre_existing_world_readable_config_is_tightened(platform, tmp_path):
+    """An existing 0644 config must not survive the install at 0644.
+
+    This is the case ``os.open``'s mode argument does not cover: the file
+    already exists, so ``O_TRUNC`` reuses its inode and its mode.
+    """
+    config_dir = tmp_path / platform
+    config_dir.mkdir()
+    written = WRITERS[platform](config_dir)
+
+    # Seed the *same* path the installer writes, at a broad mode, then re-run.
+    written.write_text(written.read_text(encoding="utf-8"), encoding="utf-8")
+    written.chmod(0o644)
+    assert written.stat().st_mode & 0o777 == 0o644
+
+    WRITERS[platform](config_dir)
+
+    mode = written.stat().st_mode & 0o777
+    assert mode == 0o600, (
+        f"{platform}: {written} carries the bearer token but was left at "
+        f"{oct(mode)}; any local account can read it."
+    )
+
+
+@pytest.mark.posix_only
+@pytest.mark.parametrize("platform", sorted(WRITERS), ids=sorted(WRITERS))
+def test_newly_created_config_is_private(platform, tmp_path):
+    """A config file the installer creates must be owner-only from the start."""
+    config_dir = tmp_path / platform
+    config_dir.mkdir()
+
+    written = WRITERS[platform](config_dir)
+
+    assert written.exists(), f"{platform}: write path produced no file"
+    mode = written.stat().st_mode & 0o777
+    assert mode == 0o600, (
+        f"{platform}: newly created {written} is {oct(mode)}, expected 0600."
+    )

--- a/tests/installer/test_token_file_permissions.py
+++ b/tests/installer/test_token_file_permissions.py
@@ -15,9 +15,32 @@ argument applies only to files it CREATES; a config file already on disk at
 tightens it.
 """
 
+import ast
+import json
+from collections.abc import Callable
 from pathlib import Path
+from typing import NamedTuple
 
 import pytest
+
+from installer.platforms.antigravity import AntigravityInstaller
+from installer.platforms.codex import (
+    _add_mcp_to_config_toml,
+    _remove_mcp_from_config_toml,
+)
+from installer.platforms.forgecode import _write_mcp_config_secure
+from installer.platforms.goose import (
+    _remove_goose_mcp_config,
+    _update_goose_mcp_config,
+)
+from installer.platforms.opencode import (
+    OpenCodeInstaller,
+    _remove_opencode_instructions,
+    _remove_opencode_mcp_config,
+    _update_opencode_config,
+    _update_opencode_instructions,
+)
+from installer.platforms.pi import _write_mcp_config
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 PLATFORMS_DIR = REPO_ROOT / "installer" / "platforms"
@@ -182,4 +205,391 @@ def test_newly_created_config_is_private(platform, tmp_path):
     mode = written.stat().st_mode & 0o777
     assert mode == 0o600, (
         f"{platform}: newly created {written} is {oct(mode)}, expected 0600."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Site-level coverage
+#
+# The module-level floor above asks each token-bearing MODULE for ONE covered
+# write path. Several modules write the token from more than one place --
+# opencode alone rewrites its config from four functions -- so a module-level
+# floor leaves every write site but the covered one unguarded. Reverting any
+# of those to a plain ``write_text`` would put the token back in a
+# world-readable file that nothing in this suite ever stats.
+#
+# The population below is DERIVED from the source: every file-writing call
+# site in every token-bearing module, found by walking the AST. A hand-listed
+# set of sites would be the same defect one level up.
+#
+# Deriving the set from calls to ``write_token_bearing_file`` alone would
+# blind the guard to exactly the regression it exists to catch: a site
+# reverted to ``write_text`` would leave the derived set rather than fail it.
+# So raw ``write_text`` and ``open(..., "w")`` calls are part of the
+# population too, and a reverted site stays under test.
+#
+# That leaves the assertion, not the population, to separate a config that
+# carries the token from one that does not. Each runner seeds a realistic
+# pre-existing config containing SENTINEL in an Authorization header, and the
+# assertion sweeps the whole tree afterwards: any file whose bytes contain
+# SENTINEL must be 0600. Nothing is exempted by name. OpenCode's gate-plugin
+# write is in the population like every other site and passes because the
+# TypeScript file it copies does not contain the token -- not because an
+# allowlist excuses it. An allowlist would be a place for a real leak to hide;
+# a content test has no such place, and cannot grow one.
+# ---------------------------------------------------------------------------
+
+# A stand-in bearer token seeded into the configs the runners hand to the
+# code under test. It is what the sweep looks for, so it must not appear in
+# any file the installers write from their own sources.
+SENTINEL = "sb-sentinel-2f7c1a9e4d0b"
+
+INSTRUCTIONS_PATH = "/opt/spellbook/AGENTS.md"
+
+
+class WriteSite(NamedTuple):
+    module: str
+    qualname: str
+    lineno: int
+    kind: str
+
+    @property
+    def key(self) -> str:
+        """Identity used for coverage: the function the write lives in."""
+        return f"{self.module}::{self.qualname}"
+
+    @property
+    def site_id(self) -> str:
+        return f"{self.module}::{self.qualname}:L{self.lineno}"
+
+
+def _write_kind(call: ast.Call):
+    """Classify ``call`` as a file write, or return None."""
+    func = call.func
+    if isinstance(func, ast.Name) and func.id == "write_token_bearing_file":
+        return "helper"
+    if isinstance(func, ast.Attribute) and func.attr == "write_text":
+        return "write_text"
+    modes: list[str] = []
+    if isinstance(func, ast.Name) and func.id == "open":
+        modes = [a.value for a in call.args[1:] if isinstance(a, ast.Constant)]
+    elif isinstance(func, ast.Attribute) and func.attr == "open":
+        modes = [a.value for a in call.args[:1] if isinstance(a, ast.Constant)]
+    modes += [
+        kw.value.value
+        for kw in call.keywords
+        if kw.arg == "mode" and isinstance(kw.value, ast.Constant)
+    ]
+    for mode in modes:
+        if isinstance(mode, str) and ("w" in mode or "a" in mode or "+" in mode):
+            return "open_w"
+    return None
+
+
+def _walk_module(node, module: str, chain: list, sites: list) -> None:
+    """Collect write sites under ``node``, tracking the enclosing scope."""
+    for child in ast.iter_child_nodes(node):
+        if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            _walk_module(child, module, chain + [child.name], sites)
+            continue
+        if isinstance(child, ast.Call):
+            kind = _write_kind(child)
+            if kind is not None:
+                sites.append(WriteSite(module, "::".join(chain), child.lineno, kind))
+        _walk_module(child, module, chain, sites)
+
+
+def _write_sites() -> list[WriteSite]:
+    """Every file-writing call site in every token-bearing platform module."""
+    sites: list[WriteSite] = []
+    for module in sorted(DISCOVERED):
+        source = (PLATFORMS_DIR / f"{module}.py").read_text(encoding="utf-8")
+        _walk_module(ast.parse(source), module, [], sites)
+    return sorted(set(sites))
+
+
+WRITE_SITES = _write_sites()
+
+# Measured by walking the AST at the time of writing: 15 write sites across
+# the 6 token-bearing modules (14 through the helper, 1 raw write of the
+# OpenCode gate plugin). A floor, not an equality: a new write site raises the
+# real number and is caught by the coverage test below, not by this one. A
+# scan that matched nothing would otherwise report a clean pass.
+SITE_FLOOR = 15
+
+# Sites whose seeded config still carries SENTINEL after the site has written
+# it, so the sweep has something to assert on. Every site but OpenCode's
+# gate-plugin write, whose file legitimately never holds a token. Also a
+# floor: it exists so a seeding change that quietly stopped putting SENTINEL
+# on disk cannot turn the sweep into a pass over nothing.
+SENTINEL_OBSERVED_FLOOR = 12
+
+
+# ---------------------------------------------------------------------------
+# One runner per write site. Each seeds a realistic pre-existing config that
+# carries SENTINEL, then drives the code the site lives in.
+# ---------------------------------------------------------------------------
+
+
+def _seed(path: Path, text: str) -> None:
+    """Write a pre-existing config, leaving an already-present mode intact."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _seed_json(path: Path, data: dict) -> None:
+    _seed(path, json.dumps(data, indent=2) + "\n")
+
+
+def _foreign_server() -> dict:
+    """Another tool's MCP entry, carrying its own bearer token."""
+    return {
+        "url": "http://127.0.0.1:9/mcp",
+        "headers": {"Authorization": f"Bearer {SENTINEL}"},
+    }
+
+
+def _antigravity_installer(config_dir: Path) -> AntigravityInstaller:
+    return AntigravityInstaller(
+        spellbook_dir=REPO_ROOT, config_dir=config_dir, version="0.0.0"
+    )
+
+
+def _site_antigravity_update(config_dir: Path) -> None:
+    installer = _antigravity_installer(config_dir)
+    _seed_json(installer.mcp_config_path, {"mcpServers": {"other": _foreign_server()}})
+    installer._update_mcp_config()
+
+
+def _site_antigravity_uninstall(config_dir: Path) -> None:
+    installer = _antigravity_installer(config_dir)
+    _seed_json(installer.mcp_config_path, {"mcpServers": {"other": _foreign_server()}})
+    installer._update_mcp_config()
+    installer.uninstall()
+
+
+CODEX_FOREIGN = (
+    "[mcp_servers.other]\n"
+    'url = "http://127.0.0.1:9/mcp"\n'
+    "\n"
+    "[mcp_servers.other.headers]\n"
+    f'Authorization = "Bearer {SENTINEL}"\n'
+)
+
+
+def _site_codex_add(config_dir: Path) -> None:
+    """Drive all three writes in ``_add_mcp_to_config_toml``."""
+    created = config_dir / "created.toml"
+    _add_mcp_to_config_toml(created)  # no file yet -> create
+
+    appended = config_dir / "config.toml"
+    _seed(appended, CODEX_FOREIGN)
+    _add_mcp_to_config_toml(appended)  # no marker -> append
+    _add_mcp_to_config_toml(appended)  # marker present -> update in place
+
+
+def _site_codex_remove(config_dir: Path) -> None:
+    path = config_dir / "config.toml"
+    _seed(path, CODEX_FOREIGN)
+    _add_mcp_to_config_toml(path)
+    _remove_mcp_from_config_toml(path)
+
+
+def _site_forgecode_write(config_dir: Path) -> None:
+    _write_mcp_config_secure(
+        config_dir / ".mcp.json", {"mcpServers": {"other": _foreign_server()}}
+    )
+
+
+GOOSE_FOREIGN = (
+    "GOOSE_PROVIDER: openai\n" f'upstream_header: "Authorization: Bearer {SENTINEL}"\n'
+)
+
+
+def _site_goose_update(config_dir: Path) -> None:
+    path = config_dir / "config.yaml"
+    _seed(path, GOOSE_FOREIGN)
+    _update_goose_mcp_config(path)
+
+
+def _site_goose_remove(config_dir: Path) -> None:
+    path = config_dir / "config.yaml"
+    _seed(path, GOOSE_FOREIGN)
+    _update_goose_mcp_config(path)
+    _remove_goose_mcp_config(path)
+
+
+def _opencode_seed(config_dir: Path) -> Path:
+    path = config_dir / "opencode.json"
+    _seed_json(
+        path,
+        {
+            "$schema": "https://opencode.ai/config.json",
+            "mcp": {"other": _foreign_server()},
+        },
+    )
+    return path
+
+
+def _site_opencode_update_config(config_dir: Path) -> None:
+    _update_opencode_config(_opencode_seed(config_dir))
+
+
+def _site_opencode_update_instructions(config_dir: Path) -> None:
+    _update_opencode_instructions(_opencode_seed(config_dir), INSTRUCTIONS_PATH)
+
+
+def _site_opencode_remove_instructions(config_dir: Path) -> None:
+    path = _opencode_seed(config_dir)
+    _update_opencode_instructions(path, INSTRUCTIONS_PATH)
+    _remove_opencode_instructions(path, INSTRUCTIONS_PATH)
+
+
+def _site_opencode_remove_mcp(config_dir: Path) -> None:
+    path = _opencode_seed(config_dir)
+    _update_opencode_config(path)
+    _remove_opencode_mcp_config(path)
+
+
+def _site_opencode_install(config_dir: Path) -> None:
+    OpenCodeInstaller(REPO_ROOT, config_dir, "0.0.0").install()
+
+
+def _site_pi_write(config_dir: Path) -> None:
+    _write_mcp_config(
+        config_dir / "mcp.json", {"mcpServers": {"other": _foreign_server()}}
+    )
+
+
+SITE_RUNNERS: dict[str, Callable[[Path], None]] = {
+    "antigravity::AntigravityInstaller::_update_mcp_config": _site_antigravity_update,
+    "antigravity::AntigravityInstaller::uninstall": _site_antigravity_uninstall,
+    "codex::_add_mcp_to_config_toml": _site_codex_add,
+    "codex::_remove_mcp_from_config_toml": _site_codex_remove,
+    "forgecode::_write_mcp_config_secure": _site_forgecode_write,
+    "goose::_update_goose_mcp_config": _site_goose_update,
+    "goose::_remove_goose_mcp_config": _site_goose_remove,
+    "opencode::OpenCodeInstaller::install": _site_opencode_install,
+    "opencode::_remove_opencode_instructions": _site_opencode_remove_instructions,
+    "opencode::_remove_opencode_mcp_config": _site_opencode_remove_mcp,
+    "opencode::_update_opencode_config": _site_opencode_update_config,
+    "opencode::_update_opencode_instructions": _site_opencode_update_instructions,
+    "pi::_write_mcp_config": _site_pi_write,
+}
+
+
+def _sentinel_bearing_files(root: Path) -> list[Path]:
+    """Every file under ``root`` whose bytes contain the seeded token."""
+    needle = SENTINEL.encode("utf-8")
+    return sorted(
+        p
+        for p in root.rglob("*")
+        if p.is_file() and not p.is_symlink() and needle in p.read_bytes()
+    )
+
+
+def _exercise(key: str, config_dir: Path) -> list[Path]:
+    """Run a site twice, the second time over a world-readable config.
+
+    The first run establishes the files; they are then broadened to 0644 and
+    the site runs again. ``os.open``'s mode argument does not cover that case
+    -- an existing inode keeps its mode through ``O_TRUNC`` -- so this is the
+    run that can leave the token world-readable.
+    """
+    config_dir.mkdir(parents=True, exist_ok=True)
+    SITE_RUNNERS[key](config_dir)
+    for path in config_dir.rglob("*"):
+        if path.is_file() and not path.is_symlink():
+            path.chmod(0o644)
+    SITE_RUNNERS[key](config_dir)
+    return _sentinel_bearing_files(config_dir)
+
+
+# ---------------------------------------------------------------------------
+# Site-level floor and coverage
+# ---------------------------------------------------------------------------
+
+
+def test_write_site_discovery_finds_at_least_its_floor():
+    """A scan that matched no write sites would pass every assertion below."""
+    assert len(WRITE_SITES) >= SITE_FLOOR, (
+        f"Discovered {len(WRITE_SITES)} write sites across {sorted(DISCOVERED)}, "
+        f"below the floor of {SITE_FLOOR}. Either the write helpers were "
+        f"renamed or the AST scan stopped matching. A scan that finds nothing "
+        f"reports a clean pass over an unchecked tree."
+    )
+
+
+def test_every_write_site_is_exercised():
+    """Every place a token-bearing module writes a file has a runner."""
+    uncovered = {s.site_id for s in WRITE_SITES if s.key not in SITE_RUNNERS}
+    assert not uncovered, (
+        f"Write site(s) {sorted(uncovered)} live in a token-bearing platform "
+        f"module but no SITE_RUNNERS entry drives them, so nothing checks the "
+        f"mode of the file they write. A module-level floor does not cover "
+        f"this: these modules write from more than one function."
+    )
+
+
+def test_no_runner_outlives_its_write_site():
+    """A runner for a site that no longer exists is coverage that isn't there."""
+    live = {s.key for s in WRITE_SITES}
+    stale = set(SITE_RUNNERS) - live
+    assert not stale, (
+        f"SITE_RUNNERS entr(ies) {sorted(stale)} name functions that no longer "
+        f"contain a file write. Either the write moved -- in which case its new "
+        f"home needs a runner -- or the entry is dead weight that makes the "
+        f"coverage count look larger than it is."
+    )
+
+
+# ---------------------------------------------------------------------------
+# The site-level permission assertion
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.posix_only
+@pytest.mark.parametrize("key", sorted(SITE_RUNNERS), ids=sorted(SITE_RUNNERS))
+def test_no_file_carrying_the_token_is_world_readable(key, tmp_path):
+    """After any token-bearing module writes, no file holding a token is loose.
+
+    The sweep is over content, not over a list of paths: a file is checked
+    because it contains the token, so a write site cannot escape by writing
+    somewhere this test did not think to look, and a file that legitimately
+    holds no token needs no exemption.
+    """
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+
+    bearing = _exercise(key, config_dir)
+
+    loose = {
+        str(p.relative_to(config_dir)): oct(p.stat().st_mode & 0o777)
+        for p in bearing
+        if p.stat().st_mode & 0o777 != 0o600
+    }
+    assert not loose, (
+        f"{key}: {loose} contain the bearer token but are not 0600; any local "
+        f"account can read them."
+    )
+
+
+@pytest.mark.posix_only
+def test_the_sweep_actually_inspects_files_holding_a_token(tmp_path):
+    """The permission sweep above passes trivially over a tree with no token.
+
+    Its assertion is conditional on content, so seeding that quietly stopped
+    putting a token on disk would turn every case green while checking
+    nothing. This pins how many sites really do leave a token behind.
+    """
+    observed = sorted(
+        key
+        for key in SITE_RUNNERS
+        if _exercise(key, (tmp_path / key.replace("::", "-")))
+    )
+    assert len(observed) >= SENTINEL_OBSERVED_FLOOR, (
+        f"Only {len(observed)} of {len(SITE_RUNNERS)} sites left a file "
+        f"containing the token ({observed}), below the floor of "
+        f"{SENTINEL_OBSERVED_FLOOR}. The permission sweep is passing over "
+        f"trees with nothing in them to check."
     )


### PR DESCRIPTION
## What does this PR do?

Spellbook's MCP bearer token lives at `~/.local/spellbook/.mcp-token`, correctly mode 0600.
Installers copy it into per-platform config files, and four of them wrote those files
world-readable.

Measured on a real machine before the fix, by comparing each file against the live token:

| file | mode | carries the token |
|---|---|---|
| `~/.local/spellbook/.mcp-token` | 0600 | source |
| `~/.claude.json` | 0600 | yes (written by `claude mcp add`, not by us) |
| `~/.codex/config.toml` | **0644** | yes |
| `~/.config/opencode/opencode.json` | **0644** | yes |
| `~/.pi/agent/mcp.json` | **0644** | yes |

The daemon URL is `http://127.0.0.1:8765/mcp`, so exposure requires a local account — a real
hygiene defect rather than a remote one. Worth noting that pi writes its own credentials
(`auth.json`, `models.json`) at 0600: the target platforms do this correctly and the
installer undid it.

**The fix already existed in this repo and had never been generalised.**
`installer/platforms/forgecode.py` opens with `os.open(..., 0o600)` and then `os.fchmod`s the
descriptor, documented as closing a gap "flagged in PR review (cycle 4)". `goose.py` has it
too. The other four token-bearing platforms did not.

`installer/components/mcp.py` now exports `write_token_bearing_file()`. That module already
owns `TOKEN_PATH` and `get_mcp_auth_token`, and all six token-bearing platforms already
import from it, so no new dependency edge was created. forgecode's private copy was collapsed
onto the shared helper.

**Why `os.open` alone is insufficient**, and the reason the `fchmod` is the load-bearing
half: the mode argument applies only to *newly created* files. An existing 0644 config
survives `O_TRUNC` with its permissions intact, which is precisely the state on any machine
that has installed before.

pi is the one caller that does not write its target directly. It writes a temp file through
the helper and lets `os.replace` carry 0600 to the destination, so atomicity is preserved and
the token is never present in a world-readable file even transiently. Its MCP registration
behaviour is untouched — a separate decision is in flight about what pi should do instead.

## The test

`tests/installer/test_token_file_permissions.py`, 14 tests, no mocking — real installers, real
`tmp_path`, real `stat`.

Platforms are **derived** by scanning `installer/platforms/*.py` for `get_mcp_auth_token`, not
hand-listed, with two anti-no-op floors: discovery must find at least the measured six, and
any discovered module without a covered write path fails the suite. A future token-bearing
platform turns it red until someone covers it.

RED-first evidence reproduces the diagnosis as a test result: before the change, **8 failed, 6
passed** — and the 6 passing were `forgecode` and `goose`, the two that already had the
pattern.

The mutation removing `fchmod` fails 5 of the 6. **pi correctly does not fail**, because its
temp file is always newly created so `os.open`'s mode suffices there; that is a property of
its atomic path, not a hole.

## Known limits

- **This fixes the next install; it does not retroactively tighten files already on disk.**
  Those were chmodded by hand on the machine where this was found, but no migration ships
  here.
- Whether to **rotate** the token, given it has sat world-readable for an unknown period, is a
  separate decision and is not in this commit.
- `docs/security.md` describes only the token file's own write and never mentions the
  per-platform copies. That reads as though 0600 was already end-to-end. It is now true and
  still undocumented.
- Discovery keys on `get_mcp_auth_token`. A future platform that reads the token some other
  way would slip past it. A lint forbidding `write_text` in token-bearing modules was
  considered and rejected — it false-positives on opencode's legitimately non-token plugin
  write.

## Related issue

None.

## Checklist

- [x] Tests pass locally — 1911 passed, 2 skipped; `tests/installer/` 237 passed
- [x] Documentation updated (if applicable) — CHANGELOG entry under `[Unreleased] > Fixed`
      naming the measured files and why `os.open`'s mode argument is insufficient
