### PR TITLE
Register pi's MCP through an adapter pi actually reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,69 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Pi's MCP registration was a silent no-op and now actually registers.
+  `installer/platforms/pi.py` wrote `~/.pi/agent/mcp.json` and reported
+  "registered MCP server", but pi has no native MCP support: its `dist/`
+  references neither `mcpServers` nor `mcp.json`, and its `docs/usage.md`
+  states it "intentionally does not include built-in MCP". Nothing read the
+  file the installer wrote, so the success message was the only artifact the
+  operation produced. MCP now arrives through the `pi-mcp-adapter` npm
+  package, declared in `~/.pi/agent/settings.json` and pinned to a named
+  constant, so a bump is a deliberate edit; pi skips versioned npm specs
+  during `pi update --extensions`. The emitted server entry gains three
+  adapter settings that correct defaults which would otherwise leave the tools
+  unusable: `directTools: true` (the default routes all tools through a single
+  proxy tool named `mcp`), `toolPrefix: "none"` (the default prepends the
+  server name, yielding `spellbook_spellbook_health_check` for tools already
+  named `spellbook_*`), and `lifecycle: "eager"`. `protocolVersion` is
+  deliberately unset so the adapter's `legacy` default negotiates. Reporting is
+  now conditioned on the adapter declaration rather than on a file having been
+  written: with the adapter undeclared the installer says MCP is not registered
+  and fails the step, and `detect()` no longer counts a bare `mcp.json` entry as
+  a registration. The installer makes no request to the daemon, so it claims
+  only what it did -- declared and wrote -- and never that the server is
+  reachable. It does now say that pi must be restarted, which is what the
+  adapter's own `init.ts` reports for a `directTools` server it bootstraps.
+  Uninstall removes the adapter declaration only when no other server remains
+  in `mcp.json`, and never touches a user-authored object-form entry.
+- Installing for pi no longer widens the permissions on an existing
+  `~/.pi/agent/settings.json`. The write is an atomic replace, and
+  `os.replace` swaps in the TEMPORARY file, so the result carried the temp
+  file's default-umask mode: an owner-only settings.json came back 0644,
+  readable by every other local account, with nothing reporting it. The
+  existing file's mode is now carried across explicitly, and a settings.json
+  the installer creates is 0600.
+- The pi installer takes pi's own settings.json lock. Pi guards every
+  settings write with `proper-lockfile` and re-reads inside the lock
+  (`withLock` in pi's `core/settings-manager.js`), so a concurrent write from
+  a running pi was computed from a read taken before the installer's replace
+  and silently dropped the new entry -- after the installer reported success.
+  The lock is a directory at `<file>.lock` created with mkdir, which is the
+  whole protocol, so the installer contends for the same lock rather than a
+  parallel one of its own. The result is also read back after the write, so a
+  lost update from a writer that does not take the lock is reported rather
+  than assumed away.
+- A non-list `packages` key in pi's settings.json is no longer silently
+  replaced with an empty list. The file level already raised on a non-object;
+  the key level was destroying user data instead. The installer now fails the
+  step and leaves the file alone.
+- Every entry naming `pi-mcp-adapter` is handled, not just the first. Pi
+  resolves an npm package by name, so a leftover older pin was a second answer
+  to the same question and could reinstall an older adapter over the pinned
+  one, making the reported version not the version that runs. Spellbook's own
+  bare-string entries collapse to one pinned entry; duplicates that include a
+  user-authored entry are reported as ambiguous rather than guessed at.
+- The pi dry run no longer reports a write it would not perform. It returned
+  "would declare ..." before reading settings.json, so it said that for the
+  two cases that write nothing -- the entry is already present and pinned, or
+  it is the user's own and is left alone.
+- The `mcp_adapter` uninstall result no longer derives its `removed`/`skipped`
+  action by searching its own human-readable message for a substring, which
+  made rewording the message change the recorded outcome. The flag comes from
+  what was removed.
+
 ### Removed
 
 - The `spellbook-planlint` package, its console script, its test suite and its

--- a/installer/platforms/pi.py
+++ b/installer/platforms/pi.py
@@ -16,11 +16,14 @@ Reference:
 - https://github.com/badlogic/pi-coding-agent/docs/prompt-templates.md
 """
 
+import contextlib
 import json
 import logging
 import os
+import stat
+import time
 from pathlib import Path
-from typing import TYPE_CHECKING, List, Optional, Tuple
+from typing import TYPE_CHECKING, Iterator, List, Optional, Tuple
 
 from ..components.mcp import get_spellbook_server_url
 from ..components.symlinks import (
@@ -49,14 +52,88 @@ SPELLBOOK_SERVER_KEY: str = "spellbook"
 # registers the servers it names.
 PI_MCP_ADAPTER_NAME: str = "pi-mcp-adapter"
 
-# Pinned, never a range. This is the version whose behaviour was verified end
-# to end against a running spellbook daemon: connect, tools/list, and tool
-# invocation with the Bearer header. Pi pins versioned npm specs and skips them
-# during `pi update --extensions`, so this value is what actually runs until
-# somebody edits this line on purpose.
+# Pinned, never a range. Pi pins versioned npm specs and skips them during
+# `pi update --extensions`, so this value is what actually runs until somebody
+# edits this line on purpose.
 PI_MCP_ADAPTER_VERSION: str = "2.26.1"
 
 PI_MCP_ADAPTER_SPEC: str = f"npm:{PI_MCP_ADAPTER_NAME}@{PI_MCP_ADAPTER_VERSION}"
+
+# Pi guards every settings.json write with proper-lockfile -- see
+# `acquireLockSyncWithRetry` and `withLock` in pi's `core/settings-manager.js`,
+# which read the file INSIDE the lock and write back inside the same one. An
+# installer that skips the lock loses its entry whenever pi writes a setting
+# during the install: pi's write is computed from a read taken before ours and
+# replaces the whole file.
+#
+# proper-lockfile's lock is a DIRECTORY at "<file>.lock" (`getLockFile`),
+# created with mkdir because mkdir is atomic and released with rmdir. Those two
+# calls are the whole protocol, so taking pi's own lock needs no Node library.
+PI_SETTINGS_LOCK_SUFFIX: str = ".lock"
+
+# proper-lockfile's default staleness threshold. A live holder refreshes the
+# lock directory's mtime every 5s; past this age the holder is gone.
+PI_SETTINGS_LOCK_STALE_SECONDS: float = 10.0
+
+# Pi retries 10 times at 20ms and then throws. The installer waits longer: it
+# runs once, and silently losing its write is worse than a moment of delay.
+PI_SETTINGS_LOCK_TIMEOUT_SECONDS: float = 2.0
+PI_SETTINGS_LOCK_POLL_SECONDS: float = 0.02
+
+# Mode for a settings.json this installer CREATES. An existing file keeps the
+# mode it already had -- see `_write_pi_settings`.
+PI_SETTINGS_NEW_FILE_MODE: int = 0o600
+
+# The adapter connects a directTools server during `session_start` when it has
+# no metadata cache entry for it, and its own `init.ts` then says the tools
+# "will be available after restart". Pi also installs a declared-but-missing
+# npm package on its next start. Both make a restart the step between this
+# installer finishing and the tools existing.
+PI_RESTART_NOTICE: str = "restart pi to load the adapter and its tools"
+
+
+class PiSettingsLockError(RuntimeError):
+    """Pi's settings.json lock is held elsewhere and did not come free."""
+
+
+class PiSettingsShapeError(ValueError):
+    """settings.json holds a key in a shape this installer will not overwrite."""
+
+
+@contextlib.contextmanager
+def _pi_settings_lock(settings_path: Path) -> Iterator[None]:
+    """Hold the same lock pi holds while it reads and writes settings.json.
+
+    Reproduces proper-lockfile's directory lock rather than approximating it:
+    the same path, the same mkdir/rmdir pair, and the same staleness rule, so
+    pi and the installer contend for one lock instead of two.
+    """
+    lock_path = settings_path.with_name(settings_path.name + PI_SETTINGS_LOCK_SUFFIX)
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    deadline = time.monotonic() + PI_SETTINGS_LOCK_TIMEOUT_SECONDS
+    while True:
+        try:
+            os.mkdir(lock_path)
+            break
+        except FileExistsError:
+            try:
+                age = time.time() - lock_path.stat().st_mtime
+            except FileNotFoundError:
+                continue
+            if age > PI_SETTINGS_LOCK_STALE_SECONDS:
+                with contextlib.suppress(OSError):
+                    os.rmdir(lock_path)
+                continue
+            if time.monotonic() >= deadline:
+                raise PiSettingsLockError(
+                    f"{lock_path.name} is held by another process"
+                )
+            time.sleep(PI_SETTINGS_LOCK_POLL_SECONDS)
+    try:
+        yield
+    finally:
+        with contextlib.suppress(OSError):
+            os.rmdir(lock_path)
 
 
 def _read_pi_settings(settings_path: Path) -> dict:
@@ -121,10 +198,11 @@ def _write_mcp_config(config_path: Path, config: dict) -> None:
 def _generate_mcp_json_section() -> dict:
     """Generate the spellbook entry for pi-mcp-adapter's mcp.json.
 
-    The transport half -- ``url`` plus a raw ``headers`` map -- is the Claude
-    Code shape the adapter accepts unchanged. The other three keys are adapter
-    settings that no native MCP host would read, and each corrects a default
-    that would otherwise leave spellbook's tools unusable:
+    The transport half -- a bare ``url`` -- is the Claude Code shape the
+    adapter accepts unchanged. The daemon authenticates on Origin and Host
+    rather than on a header, so the entry carries none. The other three keys
+    are adapter settings that no native MCP host would read, and each corrects
+    a default that would otherwise leave spellbook's tools unusable:
 
     ``directTools``
         Defaults to ``false``, which routes every tool through a single proxy
@@ -145,25 +223,42 @@ def _generate_mcp_json_section() -> dict:
     default negotiates against the daemon, which answers ``2024-11-05``.
     Pinning a version can only narrow what succeeds.
     """
-    url = get_spellbook_server_url()
-    # Whole-entry replacement by the caller: any stale auth header from a
-    # previous install disappears rather than being merged forward.
-    server_entry: dict = {
-        "url": url,
+    # Whole-entry replacement by the caller: any key a previous install wrote
+    # -- a credential header from before the daemon moved to Origin and Host
+    # validation, for instance -- disappears rather than being merged forward.
+    return {
+        "url": get_spellbook_server_url(),
+        "lifecycle": "eager",
+        "directTools": True,
+        "toolPrefix": "none",
     }
-    server_entry["lifecycle"] = "eager"
-    server_entry["directTools"] = True
-    server_entry["toolPrefix"] = "none"
-    return server_entry
 
 
 def _write_pi_settings(settings_path: Path, settings: dict) -> None:
-    """Write pi's settings.json atomically. Carries no token, so mode 0644."""
+    """Write pi's settings.json atomically, preserving its mode.
+
+    The mode has to be carried across explicitly. ``os.replace`` swaps in the
+    TEMPORARY file, so the result carries the temp file's mode, which is the
+    default umask -- typically 0644. A user whose settings.json is 0600 would
+    have it widened to world-readable by an install that only meant to add a
+    package entry, and nothing would report that it happened. Pi's own writer
+    (``writeFileSync`` in ``core/settings-manager.js``) rewrites the file in
+    place and so keeps the mode without doing anything; the atomic-replace
+    shape is what makes this explicit step necessary.
+
+    A settings.json this installer CREATES gets 0600. It is a single user's
+    config and nothing else reads it, so the restrictive mode costs nothing.
+    """
     settings_path.parent.mkdir(parents=True, exist_ok=True)
     payload = json.dumps(settings, indent=2) + "\n"
     tmp_path = settings_path.with_name(f"{settings_path.name}.tmp.{os.getpid()}")
     try:
         tmp_path.write_text(payload, encoding="utf-8")
+        try:
+            mode = stat.S_IMODE(settings_path.stat().st_mode)
+        except FileNotFoundError:
+            mode = PI_SETTINGS_NEW_FILE_MODE
+        os.chmod(tmp_path, mode)
         os.replace(tmp_path, settings_path)
     except BaseException:
         try:
@@ -171,6 +266,24 @@ def _write_pi_settings(settings_path: Path, settings: dict) -> None:
         except FileNotFoundError:
             pass
         raise
+
+
+def _settings_packages(settings: dict) -> list:
+    """The ``packages`` list, or a fresh one when the key is absent.
+
+    A present-but-wrong-typed value RAISES. Coercing it to ``[]`` and writing
+    that back destroys whatever the user had there, and does it silently. This
+    is the key-level form of the rule ``_read_pi_settings`` already applies to
+    the file as a whole.
+    """
+    if "packages" not in settings:
+        return []
+    packages = settings["packages"]
+    if not isinstance(packages, list):
+        raise PiSettingsShapeError(
+            f"'packages' is not a list (got {type(packages).__name__})"
+        )
+    return packages
 
 
 def _names_adapter(source: object) -> bool:
@@ -211,16 +324,20 @@ def _is_spellbook_managed_adapter_entry(entry: object) -> bool:
     return isinstance(entry, str) and _names_adapter(entry)
 
 
-def _adapter_entry_index(packages: list) -> Optional[int]:
-    """Index of any entry naming the adapter, whatever its form.
+def _adapter_entry_indices(packages: list) -> List[int]:
+    """Every index naming the adapter, whatever the entry's form.
 
-    Pi identifies an npm package by NAME, so two entries differing only in
-    version are ambiguous rather than additive.
+    EVERY index, not the first. Pi identifies an npm package by NAME, so two
+    entries differing only in version are ambiguous rather than additive, and
+    stopping at the first one leaves a stale sibling behind that can reinstall
+    an older adapter over the one this installer just pinned -- making the
+    version it reports not the version that runs.
     """
-    for i, entry in enumerate(packages):
-        if _names_adapter(_adapter_entry_source(entry)):
-            return i
-    return None
+    return [
+        i
+        for i, entry in enumerate(packages)
+        if _names_adapter(_adapter_entry_source(entry))
+    ]
 
 
 def _adapter_declared(settings_path: Path) -> bool:
@@ -234,12 +351,10 @@ def _adapter_declared(settings_path: Path) -> bool:
     """
     try:
         settings = _read_pi_settings(settings_path)
+        packages = _settings_packages(settings)
     except (OSError, ValueError, json.JSONDecodeError):
         return False
-    packages = settings.get("packages")
-    if not isinstance(packages, list):
-        return False
-    return _adapter_entry_index(packages) is not None
+    return bool(_adapter_entry_indices(packages))
 
 
 def _adapter_installed_version(config_dir: Path) -> Optional[str]:
@@ -261,6 +376,93 @@ def _adapter_installed_version(config_dir: Path) -> Optional[str]:
     return version if isinstance(version, str) else None
 
 
+def _plan_pi_adapter(
+    settings_path: Path, dry_run: bool
+) -> Tuple[bool, str, str, Optional[dict]]:
+    """Decide what declaring the adapter does, reading but never writing.
+
+    Returns ``(ok, message, effective_spec, settings_to_write)``. The last
+    element is ``None`` when nothing needs writing, which is what lets the dry
+    run report the outcome it would actually produce. Reporting "would declare
+    ..." before reading the file -- which is what this used to do -- announces
+    a write for the two cases that perform none: the entry is already present
+    and already pinned, or it is the user's own and is left alone.
+    """
+    verb = "would declare" if dry_run else "declared"
+    repin = "would repin" if dry_run else "repinned"
+
+    try:
+        settings = _read_pi_settings(settings_path)
+        packages = _settings_packages(settings)
+    except (OSError, ValueError, json.JSONDecodeError) as e:
+        return (
+            False,
+            f"could not read {settings_path.name}: {e}",
+            PI_MCP_ADAPTER_SPEC,
+            None,
+        )
+
+    indices = _adapter_entry_indices(packages)
+    user_owned = [i for i in indices if not _is_spellbook_managed_adapter_entry(packages[i])]
+
+    if len(indices) > 1 and user_owned:
+        # Which entry pi resolves is not something this installer can decide,
+        # and one of them is the user's. Rewriting either would guess, and
+        # reporting a version would name a guess.
+        return (
+            False,
+            (
+                f"{settings_path.name} declares {PI_MCP_ADAPTER_NAME} "
+                f"{len(indices)} times, one of them user-authored; resolve "
+                f"the duplicates by hand -- which one pi loads is ambiguous"
+            ),
+            PI_MCP_ADAPTER_NAME,
+            None,
+        )
+
+    if user_owned:
+        user_source = _adapter_entry_source(packages[user_owned[0]])
+        return (
+            True,
+            f"{PI_MCP_ADAPTER_NAME} already declared by the user; left as is",
+            user_source if isinstance(user_source, str) else PI_MCP_ADAPTER_NAME,
+            None,
+        )
+
+    if not indices:
+        packages = [*packages, PI_MCP_ADAPTER_SPEC]
+        return (
+            True,
+            f"{verb} {PI_MCP_ADAPTER_SPEC}",
+            PI_MCP_ADAPTER_SPEC,
+            {**settings, "packages": packages},
+        )
+
+    # Every remaining match is spellbook's own bare-string shape, so collapsing
+    # them to one pinned entry destroys nothing the user wrote.
+    duplicates = len(indices) - 1
+    already_correct = duplicates == 0 and packages[indices[0]] == PI_MCP_ADAPTER_SPEC
+    if already_correct:
+        return (
+            True,
+            f"{PI_MCP_ADAPTER_SPEC} already declared",
+            PI_MCP_ADAPTER_SPEC,
+            None,
+        )
+
+    keep = indices[0]
+    drop = set(indices[1:])
+    packages = [
+        PI_MCP_ADAPTER_SPEC if i == keep else entry
+        for i, entry in enumerate(packages)
+        if i not in drop
+    ]
+    message = f"{repin} to {PI_MCP_ADAPTER_SPEC}"
+    if duplicates:
+        message += f" and dropped {duplicates} duplicate declaration(s)"
+    return (True, message, PI_MCP_ADAPTER_SPEC, {**settings, "packages": packages})
+
+
 def _declare_pi_adapter(
     config_dir: Path, dry_run: bool = False
 ) -> Tuple[bool, str, str]:
@@ -273,6 +475,11 @@ def _declare_pi_adapter(
     wants -- and costs a ``pi`` binary on PATH, network access, and a failure
     mode at install time that the settings write does not have.
 
+    The read, the decision and the write all happen inside pi's own lock, and
+    the result is read back afterwards. The lock is the prevention; the
+    read-back is what keeps a lost update from being reported as a success by
+    a pi that predates the lock, or by a hand edit that never takes it.
+
     Returns ``(ok, message, effective_spec)``. The third element is the spec
     that will actually load mcp.json, which is NOT always the pinned one: a
     user's object-form entry is left as is, and reporting the pinned spec in
@@ -281,66 +488,73 @@ def _declare_pi_adapter(
     settings_path = config_dir / "settings.json"
 
     if dry_run:
-        return (True, f"would declare {PI_MCP_ADAPTER_SPEC}", PI_MCP_ADAPTER_SPEC)
+        ok, message, spec, _ = _plan_pi_adapter(settings_path, dry_run=True)
+        return (ok, message, spec)
 
     try:
-        settings = _read_pi_settings(settings_path)
-    except (OSError, ValueError, json.JSONDecodeError) as e:
-        return (False, f"could not read {settings_path.name}: {e}", PI_MCP_ADAPTER_SPEC)
-
-    packages = settings.get("packages")
-    if not isinstance(packages, list):
-        packages = []
-
-    index = _adapter_entry_index(packages)
-    if index is not None and not _is_spellbook_managed_adapter_entry(packages[index]):
-        user_source = _adapter_entry_source(packages[index])
-        return (
-            True,
-            f"{PI_MCP_ADAPTER_NAME} already declared by the user; left as is",
-            user_source if isinstance(user_source, str) else PI_MCP_ADAPTER_NAME,
-        )
-
-    if index is not None and packages[index] == PI_MCP_ADAPTER_SPEC:
-        return (True, f"{PI_MCP_ADAPTER_SPEC} already declared", PI_MCP_ADAPTER_SPEC)
-
-    if index is not None:
-        packages[index] = PI_MCP_ADAPTER_SPEC
-        action = f"repinned to {PI_MCP_ADAPTER_SPEC}"
-    else:
-        packages.append(PI_MCP_ADAPTER_SPEC)
-        action = f"declared {PI_MCP_ADAPTER_SPEC}"
-
-    settings["packages"] = packages
-    try:
-        _write_pi_settings(settings_path, settings)
-    except OSError as e:
+        with _pi_settings_lock(settings_path):
+            ok, message, spec, new_settings = _plan_pi_adapter(
+                settings_path, dry_run=False
+            )
+            if not ok or new_settings is None:
+                return (ok, message, spec)
+            try:
+                _write_pi_settings(settings_path, new_settings)
+            except OSError as e:
+                return (False, f"could not write {settings_path.name}: {e}", spec)
+            if not _spec_is_declared(settings_path, PI_MCP_ADAPTER_SPEC):
+                return (
+                    False,
+                    (
+                        f"{PI_MCP_ADAPTER_SPEC} did not survive the write to "
+                        f"{settings_path.name}; another process replaced the file"
+                    ),
+                    spec,
+                )
+            return (True, message, spec)
+    except PiSettingsLockError as e:
         return (
             False,
-            f"could not write {settings_path.name}: {e}",
+            (
+                f"could not take pi's settings lock ({e}); pi is writing "
+                f"{settings_path.name} and the declaration would be lost"
+            ),
             PI_MCP_ADAPTER_SPEC,
         )
-    return (True, action, PI_MCP_ADAPTER_SPEC)
+
+
+def _spec_is_declared(settings_path: Path, spec: str) -> bool:
+    """Whether ``spec`` is on disk in settings.json right now."""
+    try:
+        settings = _read_pi_settings(settings_path)
+        packages = _settings_packages(settings)
+    except (OSError, ValueError, json.JSONDecodeError):
+        return False
+    return spec in packages
 
 
 def _retract_pi_adapter(
     config_dir: Path, dry_run: bool = False
-) -> Tuple[bool, str]:
+) -> Tuple[bool, str, bool]:
     """Remove spellbook's adapter declaration, but only if nothing else needs it.
 
     The adapter is a general-purpose MCP bridge, not a spellbook component. If
     any other server remains in mcp.json after spellbook's entry is gone, that
     server still needs the adapter loaded and removing it would break it. Only
-    the bare string entry spellbook itself writes is ever removed; a
+    the bare string entries spellbook itself writes are ever removed; a
     user-authored object-form entry is left untouched.
 
     The on-disk package under ``npm/node_modules/`` is left in place. Deleting
     it is pi's business (``pi remove``), and it is inert once undeclared.
+
+    Returns ``(ok, message, retracted)``. ``retracted`` is the fact, decided by
+    what was actually removed. Recovering it by searching the message for a
+    word made the recorded outcome depend on the message's wording.
     """
     settings_path = config_dir / "settings.json"
 
     if dry_run:
-        return (True, f"would retract {PI_MCP_ADAPTER_SPEC} if unused")
+        return (True, f"would retract {PI_MCP_ADAPTER_SPEC} if unused", False)
 
     mcp_config = _load_mcp_config_dict(config_dir / "mcp.json")
     remaining = mcp_config.get("mcpServers")
@@ -348,30 +562,55 @@ def _retract_pi_adapter(
         return (
             True,
             f"{PI_MCP_ADAPTER_NAME} kept: {len(remaining)} other MCP server(s) need it",
+            False,
         )
 
     try:
-        settings = _read_pi_settings(settings_path)
-    except (OSError, ValueError, json.JSONDecodeError):
-        return (True, f"{settings_path.name} unreadable; {PI_MCP_ADAPTER_NAME} left as is")
+        with _pi_settings_lock(settings_path):
+            try:
+                settings = _read_pi_settings(settings_path)
+                packages = _settings_packages(settings)
+            except (OSError, ValueError, json.JSONDecodeError) as e:
+                return (
+                    True,
+                    (
+                        f"{settings_path.name} unreadable ({e}); "
+                        f"{PI_MCP_ADAPTER_NAME} left as is"
+                    ),
+                    False,
+                )
 
-    packages = settings.get("packages")
-    if not isinstance(packages, list):
-        return (True, f"{PI_MCP_ADAPTER_NAME} was not declared")
+            indices = _adapter_entry_indices(packages)
+            managed = [
+                i for i in indices if _is_spellbook_managed_adapter_entry(packages[i])
+            ]
+            if not indices:
+                return (True, f"{PI_MCP_ADAPTER_NAME} was not declared", False)
+            if not managed:
+                return (
+                    True,
+                    f"{PI_MCP_ADAPTER_NAME} was declared by the user; left as is",
+                    False,
+                )
 
-    index = _adapter_entry_index(packages)
-    if index is None:
-        return (True, f"{PI_MCP_ADAPTER_NAME} was not declared")
-    if not _is_spellbook_managed_adapter_entry(packages[index]):
-        return (True, f"{PI_MCP_ADAPTER_NAME} was declared by the user; left as is")
-
-    del packages[index]
-    settings["packages"] = packages
-    try:
-        _write_pi_settings(settings_path, settings)
-    except OSError as e:
-        return (False, f"could not write {settings_path.name}: {e}")
-    return (True, f"retracted {PI_MCP_ADAPTER_SPEC}")
+            drop = set(managed)
+            settings["packages"] = [
+                entry for i, entry in enumerate(packages) if i not in drop
+            ]
+            try:
+                _write_pi_settings(settings_path, settings)
+            except OSError as e:
+                return (False, f"could not write {settings_path.name}: {e}", False)
+            return (True, f"retracted {PI_MCP_ADAPTER_SPEC}", True)
+    except PiSettingsLockError as e:
+        return (
+            False,
+            (
+                f"could not take pi's settings lock ({e}); "
+                f"{PI_MCP_ADAPTER_NAME} left declared"
+            ),
+            False,
+        )
 
 
 def _update_pi_mcp_config(
@@ -753,8 +992,8 @@ class PiInstaller(PlatformInstaller):
             success, msg = _update_pi_mcp_config(self.mcp_config_file, self.dry_run)
 
             # The installer makes no request to the daemon, so it cannot tell a
-            # running daemon from a stopped one, nor a live token from a stale
-            # one. Its vocabulary is therefore limited to what it actually did.
+            # running daemon from a stopped one. Its vocabulary is therefore
+            # limited to what it actually did.
             if not adapter_ok:
                 success = False
                 msg = (
@@ -763,7 +1002,7 @@ class PiInstaller(PlatformInstaller):
                     f"reads mcp.json"
                 )
             else:
-                msg = f"{msg} via {adapter_spec}"
+                msg = f"{msg} via {adapter_spec}; {PI_RESTART_NOTICE}"
 
             results.append(
                 InstallResult(
@@ -863,7 +1102,7 @@ class PiInstaller(PlatformInstaller):
 
             # Retract the adapter declaration only after the spellbook entry is
             # gone from mcp.json, because the decision depends on what remains.
-            adapter_ok, adapter_msg = _retract_pi_adapter(
+            adapter_ok, adapter_msg, retracted = _retract_pi_adapter(
                 self.config_dir, self.dry_run
             )
             results.append(
@@ -871,7 +1110,7 @@ class PiInstaller(PlatformInstaller):
                     component="mcp_adapter",
                     platform=self.platform_id,
                     success=adapter_ok,
-                    action="removed" if "retracted" in adapter_msg else "skipped",
+                    action="removed" if retracted else "skipped",
                     message=f"MCP adapter: {adapter_msg}",
                 )
             )

--- a/installer/platforms/pi.py
+++ b/installer/platforms/pi.py
@@ -173,15 +173,42 @@ def _write_pi_settings(settings_path: Path, settings: dict) -> None:
         raise
 
 
-def _is_spellbook_managed_adapter_entry(entry: object) -> bool:
-    """True for a bare ``npm:pi-mcp-adapter@<version>`` string.
+def _names_adapter(source: object) -> bool:
+    """True for an npm spec naming the adapter, versioned or not.
 
-    Spellbook writes and removes only this shape. Pi also accepts an object
-    form carrying resource filters; a user who wrote one configured it
+    The boundary is what makes this correct. A bare prefix test also matches
+    ``npm:pi-mcp-adapter-extra@1.0.0``, a DIFFERENT package, which would make
+    ``detect`` report the adapter as declared while the real adapter is absent.
+    An npm spec ends the package name at ``@`` or at end of string, so those
+    are the only two accepted forms.
+    """
+    if not isinstance(source, str):
+        return False
+    return source == f"npm:{PI_MCP_ADAPTER_NAME}" or source.startswith(
+        f"npm:{PI_MCP_ADAPTER_NAME}@"
+    )
+
+
+def _adapter_entry_source(entry: object) -> object:
+    """The npm spec an entry declares, for either shape pi accepts."""
+    return entry.get("source") if isinstance(entry, dict) else entry
+
+
+def _is_spellbook_managed_adapter_entry(entry: object) -> bool:
+    """True for a bare adapter string, with or without a pinned version.
+
+    Spellbook writes and removes only the bare-string shape. Pi also accepts an
+    object form carrying resource filters; a user who wrote one configured it
     deliberately, and flattening it back to a string would discard those
     filters silently.
+
+    A version-less bare string counts as managed. It is spellbook's own shape,
+    and leaving it unpinned is the drift ``PI_MCP_ADAPTER_VERSION`` exists to
+    prevent -- ``pi update --extensions`` skips pinned specs and moves unpinned
+    ones to latest. Repinning it is also what keeps the reported version equal
+    to the version on disk.
     """
-    return isinstance(entry, str) and entry.startswith(f"npm:{PI_MCP_ADAPTER_NAME}@")
+    return isinstance(entry, str) and _names_adapter(entry)
 
 
 def _adapter_entry_index(packages: list) -> Optional[int]:
@@ -191,8 +218,7 @@ def _adapter_entry_index(packages: list) -> Optional[int]:
     version are ambiguous rather than additive.
     """
     for i, entry in enumerate(packages):
-        source = entry.get("source") if isinstance(entry, dict) else entry
-        if isinstance(source, str) and source.startswith(f"npm:{PI_MCP_ADAPTER_NAME}"):
+        if _names_adapter(_adapter_entry_source(entry)):
             return i
     return None
 
@@ -237,7 +263,7 @@ def _adapter_installed_version(config_dir: Path) -> Optional[str]:
 
 def _declare_pi_adapter(
     config_dir: Path, dry_run: bool = False
-) -> Tuple[bool, str]:
+) -> Tuple[bool, str, str]:
     """Declare the pinned adapter in pi's settings.json.
 
     Writes the ``packages[]`` entry directly rather than shelling out to
@@ -246,16 +272,21 @@ def _declare_pi_adapter(
     declared-but-missing package, so the subprocess buys nothing an installer
     wants -- and costs a ``pi`` binary on PATH, network access, and a failure
     mode at install time that the settings write does not have.
+
+    Returns ``(ok, message, effective_spec)``. The third element is the spec
+    that will actually load mcp.json, which is NOT always the pinned one: a
+    user's object-form entry is left as is, and reporting the pinned spec in
+    that case would name a version this function declined to write.
     """
     settings_path = config_dir / "settings.json"
 
     if dry_run:
-        return (True, f"would declare {PI_MCP_ADAPTER_SPEC}")
+        return (True, f"would declare {PI_MCP_ADAPTER_SPEC}", PI_MCP_ADAPTER_SPEC)
 
     try:
         settings = _read_pi_settings(settings_path)
     except (OSError, ValueError, json.JSONDecodeError) as e:
-        return (False, f"could not read {settings_path.name}: {e}")
+        return (False, f"could not read {settings_path.name}: {e}", PI_MCP_ADAPTER_SPEC)
 
     packages = settings.get("packages")
     if not isinstance(packages, list):
@@ -263,10 +294,15 @@ def _declare_pi_adapter(
 
     index = _adapter_entry_index(packages)
     if index is not None and not _is_spellbook_managed_adapter_entry(packages[index]):
-        return (True, f"{PI_MCP_ADAPTER_NAME} already declared by the user; left as is")
+        user_source = _adapter_entry_source(packages[index])
+        return (
+            True,
+            f"{PI_MCP_ADAPTER_NAME} already declared by the user; left as is",
+            user_source if isinstance(user_source, str) else PI_MCP_ADAPTER_NAME,
+        )
 
     if index is not None and packages[index] == PI_MCP_ADAPTER_SPEC:
-        return (True, f"{PI_MCP_ADAPTER_SPEC} already declared")
+        return (True, f"{PI_MCP_ADAPTER_SPEC} already declared", PI_MCP_ADAPTER_SPEC)
 
     if index is not None:
         packages[index] = PI_MCP_ADAPTER_SPEC
@@ -279,8 +315,12 @@ def _declare_pi_adapter(
     try:
         _write_pi_settings(settings_path, settings)
     except OSError as e:
-        return (False, f"could not write {settings_path.name}: {e}")
-    return (True, action)
+        return (
+            False,
+            f"could not write {settings_path.name}: {e}",
+            PI_MCP_ADAPTER_SPEC,
+        )
+    return (True, action, PI_MCP_ADAPTER_SPEC)
 
 
 def _retract_pi_adapter(
@@ -689,7 +729,7 @@ class PiInstaller(PlatformInstaller):
         # that had no effect on pi whatsoever.
         if not skip_global_steps:
             self._step("Declaring MCP adapter")
-            adapter_ok, adapter_msg = _declare_pi_adapter(
+            adapter_ok, adapter_msg, adapter_spec = _declare_pi_adapter(
                 self.config_dir, self.dry_run
             )
             if adapter_ok and not self.dry_run:
@@ -723,7 +763,7 @@ class PiInstaller(PlatformInstaller):
                     f"reads mcp.json"
                 )
             else:
-                msg = f"{msg} via {PI_MCP_ADAPTER_SPEC}"
+                msg = f"{msg} via {adapter_spec}"
 
             results.append(
                 InstallResult(

--- a/installer/platforms/pi.py
+++ b/installer/platforms/pi.py
@@ -4,8 +4,12 @@ Pi (https://github.com/badlogic/pi) supports:
 - AGENTS.md or CLAUDE.md for context (loaded from ~/.pi/agent/AGENTS.md globally)
 - Skills via Agent Skills standard in ~/.pi/agent/skills/ (directories or flat .md files)
 - Prompt templates as .md files in ~/.pi/agent/prompts/
-- MCP servers via JSON config in ~/.pi/agent/mcp.json (Claude Code shape)
-- HTTP MCP transport
+
+Pi does NOT support MCP natively. Its dist/ references neither "mcpServers"
+nor "mcp.json", and docs/usage.md states it "intentionally does not include
+built-in MCP". MCP arrives through the pi-mcp-adapter npm package, which this
+installer declares in ~/.pi/agent/settings.json; the adapter is what reads
+~/.pi/agent/mcp.json (Claude Code shape, HTTP transport).
 
 Reference:
 - https://github.com/badlogic/pi-coding-agent/docs/skills.md
@@ -16,7 +20,7 @@ import json
 import logging
 import os
 from pathlib import Path
-from typing import TYPE_CHECKING, List, Tuple
+from typing import TYPE_CHECKING, List, Optional, Tuple
 
 from ..components.mcp import get_spellbook_server_url
 from ..components.symlinks import (
@@ -38,6 +42,39 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 SPELLBOOK_SERVER_KEY: str = "spellbook"
+
+# Pi has no native MCP support. Its dist/ references neither "mcpServers" nor
+# "mcp.json", and docs/usage.md states it "intentionally does not include
+# built-in MCP". This npm package is the extension that reads mcp.json and
+# registers the servers it names.
+PI_MCP_ADAPTER_NAME: str = "pi-mcp-adapter"
+
+# Pinned, never a range. This is the version whose behaviour was verified end
+# to end against a running spellbook daemon: connect, tools/list, and tool
+# invocation with the Bearer header. Pi pins versioned npm specs and skips them
+# during `pi update --extensions`, so this value is what actually runs until
+# somebody edits this line on purpose.
+PI_MCP_ADAPTER_VERSION: str = "2.26.1"
+
+PI_MCP_ADAPTER_SPEC: str = f"npm:{PI_MCP_ADAPTER_NAME}@{PI_MCP_ADAPTER_VERSION}"
+
+
+def _read_pi_settings(settings_path: Path) -> dict:
+    """Read pi's settings.json, or ``{}`` when it is absent.
+
+    Distinct from ``_load_mcp_config_dict`` in one way that matters: a parse
+    failure RAISES. settings.json is the user's file and holds their model,
+    provider, and theme choices. Silently treating an unparseable one as empty
+    and writing a fresh object over it would discard all of that.
+    """
+    if not settings_path.exists():
+        return {}
+    data = json.loads(settings_path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(
+            f"{settings_path} is not a JSON object (got {type(data).__name__})"
+        )
+    return data
 
 
 def _load_mcp_config_dict(config_path: Path) -> dict:
@@ -82,14 +119,219 @@ def _write_mcp_config(config_path: Path, config: dict) -> None:
 
 
 def _generate_mcp_json_section() -> dict:
-    """Generate the MCP server entry for spellbook (HTTP transport)."""
+    """Generate the spellbook entry for pi-mcp-adapter's mcp.json.
+
+    The transport half -- ``url`` plus a raw ``headers`` map -- is the Claude
+    Code shape the adapter accepts unchanged. The other three keys are adapter
+    settings that no native MCP host would read, and each corrects a default
+    that would otherwise leave spellbook's tools unusable:
+
+    ``directTools``
+        Defaults to ``false``, which routes every tool through a single proxy
+        tool named ``mcp``. Spellbook's skills address tools by name.
+
+    ``toolPrefix``
+        Defaults to ``"server"``, which prepends the server name to each tool
+        name. The server is ``spellbook`` and its tools are already named
+        ``spellbook_*``, so the default yields
+        ``spellbook_spellbook_health_check``. ``directTools`` does not fix this;
+        it governs whether tools are registered individually, not their names.
+
+    ``lifecycle``
+        Defaults to ``"lazy"``. Only ``"eager"`` was verified to register
+        direct tools; whether ``"lazy"`` does so before first use is unverified.
+
+    ``protocolVersion`` is deliberately absent. The adapter's ``"legacy"``
+    default negotiates against the daemon, which answers ``2024-11-05``.
+    Pinning a version can only narrow what succeeds.
+    """
     url = get_spellbook_server_url()
     # Whole-entry replacement by the caller: any stale auth header from a
     # previous install disappears rather than being merged forward.
     server_entry: dict = {
         "url": url,
     }
+    server_entry["lifecycle"] = "eager"
+    server_entry["directTools"] = True
+    server_entry["toolPrefix"] = "none"
     return server_entry
+
+
+def _write_pi_settings(settings_path: Path, settings: dict) -> None:
+    """Write pi's settings.json atomically. Carries no token, so mode 0644."""
+    settings_path.parent.mkdir(parents=True, exist_ok=True)
+    payload = json.dumps(settings, indent=2) + "\n"
+    tmp_path = settings_path.with_name(f"{settings_path.name}.tmp.{os.getpid()}")
+    try:
+        tmp_path.write_text(payload, encoding="utf-8")
+        os.replace(tmp_path, settings_path)
+    except BaseException:
+        try:
+            tmp_path.unlink()
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def _is_spellbook_managed_adapter_entry(entry: object) -> bool:
+    """True for a bare ``npm:pi-mcp-adapter@<version>`` string.
+
+    Spellbook writes and removes only this shape. Pi also accepts an object
+    form carrying resource filters; a user who wrote one configured it
+    deliberately, and flattening it back to a string would discard those
+    filters silently.
+    """
+    return isinstance(entry, str) and entry.startswith(f"npm:{PI_MCP_ADAPTER_NAME}@")
+
+
+def _adapter_entry_index(packages: list) -> Optional[int]:
+    """Index of any entry naming the adapter, whatever its form.
+
+    Pi identifies an npm package by NAME, so two entries differing only in
+    version are ambiguous rather than additive.
+    """
+    for i, entry in enumerate(packages):
+        source = entry.get("source") if isinstance(entry, dict) else entry
+        if isinstance(source, str) and source.startswith(f"npm:{PI_MCP_ADAPTER_NAME}"):
+            return i
+    return None
+
+
+def _adapter_declared(settings_path: Path) -> bool:
+    """Whether settings.json declares the adapter package at all.
+
+    This is what the installer can substantiate. It is NOT the same as the
+    adapter being resolved on disk: pi installs a declared-but-missing npm
+    package on its next start (``resolvePackageSources`` in pi's
+    ``core/package-manager.js`` calls ``installMissing`` for any user-scope
+    npm entry whose install path is absent or version-mismatched).
+    """
+    try:
+        settings = _read_pi_settings(settings_path)
+    except (OSError, ValueError, json.JSONDecodeError):
+        return False
+    packages = settings.get("packages")
+    if not isinstance(packages, list):
+        return False
+    return _adapter_entry_index(packages) is not None
+
+
+def _adapter_installed_version(config_dir: Path) -> Optional[str]:
+    """Version of the adapter resolved on disk, or ``None``.
+
+    Pi installs user-scope npm packages to ``<agent dir>/npm/node_modules/<name>``
+    (``getManagedNpmInstallPath``). Reported separately from declaration so a
+    fresh install can say "declared, pi installs it on next start" rather than
+    implying the package is already present.
+    """
+    pkg_json = (
+        config_dir / "npm" / "node_modules" / PI_MCP_ADAPTER_NAME / "package.json"
+    )
+    try:
+        data = json.loads(pkg_json.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    version = data.get("version") if isinstance(data, dict) else None
+    return version if isinstance(version, str) else None
+
+
+def _declare_pi_adapter(
+    config_dir: Path, dry_run: bool = False
+) -> Tuple[bool, str]:
+    """Declare the pinned adapter in pi's settings.json.
+
+    Writes the ``packages[]`` entry directly rather than shelling out to
+    ``pi install``. That command does two things: it appends this entry, and it
+    runs npm. Pi already performs the npm half itself on the next start for any
+    declared-but-missing package, so the subprocess buys nothing an installer
+    wants -- and costs a ``pi`` binary on PATH, network access, and a failure
+    mode at install time that the settings write does not have.
+    """
+    settings_path = config_dir / "settings.json"
+
+    if dry_run:
+        return (True, f"would declare {PI_MCP_ADAPTER_SPEC}")
+
+    try:
+        settings = _read_pi_settings(settings_path)
+    except (OSError, ValueError, json.JSONDecodeError) as e:
+        return (False, f"could not read {settings_path.name}: {e}")
+
+    packages = settings.get("packages")
+    if not isinstance(packages, list):
+        packages = []
+
+    index = _adapter_entry_index(packages)
+    if index is not None and not _is_spellbook_managed_adapter_entry(packages[index]):
+        return (True, f"{PI_MCP_ADAPTER_NAME} already declared by the user; left as is")
+
+    if index is not None and packages[index] == PI_MCP_ADAPTER_SPEC:
+        return (True, f"{PI_MCP_ADAPTER_SPEC} already declared")
+
+    if index is not None:
+        packages[index] = PI_MCP_ADAPTER_SPEC
+        action = f"repinned to {PI_MCP_ADAPTER_SPEC}"
+    else:
+        packages.append(PI_MCP_ADAPTER_SPEC)
+        action = f"declared {PI_MCP_ADAPTER_SPEC}"
+
+    settings["packages"] = packages
+    try:
+        _write_pi_settings(settings_path, settings)
+    except OSError as e:
+        return (False, f"could not write {settings_path.name}: {e}")
+    return (True, action)
+
+
+def _retract_pi_adapter(
+    config_dir: Path, dry_run: bool = False
+) -> Tuple[bool, str]:
+    """Remove spellbook's adapter declaration, but only if nothing else needs it.
+
+    The adapter is a general-purpose MCP bridge, not a spellbook component. If
+    any other server remains in mcp.json after spellbook's entry is gone, that
+    server still needs the adapter loaded and removing it would break it. Only
+    the bare string entry spellbook itself writes is ever removed; a
+    user-authored object-form entry is left untouched.
+
+    The on-disk package under ``npm/node_modules/`` is left in place. Deleting
+    it is pi's business (``pi remove``), and it is inert once undeclared.
+    """
+    settings_path = config_dir / "settings.json"
+
+    if dry_run:
+        return (True, f"would retract {PI_MCP_ADAPTER_SPEC} if unused")
+
+    mcp_config = _load_mcp_config_dict(config_dir / "mcp.json")
+    remaining = mcp_config.get("mcpServers")
+    if isinstance(remaining, dict) and remaining:
+        return (
+            True,
+            f"{PI_MCP_ADAPTER_NAME} kept: {len(remaining)} other MCP server(s) need it",
+        )
+
+    try:
+        settings = _read_pi_settings(settings_path)
+    except (OSError, ValueError, json.JSONDecodeError):
+        return (True, f"{settings_path.name} unreadable; {PI_MCP_ADAPTER_NAME} left as is")
+
+    packages = settings.get("packages")
+    if not isinstance(packages, list):
+        return (True, f"{PI_MCP_ADAPTER_NAME} was not declared")
+
+    index = _adapter_entry_index(packages)
+    if index is None:
+        return (True, f"{PI_MCP_ADAPTER_NAME} was not declared")
+    if not _is_spellbook_managed_adapter_entry(packages[index]):
+        return (True, f"{PI_MCP_ADAPTER_NAME} was declared by the user; left as is")
+
+    del packages[index]
+    settings["packages"] = packages
+    try:
+        _write_pi_settings(settings_path, settings)
+    except OSError as e:
+        return (False, f"could not write {settings_path.name}: {e}")
+    return (True, f"retracted {PI_MCP_ADAPTER_SPEC}")
 
 
 def _update_pi_mcp_config(
@@ -200,12 +442,18 @@ class PiInstaller(PlatformInstaller):
         """Detect Pi installation status."""
         installed_version = get_installed_version(self.context_file)
 
-        has_mcp = False
+        # An entry in mcp.json is not a registration on its own -- pi reads
+        # that file only through pi-mcp-adapter. Every install before this one
+        # left exactly that state behind, so reporting it as registered would
+        # keep the original defect alive inside `detect`.
+        has_mcp_entry = False
         if self.mcp_config_file.exists():
             cfg = _load_mcp_config_dict(self.mcp_config_file)
             servers = cfg.get("mcpServers", {})
             if isinstance(servers, dict):
-                has_mcp = SPELLBOOK_SERVER_KEY in servers
+                has_mcp_entry = SPELLBOOK_SERVER_KEY in servers
+        adapter_declared = _adapter_declared(self.config_dir / "settings.json")
+        has_mcp = has_mcp_entry and adapter_declared
 
         # Check for any spellbook-related skills or prompts
         has_skills = False
@@ -252,7 +500,7 @@ class PiInstaller(PlatformInstaller):
 
         installed = (
             installed_version is not None
-            or has_mcp
+            or has_mcp_entry
             or has_skills
             or has_prompts
             or has_bundle
@@ -266,6 +514,8 @@ class PiInstaller(PlatformInstaller):
             details={
                 "config_dir": str(self.config_dir),
                 "mcp_registered": has_mcp,
+                "mcp_adapter_declared": adapter_declared,
+                "mcp_adapter_version": _adapter_installed_version(self.config_dir),
                 "skills_installed": has_skills,
                 "prompts_installed": has_prompts,
             },
@@ -429,11 +679,52 @@ class PiInstaller(PlatformInstaller):
         ):
             remove_demarcated_section(self.context_file)
 
-        # Step 4: Register MCP server in mcp.json
-        # This is a global step: MCP registration is system-wide, not per-dir.
+        # Step 4: Declare the MCP adapter, then write mcp.json.
+        # These are global steps: MCP registration is system-wide, not per-dir.
+        #
+        # Order matters for what gets REPORTED. Pi reads mcp.json only through
+        # pi-mcp-adapter, so the declaration is the thing that makes the file
+        # mean anything. Writing mcp.json and reporting "registered MCP server"
+        # -- which is what this installer used to do -- described an operation
+        # that had no effect on pi whatsoever.
         if not skip_global_steps:
+            self._step("Declaring MCP adapter")
+            adapter_ok, adapter_msg = _declare_pi_adapter(
+                self.config_dir, self.dry_run
+            )
+            if adapter_ok and not self.dry_run:
+                on_disk = _adapter_installed_version(self.config_dir)
+                adapter_msg += (
+                    f" (present on disk: {on_disk})"
+                    if on_disk
+                    else " (not on disk yet; pi installs it on next start)"
+                )
+            results.append(
+                InstallResult(
+                    component="mcp_adapter",
+                    platform=self.platform_id,
+                    success=adapter_ok,
+                    action="installed" if adapter_ok else "failed",
+                    message=f"MCP adapter: {adapter_msg}",
+                )
+            )
+
             self._step("Registering MCP server")
             success, msg = _update_pi_mcp_config(self.mcp_config_file, self.dry_run)
+
+            # The installer makes no request to the daemon, so it cannot tell a
+            # running daemon from a stopped one, nor a live token from a stale
+            # one. Its vocabulary is therefore limited to what it actually did.
+            if not adapter_ok:
+                success = False
+                msg = (
+                    f"not registered -- pi has no native MCP support and "
+                    f"{PI_MCP_ADAPTER_NAME} could not be declared, so nothing "
+                    f"reads mcp.json"
+                )
+            else:
+                msg = f"{msg} via {PI_MCP_ADAPTER_SPEC}"
+
             results.append(
                 InstallResult(
                     component="mcp_server",
@@ -527,6 +818,21 @@ class PiInstaller(PlatformInstaller):
                     success=success,
                     action="removed" if "removed" in msg else "skipped",
                     message=f"MCP server: {msg}",
+                )
+            )
+
+            # Retract the adapter declaration only after the spellbook entry is
+            # gone from mcp.json, because the decision depends on what remains.
+            adapter_ok, adapter_msg = _retract_pi_adapter(
+                self.config_dir, self.dry_run
+            )
+            results.append(
+                InstallResult(
+                    component="mcp_adapter",
+                    platform=self.platform_id,
+                    success=adapter_ok,
+                    action="removed" if "retracted" in adapter_msg else "skipped",
+                    message=f"MCP adapter: {adapter_msg}",
                 )
             )
 

--- a/tests/installer/test_pi_mcp_adapter.py
+++ b/tests/installer/test_pi_mcp_adapter.py
@@ -1,0 +1,415 @@
+"""Pi has no native MCP; the adapter package is what makes mcp.json load.
+
+Pi's own ``dist/`` references neither ``mcpServers`` nor ``mcp.json``, and its
+``docs/usage.md`` states it "intentionally does not include built-in MCP". The
+installer nevertheless wrote ``~/.pi/agent/mcp.json`` and reported that it had
+registered spellbook's MCP server. Nothing read that file. The success message
+was the only artifact the operation produced.
+
+The fix has two halves and this file locks in both:
+
+1. ``mcp.json`` is emitted in the shape ``pi-mcp-adapter`` actually needs, not
+   the bare ``{url, headers}`` a native host would accept.
+2. The adapter is declared in ``settings.json``, and the reported outcome is
+   conditioned on that declaration rather than on a file having been written.
+
+No mocking is required anywhere in this file: ``PlatformInstaller`` takes
+``config_dir`` as a constructor argument, so every assertion runs against real
+files under ``tmp_path``. Nothing here shells out to ``pi``.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from installer.platforms.pi import (
+    PI_MCP_ADAPTER_NAME,
+    PI_MCP_ADAPTER_SPEC,
+    PI_MCP_ADAPTER_VERSION,
+    SPELLBOOK_SERVER_KEY,
+    PiInstaller,
+    _generate_mcp_json_section,
+    _read_pi_settings,
+)
+
+
+@pytest.fixture
+def config_dir(tmp_path: Path) -> Path:
+    """A stand-in for ~/.pi/agent/."""
+    d = tmp_path / "pi" / "agent"
+    d.mkdir(parents=True)
+    return d
+
+
+@pytest.fixture
+def spellbook_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "spellbook"
+    (d / "skills").mkdir(parents=True)
+    (d / "commands").mkdir(parents=True)
+    return d
+
+
+def _installer(spellbook_dir: Path, config_dir: Path, **kw) -> PiInstaller:
+    return PiInstaller(
+        spellbook_dir=spellbook_dir, config_dir=config_dir, version="test", **kw
+    )
+
+
+def _result(results, component: str):
+    matches = [r for r in results if r.component == component]
+    assert len(matches) == 1, (
+        f"expected exactly one {component!r} result, got "
+        f"{[r.component for r in results]}"
+    )
+    return matches[0]
+
+
+# ---------------------------------------------------------------------------
+# The emitted mcp.json shape
+# ---------------------------------------------------------------------------
+
+
+def test_emitted_config_carries_the_adapter_only_fields():
+    """``directTools`` and ``lifecycle`` are adapter settings, not MCP ones.
+
+    A native MCP host ignores both. The adapter's global default for
+    ``directTools`` is ``false``, which exposes a SINGLE proxy tool named
+    ``mcp`` instead of the individual ``spellbook_*`` tools that every
+    spellbook skill addresses by name.
+    """
+    entry = _generate_mcp_json_section()
+
+    assert entry["directTools"] is True, (
+        "directTools defaults to false in the adapter, which collapses all 28 "
+        "spellbook tools behind one proxy tool named 'mcp'. Spellbook skills "
+        "reference tools by name, so they would all be unreachable."
+    )
+    assert entry["lifecycle"] == "eager", (
+        "The adapter's lifecycle default is 'lazy'. Only 'eager' was verified "
+        "to register direct tools; whether 'lazy' does so before first use is "
+        "unverified, so 'eager' is emitted rather than relying on the default."
+    )
+
+
+def test_emitted_config_does_not_pin_protocol_version():
+    """Pinning ``protocolVersion`` fails when the server does not offer it.
+
+    The adapter's ``"legacy"`` default negotiates successfully against the
+    daemon, which answers ``2024-11-05``. The daemon does not offer
+    ``2026-07-28``, so a pinned value would break the handshake.
+    """
+    entry = _generate_mcp_json_section()
+
+    assert "protocolVersion" not in entry, (
+        "protocolVersion must stay unset so the adapter's 'legacy' default "
+        "negotiates. The daemon answers 2024-11-05 and does not offer "
+        "2026-07-28; pinning either value can only narrow what succeeds."
+    )
+
+
+def _adapter_get_server_prefix(server_name: str, mode: str) -> str:
+    """Port of the adapter's ``getServerPrefix`` from ``types.ts``.
+
+    Kept deliberately literal so a reader can diff it against the original.
+    Only the modes reachable from a spellbook-emitted config are covered.
+    """
+    if mode == "none":
+        return ""
+    if mode == "mcp":
+        return f"mcp__{server_name}"
+    if mode == "short":
+        return server_name.removesuffix("mcp").rstrip("-") or "mcp"
+    return server_name  # "server", the adapter's default
+
+
+def _adapter_format_tool_name(tool_name: str, server_name: str, mode: str) -> str:
+    """Port of the adapter's ``formatToolName`` from ``types.ts``."""
+    prefix = _adapter_get_server_prefix(server_name, mode)
+    sanitized = tool_name.replace(".", "_")
+    return f"{prefix}_{sanitized}" if prefix else sanitized
+
+
+def test_tool_prefix_none_is_what_prevents_a_doubled_spellbook_prefix():
+    """``toolPrefix`` is load-bearing, and ``directTools`` does NOT cover it.
+
+    The adapter prefixes every direct tool name with the SERVER name. Our
+    server is named ``spellbook`` and every tool it exports is already named
+    ``spellbook_*``, so the adapter's default mode produces
+    ``spellbook_spellbook_health_check``. Every tool name referenced by every
+    spellbook skill would be wrong.
+
+    This test runs the adapter's own prefixing rule over the name spellbook
+    actually emits, so it fails with the doubled name in the message rather
+    than with a bare shape mismatch.
+    """
+    entry = _generate_mcp_json_section()
+    tool = "spellbook_health_check"
+
+    default_mode_name = _adapter_format_tool_name(
+        tool, SPELLBOOK_SERVER_KEY, "server"
+    )
+    assert default_mode_name == "spellbook_spellbook_health_check", (
+        "Guard on the port itself: if this no longer reproduces the doubled "
+        "name, _adapter_format_tool_name has drifted from the adapter's "
+        "types.ts and the assertion below proves nothing."
+    )
+
+    assert entry.get("toolPrefix") == "none", (
+        "toolPrefix must be 'none'. With the adapter's default ('server') the "
+        f"server name is prepended to names that already start with "
+        f"'spellbook_', yielding {default_mode_name!r}. directTools alone does "
+        "NOT fix this -- it controls WHETHER tools are registered "
+        "individually, not what they are NAMED."
+    )
+
+    configured_name = _adapter_format_tool_name(
+        tool, SPELLBOOK_SERVER_KEY, entry["toolPrefix"]
+    )
+    assert configured_name == tool, (
+        f"With the emitted toolPrefix the adapter registers {configured_name!r}; "
+        f"spellbook skills address {tool!r}."
+    )
+
+
+def test_emitted_config_keeps_the_bearer_header_shape():
+    """The adapter accepts a raw ``headers`` map; the daemon 401s without it."""
+    entry = _generate_mcp_json_section()
+
+    assert entry["url"].endswith("/mcp")
+    if "headers" in entry:
+        assert entry["headers"]["Authorization"].startswith("Bearer ")
+
+
+# ---------------------------------------------------------------------------
+# Declaring the adapter in settings.json
+# ---------------------------------------------------------------------------
+
+
+def test_install_declares_the_adapter_pinned_in_settings(spellbook_dir, config_dir):
+    """A pinned ``npm:`` spec is skipped by ``pi update --extensions``."""
+    _installer(spellbook_dir, config_dir).install()
+
+    settings = _read_pi_settings(config_dir / "settings.json")
+
+    assert settings["packages"] == [PI_MCP_ADAPTER_SPEC]
+    assert PI_MCP_ADAPTER_SPEC == f"npm:{PI_MCP_ADAPTER_NAME}@{PI_MCP_ADAPTER_VERSION}"
+    assert "@" in PI_MCP_ADAPTER_SPEC, (
+        "The spec must carry an explicit version. Pi pins versioned npm specs "
+        "and skips them during updates; an unversioned spec would drift to "
+        "whatever is latest, which is not what was verified."
+    )
+
+
+def test_install_preserves_unrelated_settings_and_other_packages(
+    spellbook_dir, config_dir
+):
+    """settings.json belongs to the user. Spellbook adds one entry to it."""
+    settings_path = config_dir / "settings.json"
+    settings_path.write_text(
+        json.dumps(
+            {
+                "defaultModel": "some-model",
+                "theme": "dark",
+                "packages": ["npm:someone-elses-package@1.0.0"],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    _installer(spellbook_dir, config_dir).install()
+
+    settings = _read_pi_settings(settings_path)
+    assert settings["defaultModel"] == "some-model"
+    assert settings["theme"] == "dark"
+    assert "npm:someone-elses-package@1.0.0" in settings["packages"]
+    assert PI_MCP_ADAPTER_SPEC in settings["packages"]
+
+
+def test_install_replaces_a_differently_versioned_adapter_entry(
+    spellbook_dir, config_dir
+):
+    """Identity for an npm package is its NAME, per pi's docs/packages.md.
+
+    Two entries for the same package name would be ambiguous, so an older
+    pinned version is replaced rather than appended to.
+    """
+    settings_path = config_dir / "settings.json"
+    settings_path.write_text(
+        json.dumps({"packages": [f"npm:{PI_MCP_ADAPTER_NAME}@0.0.1"]}),
+        encoding="utf-8",
+    )
+
+    _installer(spellbook_dir, config_dir).install()
+
+    packages = _read_pi_settings(settings_path)["packages"]
+    adapter_entries = [p for p in packages if PI_MCP_ADAPTER_NAME in str(p)]
+    assert adapter_entries == [PI_MCP_ADAPTER_SPEC]
+
+
+def test_install_does_not_touch_an_object_form_adapter_entry(
+    spellbook_dir, config_dir
+):
+    """A user who filtered the package with the object form configured it
+    deliberately. Spellbook leaves that entry alone rather than flattening it
+    back to a bare string and silently discarding the filters."""
+    settings_path = config_dir / "settings.json"
+    user_entry = {"source": f"npm:{PI_MCP_ADAPTER_NAME}@2.0.0", "skills": []}
+    settings_path.write_text(json.dumps({"packages": [user_entry]}), encoding="utf-8")
+
+    _installer(spellbook_dir, config_dir).install()
+
+    packages = _read_pi_settings(settings_path)["packages"]
+    assert packages == [user_entry]
+
+
+# ---------------------------------------------------------------------------
+# Honest reporting -- the point of the whole change
+# ---------------------------------------------------------------------------
+
+
+def test_reported_message_names_the_adapter_not_a_bare_registration(
+    spellbook_dir, config_dir
+):
+    """The old message claimed registration that nothing could substantiate."""
+    results = _installer(spellbook_dir, config_dir).install()
+
+    mcp = _result(results, "mcp_server")
+    assert mcp.success
+    assert PI_MCP_ADAPTER_NAME in mcp.message, (
+        "Pi cannot read mcp.json on its own. A message that claims MCP "
+        "registration without naming the adapter that provides it is the "
+        "silent no-op this change exists to remove."
+    )
+
+
+def test_reports_unregistered_when_the_adapter_cannot_be_declared(
+    spellbook_dir, config_dir
+):
+    """settings.json is unparseable, so the declaration cannot be made.
+
+    mcp.json may still be written -- it is harmless -- but the installer must
+    NOT report MCP as registered on the strength of having written a file.
+    """
+    (config_dir / "settings.json").write_text("{ this is not json", encoding="utf-8")
+
+    results = _installer(spellbook_dir, config_dir).install()
+
+    adapter = _result(results, "mcp_adapter")
+    assert not adapter.success
+
+    mcp = _result(results, "mcp_server")
+    assert not mcp.success, (
+        "Without the adapter declared, nothing in pi reads mcp.json. Reporting "
+        "success here is exactly the defect being fixed."
+    )
+    assert "not registered" in mcp.message.lower()
+
+
+def test_install_never_claims_a_verified_connection(spellbook_dir, config_dir):
+    """The installer does not probe the daemon and must not imply that it did.
+
+    Two states are explicitly untested upstream -- daemon down, and a stale
+    token. The installer cannot distinguish them because it makes no request,
+    so its vocabulary is confined to what it did: declare and write.
+    """
+    results = _installer(spellbook_dir, config_dir).install()
+
+    for component in ("mcp_adapter", "mcp_server"):
+        message = _result(results, component).message.lower()
+        for claim in ("connected", "verified", "reachable", "working", "available"):
+            assert claim not in message, (
+                f"{component} message claims {claim!r}, but the installer "
+                f"never contacts the daemon: {message!r}"
+            )
+
+
+def test_detect_reports_mcp_unregistered_when_the_adapter_is_absent(
+    spellbook_dir, config_dir
+):
+    """mcp.json alone is not MCP support. ``detect`` must agree with that."""
+    (config_dir / "mcp.json").write_text(
+        json.dumps({"mcpServers": {SPELLBOOK_SERVER_KEY: {"url": "http://x/mcp"}}}),
+        encoding="utf-8",
+    )
+
+    status = _installer(spellbook_dir, config_dir).detect()
+
+    assert status.details["mcp_registered"] is False, (
+        "A spellbook entry in mcp.json with no adapter declared is the state "
+        "every prior install left behind. It is not a registration."
+    )
+    assert status.details["mcp_adapter_declared"] is False
+
+
+def test_detect_reports_mcp_registered_once_the_adapter_is_declared(
+    spellbook_dir, config_dir
+):
+    _installer(spellbook_dir, config_dir).install()
+
+    status = _installer(spellbook_dir, config_dir).detect()
+
+    assert status.details["mcp_registered"] is True
+    assert status.details["mcp_adapter_declared"] is True
+
+
+# ---------------------------------------------------------------------------
+# Uninstall
+# ---------------------------------------------------------------------------
+
+
+def test_uninstall_retracts_the_adapter_when_spellbook_was_its_only_reason(
+    spellbook_dir, config_dir
+):
+    """Spellbook declared it and no other server needs it, so it is retracted."""
+    _installer(spellbook_dir, config_dir).install()
+
+    _installer(spellbook_dir, config_dir).uninstall()
+
+    packages = _read_pi_settings(config_dir / "settings.json").get("packages", [])
+    assert PI_MCP_ADAPTER_SPEC not in packages
+
+
+def test_uninstall_keeps_the_adapter_when_another_mcp_server_remains(
+    spellbook_dir, config_dir
+):
+    """The adapter is a general-purpose bridge, not a spellbook component.
+
+    Removing it would break every other server in the user's mcp.json.
+    """
+    _installer(spellbook_dir, config_dir).install()
+    mcp_path = config_dir / "mcp.json"
+    config = json.loads(mcp_path.read_text(encoding="utf-8"))
+    config["mcpServers"]["someone-else"] = {"url": "http://example/mcp"}
+    mcp_path.write_text(json.dumps(config), encoding="utf-8")
+
+    _installer(spellbook_dir, config_dir).uninstall()
+
+    packages = _read_pi_settings(config_dir / "settings.json").get("packages", [])
+    assert PI_MCP_ADAPTER_SPEC in packages, (
+        "another server still needs the adapter to be loaded"
+    )
+    remaining = json.loads(mcp_path.read_text(encoding="utf-8"))["mcpServers"]
+    assert SPELLBOOK_SERVER_KEY not in remaining
+    assert "someone-else" in remaining
+
+
+def test_uninstall_never_removes_an_adapter_entry_spellbook_did_not_write(
+    spellbook_dir, config_dir
+):
+    """A user-authored object-form entry survives uninstall untouched."""
+    settings_path = config_dir / "settings.json"
+    user_entry = {"source": f"npm:{PI_MCP_ADAPTER_NAME}@2.0.0", "skills": []}
+    settings_path.write_text(json.dumps({"packages": [user_entry]}), encoding="utf-8")
+
+    _installer(spellbook_dir, config_dir).install()
+    _installer(spellbook_dir, config_dir).uninstall()
+
+    assert _read_pi_settings(settings_path)["packages"] == [user_entry]
+
+
+def test_dry_run_writes_nothing(spellbook_dir, config_dir):
+    _installer(spellbook_dir, config_dir, dry_run=True).install()
+
+    assert not (config_dir / "settings.json").exists()
+    assert not (config_dir / "mcp.json").exists()

--- a/tests/installer/test_pi_mcp_adapter.py
+++ b/tests/installer/test_pi_mcp_adapter.py
@@ -413,3 +413,103 @@ def test_dry_run_writes_nothing(spellbook_dir, config_dir):
 
     assert not (config_dir / "settings.json").exists()
     assert not (config_dir / "mcp.json").exists()
+
+
+# ---------------------------------------------------------------------------
+# The adapter-entry boundary: which settings.json entries ARE the adapter
+# ---------------------------------------------------------------------------
+
+
+def test_install_repins_a_version_less_adapter_entry(spellbook_dir, config_dir):
+    """A bare ``npm:pi-mcp-adapter`` with no version is spellbook-shaped.
+
+    An unpinned spec is the exact drift ``PI_MCP_ADAPTER_VERSION`` exists to
+    prevent: ``pi update --extensions`` skips pinned specs and moves unpinned
+    ones to whatever is latest, which is not the version verified end to end.
+    The entry is a bare string, which is the only shape spellbook writes, so it
+    is repinned rather than left alone.
+    """
+    settings_path = config_dir / "settings.json"
+    settings_path.write_text(
+        json.dumps({"packages": [f"npm:{PI_MCP_ADAPTER_NAME}"]}), encoding="utf-8"
+    )
+
+    _installer(spellbook_dir, config_dir).install()
+
+    packages = _read_pi_settings(settings_path)["packages"]
+    assert packages == [PI_MCP_ADAPTER_SPEC], (
+        "An unpinned bare-string entry must be repinned. Leaving it makes the "
+        "installer report a version it did not write."
+    )
+
+
+def test_a_package_whose_name_merely_starts_with_the_adapter_is_not_the_adapter(
+    spellbook_dir, config_dir
+):
+    """``npm:pi-mcp-adapter-extra`` is a DIFFERENT package.
+
+    A prefix test without a boundary matches it, which makes ``detect`` report
+    the adapter as declared while the real adapter is absent, and makes the
+    installer decline to declare the one thing it is responsible for.
+    """
+    settings_path = config_dir / "settings.json"
+    lookalike = f"npm:{PI_MCP_ADAPTER_NAME}-extra@1.0.0"
+    settings_path.write_text(json.dumps({"packages": [lookalike]}), encoding="utf-8")
+
+    _installer(spellbook_dir, config_dir).install()
+
+    packages = _read_pi_settings(settings_path)["packages"]
+    assert lookalike in packages, "the user's unrelated package must survive"
+    assert PI_MCP_ADAPTER_SPEC in packages, (
+        f"{lookalike!r} is not the adapter; the adapter must still be declared"
+    )
+
+
+def test_detect_does_not_count_a_lookalike_package_as_the_adapter(
+    spellbook_dir, config_dir
+):
+    """``detect`` must not report a registration a lookalike name cannot provide."""
+    (config_dir / "settings.json").write_text(
+        json.dumps({"packages": [f"npm:{PI_MCP_ADAPTER_NAME}-extra@1.0.0"]}),
+        encoding="utf-8",
+    )
+    (config_dir / "mcp.json").write_text(
+        json.dumps({"mcpServers": {SPELLBOOK_SERVER_KEY: {"url": "http://x/mcp"}}}),
+        encoding="utf-8",
+    )
+
+    status = _installer(spellbook_dir, config_dir).detect()
+
+    assert status.details["mcp_adapter_declared"] is False
+    assert status.details["mcp_registered"] is False
+
+
+def test_reported_message_never_names_a_version_spellbook_did_not_write(
+    spellbook_dir, config_dir
+):
+    """The object-form entry is left as is, so the pinned spec is NOT on disk.
+
+    Reporting "via npm:pi-mcp-adapter@<pinned>" here states a version that the
+    installer declined to write. The message must name the spec that actually
+    loads mcp.json -- the user's own.
+    """
+    settings_path = config_dir / "settings.json"
+    user_source = f"npm:{PI_MCP_ADAPTER_NAME}@2.0.0"
+    settings_path.write_text(
+        json.dumps({"packages": [{"source": user_source, "skills": []}]}),
+        encoding="utf-8",
+    )
+
+    results = _installer(spellbook_dir, config_dir).install()
+
+    packages = _read_pi_settings(settings_path)["packages"]
+    assert packages == [{"source": user_source, "skills": []}]
+
+    message = _result(results, "mcp_server").message
+    assert PI_MCP_ADAPTER_SPEC not in message, (
+        f"message names {PI_MCP_ADAPTER_SPEC!r}, but that spec was never "
+        f"written to settings.json: {message!r}"
+    )
+    assert user_source in message, (
+        f"the message must name the spec that actually loads mcp.json: {message!r}"
+    )

--- a/tests/installer/test_pi_mcp_adapter.py
+++ b/tests/installer/test_pi_mcp_adapter.py
@@ -9,7 +9,7 @@ was the only artifact the operation produced.
 The fix has two halves and this file locks in both:
 
 1. ``mcp.json`` is emitted in the shape ``pi-mcp-adapter`` actually needs, not
-   the bare ``{url, headers}`` a native host would accept.
+   the bare ``{url}`` a native host would accept.
 2. The adapter is declared in ``settings.json``, and the reported outcome is
    conditioned on that declaration rather than on a file having been written.
 
@@ -19,6 +19,9 @@ files under ``tmp_path``. Nothing here shells out to ``pi``.
 """
 
 import json
+import os
+import stat
+import time
 from pathlib import Path
 
 import pytest
@@ -27,10 +30,16 @@ from installer.platforms.pi import (
     PI_MCP_ADAPTER_NAME,
     PI_MCP_ADAPTER_SPEC,
     PI_MCP_ADAPTER_VERSION,
+    PI_RESTART_NOTICE,
+    PI_SETTINGS_LOCK_SUFFIX,
+    PI_SETTINGS_NEW_FILE_MODE,
     SPELLBOOK_SERVER_KEY,
     PiInstaller,
+    _declare_pi_adapter,
     _generate_mcp_json_section,
+    _pi_settings_lock,
     _read_pi_settings,
+    _retract_pi_adapter,
 )
 
 
@@ -81,8 +90,8 @@ def test_emitted_config_carries_the_adapter_only_fields():
     entry = _generate_mcp_json_section()
 
     assert entry["directTools"] is True, (
-        "directTools defaults to false in the adapter, which collapses all 28 "
-        "spellbook tools behind one proxy tool named 'mcp'. Spellbook skills "
+        "directTools defaults to false in the adapter, which collapses every "
+        "spellbook tool behind one proxy tool named 'mcp'. Spellbook skills "
         "reference tools by name, so they would all be unreachable."
     )
     assert entry["lifecycle"] == "eager", (
@@ -172,13 +181,19 @@ def test_tool_prefix_none_is_what_prevents_a_doubled_spellbook_prefix():
     )
 
 
-def test_emitted_config_keeps_the_bearer_header_shape():
-    """The adapter accepts a raw ``headers`` map; the daemon 401s without it."""
+def test_emitted_config_carries_a_url_and_no_auth_header():
+    """The daemon authenticates on Origin and Host, not on a header.
+
+    The entry must carry no ``headers`` map at all. Emitting one would put a
+    credential in a world-readable config for an authentication scheme the
+    daemon no longer runs.
+    """
     entry = _generate_mcp_json_section()
 
     assert entry["url"].endswith("/mcp")
-    if "headers" in entry:
-        assert entry["headers"]["Authorization"].startswith("Bearer ")
+    assert "headers" not in entry, (
+        f"the entry carries a headers map the daemon does not read: {entry!r}"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -309,9 +324,9 @@ def test_reports_unregistered_when_the_adapter_cannot_be_declared(
 def test_install_never_claims_a_verified_connection(spellbook_dir, config_dir):
     """The installer does not probe the daemon and must not imply that it did.
 
-    Two states are explicitly untested upstream -- daemon down, and a stale
-    token. The installer cannot distinguish them because it makes no request,
-    so its vocabulary is confined to what it did: declare and write.
+    A daemon that is down and a daemon that is up are indistinguishable to an
+    installer that makes no request, so its vocabulary is confined to what it
+    did: declare and write.
     """
     results = _installer(spellbook_dir, config_dir).install()
 
@@ -513,3 +528,274 @@ def test_reported_message_never_names_a_version_spellbook_did_not_write(
     assert user_source in message, (
         f"the message must name the spec that actually loads mcp.json: {message!r}"
     )
+
+
+# ---------------------------------------------------------------------------
+# settings.json belongs to the user: its mode, its shape, its concurrent writer
+# ---------------------------------------------------------------------------
+
+
+def test_install_preserves_an_owner_only_settings_mode(spellbook_dir, config_dir):
+    """An owner-only settings.json must not come back world-readable.
+
+    ``os.replace`` swaps in the TEMPORARY file, so without an explicit chmod the
+    result carries the temp file's default-umask mode -- typically 0644. A user
+    who tightened settings.json to 0600 would have it widened by an install that
+    only meant to append a package entry.
+    """
+    settings_path = config_dir / "settings.json"
+    settings_path.write_text(json.dumps({"theme": "dark"}), encoding="utf-8")
+    settings_path.chmod(0o600)
+
+    _installer(spellbook_dir, config_dir).install()
+
+    assert stat.S_IMODE(settings_path.stat().st_mode) == 0o600, (
+        "the install widened the user's settings.json; every other local "
+        "account can now read it"
+    )
+    assert PI_MCP_ADAPTER_SPEC in _read_pi_settings(settings_path)["packages"]
+
+
+def test_a_settings_file_the_installer_creates_is_owner_only(
+    spellbook_dir, config_dir
+):
+    """With no file to inherit a mode from, the restrictive default applies."""
+    settings_path = config_dir / "settings.json"
+    assert not settings_path.exists()
+
+    _installer(spellbook_dir, config_dir).install()
+
+    assert stat.S_IMODE(settings_path.stat().st_mode) == PI_SETTINGS_NEW_FILE_MODE
+
+
+def test_a_non_list_packages_key_is_never_overwritten(spellbook_dir, config_dir):
+    """A wrong-typed ``packages`` is the user's data, not a blank slate.
+
+    Coercing it to ``[]`` and writing that back destroys it silently. The file
+    level already raises on a non-object; the key level must not be laxer.
+    """
+    settings_path = config_dir / "settings.json"
+    original = json.dumps({"theme": "dark", "packages": "npm:pi-mcp-adapter"})
+    settings_path.write_text(original, encoding="utf-8")
+
+    results = _installer(spellbook_dir, config_dir).install()
+
+    assert settings_path.read_text(encoding="utf-8") == original, (
+        "settings.json was rewritten; whatever 'packages' held is gone"
+    )
+    adapter = _result(results, "mcp_adapter")
+    assert not adapter.success
+    assert "packages" in adapter.message
+
+
+def test_a_second_stale_adapter_entry_is_not_left_behind(spellbook_dir, config_dir):
+    """Handling only the FIRST match leaves a sibling that can win.
+
+    Pi resolves an npm package by name, so a leftover older pin is not additive
+    -- it is a second answer to the same question, and the version the
+    installer reports need not be the version that loads.
+    """
+    settings_path = config_dir / "settings.json"
+    settings_path.write_text(
+        json.dumps(
+            {
+                "packages": [
+                    f"npm:{PI_MCP_ADAPTER_NAME}@0.0.1",
+                    "npm:someone-elses-package@1.0.0",
+                    f"npm:{PI_MCP_ADAPTER_NAME}@0.0.2",
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    _installer(spellbook_dir, config_dir).install()
+
+    packages = _read_pi_settings(settings_path)["packages"]
+    assert [p for p in packages if PI_MCP_ADAPTER_NAME in str(p)] == [
+        PI_MCP_ADAPTER_SPEC
+    ], f"a stale adapter declaration survived: {packages!r}"
+    assert "npm:someone-elses-package@1.0.0" in packages
+
+
+def test_duplicate_entries_including_a_user_one_fail_loudly(
+    spellbook_dir, config_dir
+):
+    """Which entry pi loads is ambiguous, and one of them is the user's.
+
+    Rewriting either would guess, and reporting a version would report the
+    guess. The installer says so instead.
+    """
+    settings_path = config_dir / "settings.json"
+    user_entry = {"source": f"npm:{PI_MCP_ADAPTER_NAME}@2.0.0", "skills": []}
+    packages = [f"npm:{PI_MCP_ADAPTER_NAME}@0.0.1", user_entry]
+    settings_path.write_text(json.dumps({"packages": packages}), encoding="utf-8")
+
+    results = _installer(spellbook_dir, config_dir).install()
+
+    assert _read_pi_settings(settings_path)["packages"] == packages
+    adapter = _result(results, "mcp_adapter")
+    assert not adapter.success
+    assert not _result(results, "mcp_server").success
+
+
+def test_uninstall_removes_every_entry_spellbook_wrote(spellbook_dir, config_dir):
+    """One retract, every managed entry -- the same reason install collapses them."""
+    settings_path = config_dir / "settings.json"
+    settings_path.write_text(
+        json.dumps(
+            {
+                "packages": [
+                    f"npm:{PI_MCP_ADAPTER_NAME}@0.0.1",
+                    f"npm:{PI_MCP_ADAPTER_NAME}",
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    ok, message, retracted = _retract_pi_adapter(config_dir)
+
+    assert ok and retracted, message
+    assert _read_pi_settings(settings_path)["packages"] == []
+
+
+def test_the_retracted_flag_is_a_fact_not_a_word_in_the_message(
+    spellbook_dir, config_dir
+):
+    """``action`` must come from what was removed, not from the message's text.
+
+    Deriving it by searching the message for a substring makes a reworded
+    message change the recorded outcome, silently and for no stated reason.
+    """
+    _installer(spellbook_dir, config_dir).install()
+    results = _installer(spellbook_dir, config_dir).uninstall()
+
+    assert _result(results, "mcp_adapter").action == "removed"
+
+    ok, message, retracted = _retract_pi_adapter(config_dir)
+    assert ok
+    assert retracted is False, (
+        f"nothing was removed on the second pass, yet retracted is True: {message!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Pi's lock, which pi takes around every settings.json read-modify-write
+# ---------------------------------------------------------------------------
+
+
+def test_the_declaration_waits_for_pis_lock_instead_of_overwriting(config_dir):
+    """A held lock means pi is mid read-modify-write. Writing through it loses.
+
+    Pi's ``withLock`` reads INSIDE the lock and writes back inside the same one
+    (``core/settings-manager.js``). An installer that ignores the lock has its
+    entry overwritten by pi's write, which was computed from a read taken
+    before ours -- after the installer already reported success.
+    """
+    settings_path = config_dir / "settings.json"
+    settings_path.write_text(json.dumps({"theme": "dark"}), encoding="utf-8")
+    lock_path = settings_path.with_name(settings_path.name + PI_SETTINGS_LOCK_SUFFIX)
+    lock_path.mkdir()
+
+    try:
+        ok, message, _ = _declare_pi_adapter(config_dir)
+    finally:
+        lock_path.rmdir()
+
+    assert not ok, "the installer wrote through a lock pi was holding"
+    assert "lock" in message
+    assert "packages" not in _read_pi_settings(settings_path)
+
+
+def test_the_lock_is_the_path_proper_lockfile_uses(config_dir):
+    """The lock is only pi's lock if it is at the path pi's library uses.
+
+    proper-lockfile's ``getLockFile`` returns the target path with ``.lock``
+    appended, and the lock itself is a DIRECTORY, created with mkdir. A lock at
+    any other path, or of any other kind, contends with nothing.
+    """
+    settings_path = config_dir / "settings.json"
+    settings_path.write_text("{}", encoding="utf-8")
+
+    with _pi_settings_lock(settings_path):
+        held = config_dir / "settings.json.lock"
+        assert held.is_dir(), "pi's lock is a directory at <file>.lock"
+
+    assert not held.exists(), "the lock must be released, or pi blocks forever"
+
+
+def test_a_stale_lock_does_not_block_the_install_forever(spellbook_dir, config_dir):
+    """proper-lockfile treats a lock older than its staleness window as dead."""
+    settings_path = config_dir / "settings.json"
+    settings_path.write_text("{}", encoding="utf-8")
+    lock_path = settings_path.with_name(settings_path.name + PI_SETTINGS_LOCK_SUFFIX)
+    lock_path.mkdir()
+    ancient = time.time() - 3600
+    os.utime(lock_path, (ancient, ancient))
+
+    ok, message, _ = _declare_pi_adapter(config_dir)
+
+    assert ok, message
+    assert PI_MCP_ADAPTER_SPEC in _read_pi_settings(settings_path)["packages"]
+
+
+# ---------------------------------------------------------------------------
+# What the dry run says it would do, and what the user is told to do next
+# ---------------------------------------------------------------------------
+
+
+def test_dry_run_does_not_claim_a_write_it_would_not_perform(
+    spellbook_dir, config_dir
+):
+    """The entry is already correct, so a real run writes nothing.
+
+    Returning "would declare ..." before reading the file announces a write for
+    the one case that performs none.
+    """
+    _installer(spellbook_dir, config_dir).install()
+
+    results = _installer(spellbook_dir, config_dir, dry_run=True).install()
+
+    message = _result(results, "mcp_adapter").message
+    assert "would declare" not in message, (
+        f"the dry run announces a write that would not happen: {message!r}"
+    )
+    assert "already declared" in message
+
+
+def test_dry_run_reports_leaving_a_user_entry_alone(spellbook_dir, config_dir):
+    """A user's object-form entry is left as is, dry run or not."""
+    settings_path = config_dir / "settings.json"
+    settings_path.write_text(
+        json.dumps(
+            {"packages": [{"source": f"npm:{PI_MCP_ADAPTER_NAME}@2.0.0", "skills": []}]}
+        ),
+        encoding="utf-8",
+    )
+
+    results = _installer(spellbook_dir, config_dir, dry_run=True).install()
+
+    message = _result(results, "mcp_adapter").message
+    assert "would declare" not in message
+    assert "left as is" in message
+
+
+def test_dry_run_still_announces_a_write_it_would_perform(spellbook_dir, config_dir):
+    """Reading first must not silence the case that does write."""
+    results = _installer(spellbook_dir, config_dir, dry_run=True).install()
+
+    assert "would declare" in _result(results, "mcp_adapter").message
+
+
+def test_install_tells_the_user_that_pi_must_be_restarted(spellbook_dir, config_dir):
+    """The tools do not exist until pi restarts, and nothing else says so.
+
+    The adapter connects a ``directTools`` server during ``session_start`` when
+    it has no cache entry for it and then reports, in its own ``init.ts``, that
+    the tools "will be available after restart". Pi separately installs a
+    declared-but-missing npm package on its next start.
+    """
+    results = _installer(spellbook_dir, config_dir).install()
+
+    assert PI_RESTART_NOTICE in _result(results, "mcp_server").message


### PR DESCRIPTION
## What does this PR do?

Makes pi's MCP registration do something. `installer/platforms/pi.py` wrote
`~/.pi/agent/mcp.json` and reported that it had registered spellbook's MCP server, but **pi
has no native MCP support**: its `dist/` references neither `mcpServers` nor `mcp.json`, and
`docs/usage.md` says so outright. Nothing read the file. The success message was the only
artifact the operation produced.

The config was never wrong. It was unread. MCP now arrives through the `pi-mcp-adapter` npm
package, declared in `~/.pi/agent/settings.json`, and the reported outcome is conditioned on
that declaration rather than on a file having been written.

### Rebased onto `main`

This branch previously stacked on #477 (`token-file-perms`), which was closed unmerged, and
its earlier revisions emitted an `Authorization: Bearer` header. Both are gone. The branch is
rebased onto `main` as of PR #479, which replaced the bearer token with Origin and Host
validation: the emitted entry is a bare `url` plus three adapter settings, and nothing in the
diff touches the six platform installers or the token-permissions test file that belonged to
#477. The diff is three files: `CHANGELOG.md`, `installer/platforms/pi.py`,
`tests/installer/test_pi_mcp_adapter.py`.

## What is verified, and what is not

**Honest accounting, because the rebase invalidated the strongest evidence this PR had.** The
original end-to-end run — connect, `tools/list`, and live invocation of `spellbook_health_check`
and `tooling_discover` against the running daemon — was performed with a `Bearer` header that
no longer exists. That run is **no longer evidence for the config this PR now emits.** It
still establishes the two facts that do not depend on the header:

- `pi-mcp-adapter` reads `~/.pi/agent/mcp.json` in the Claude Code shape.
- The three adapter settings below are the ones that make the tools addressable.

**Not verified:** that the current headerless entry authenticates against the daemon's
Origin/Host validation. Nobody has run it end to end since the rebase. The installer makes no
request either way, so it claims nothing about reachability — see *The no-op cannot come back*
below.

## The config, and why each field is load-bearing

```json
{"mcpServers":{"spellbook":{"url":"...",
 "lifecycle":"eager","directTools":true,"toolPrefix":"none"}}}
```

- `directTools: true` — the adapter's default exposes a single `mcp` proxy tool. Spellbook's
  skills reference tools by name.
- `toolPrefix: "none"` — **the one that matters**. The default is `"server"`, which prepends
  the server name to names that already start with `spellbook_`, yielding
  `spellbook_spellbook_health_check`. Every tool name spellbook's skills reference would be
  wrong. `directTools` alone does **not** fix this: the test runs a literal port of the
  adapter's own `formatToolName` over the name spellbook emits, and guards the port itself, so
  dropping `toolPrefix` fails with the doubled name in the message rather than with a bare
  shape mismatch.
- `lifecycle: "eager"` — the default is `"lazy"`; only `eager` was verified to register direct
  tools.
- `protocolVersion` deliberately omitted — the adapter's `legacy` default negotiates, and
  pinning can only narrow what succeeds.

## Declaring the adapter, not shelling out to `pi install`

The entry is written to `settings.json` directly. Evidence from pi's
`dist/core/package-manager.js`: `resolvePackageSources` self-heals **any** npm entry on next
start (`needsInstall = !exists || version mismatch → installMissing()`) with **no scope gate**.
The docs advertise that for project settings only; the code is broader. `pi install` would do
the same append plus an npm run, so the subprocess buys nothing an installer wants and costs a
`pi` binary on PATH, network access, and an install-time failure mode the settings write does
not have. It is also testable without mocking.

The version is pinned in a named constant, so a bump is a deliberate edit; pi skips versioned
npm specs during `pi update --extensions`.

Detection is deliberately **two facts**, because they can disagree: the settings.json
declaration (what the installer controls) and the on-disk package version (what pi does later).

## The no-op cannot come back

The installer makes no request, so it cannot distinguish a daemon that is down from one that
is up. Rather than guess, its vocabulary is constrained to what it did:
`test_install_never_claims_a_verified_connection` mechanically forbids *connected*, *verified*,
*reachable*, *working* and *available* in either message.

`detect()` also changed: `mcp_registered` now requires the adapter declaration, so the state
every prior install left behind stops reporting as registered. `installed` still keys off the
bare entry, so uninstall still finds legacy installs.

When the adapter cannot be declared, both steps **fail** and say why: *"not registered — pi has
no native MCP support and pi-mcp-adapter could not be declared, so nothing reads mcp.json"*.

The install result now also tells the user to restart pi. That is what the **code** does, not
what the README claims: the adapter connects a `directTools` server during `session_start`
when it has no cache entry for it and then reports, in its own `init.ts`, that the tools "will
be available after restart". Pi separately installs a declared-but-missing npm package on its
next start. The README's hot-load claim describes `mcp({ connect: … })` on an already-connected
server, which is not the first-install path.

## Uninstall

The adapter declaration is removed **only when no other server remains** in `mcp.json` after
spellbook's entry is dropped — it is a general-purpose bridge, and unconditional removal would
break every other server the user configured. A user's object-form entry (resource filters) is
never touched, since flattening it would discard those filters silently. The on-disk npm
package is left alone: inert once undeclared, and `pi remove`'s business.

## Review findings addressed

- **settings.json permissions were downgraded.** The write is an atomic replace, and
  `os.replace` swaps in the *temporary* file, so the result carried the temp file's
  default-umask mode. An owner-only settings.json came back 0644, readable by every other local
  account, with nothing reporting it. The existing file's mode is now carried across
  explicitly; a file the installer creates is 0600. Two tests cover it, and both were confirmed
  red with the fix reverted.
- **The read-modify-write took no lock.** Pi guards every settings write with `proper-lockfile`
  and re-reads *inside* the lock (`withLock` in pi's `core/settings-manager.js`), so a
  concurrent write from a running pi was computed from a read taken before the installer's
  replace and silently dropped the new entry — after the installer reported success. The
  installer now takes pi's own lock rather than a parallel one: proper-lockfile's lock is a
  directory at `<file>.lock`, created with mkdir because mkdir is atomic and released with
  rmdir, which is the entire protocol. The written result is also read back, so a lost update
  from a writer that does not take the lock is reported rather than assumed away.
- **A non-list `packages` key was silently destroyed.** `packages = settings.get("packages")`
  followed by `if not isinstance(packages, list): packages = []` discarded whatever was there,
  while the file-level equivalent already raised on a non-object. The key level now matches:
  the step fails and the file is left alone.
- **Only the first adapter entry was handled.** Pi resolves an npm package by name, so a
  leftover older pin was a second answer to the same question and could reinstall an older
  adapter over the pinned one, making the reported version not the version that runs. Every
  matching entry is handled: spellbook's own bare-string entries collapse to one pinned entry,
  and duplicates that include a user-authored entry are reported as ambiguous rather than
  guessed at.
- **The dry run reported a write it would not perform.** It returned "would declare …" before
  reading the file, so it said that for the two cases that write nothing — the entry is already
  present and pinned, or it is the user's own and is left alone. It reads first now.
- **The restart requirement was never communicated.** Added to the install result, sourced from
  the adapter's code rather than its README (above).
- **A count lived in a test message** (`all 28 spellbook tools`). Removed; the repo's own
  `rules/80-code-quality.md` forbids it.
- **A structured field was derived by substring-matching a prose message.** The `mcp_adapter`
  uninstall result computed `action="removed" if "retracted" in adapter_msg else "skipped"`, so
  rewording the message changed the recorded outcome. `_retract_pi_adapter` now returns the
  fact.

## Known limits

- The headerless entry has not been exercised against a live daemon since the rebase (above).
- Daemon-down behaviour is untested. Not made to work; the installer stops claiming anything
  about it.
- `lifecycle: "lazy"` is unverified — `eager` is emitted, but nobody has shown `lazy` is broken.
- A pin does not auto-update; a security fix in the adapter would need a spellbook release, and
  nothing notices when the pin falls behind.
- A user who already declared the adapter **unpinned** gets repinned, since that is a
  bare-string spellbook-shaped entry. Arguably correct, arguably surprising.
- **Pre-existing, not fixed here.** The installer resolves pi's config directory from
  `PI_CONFIG_DIR` (`installer/config.py`), which appears nowhere in pi's `dist/`. Pi reads
  `PI_CODING_AGENT_DIR` (`ENV_AGENT_DIR` in pi's `config.js`). A user who relocates pi's
  directory therefore gets this PR's exact bug back — the installer writes a settings.json and
  an mcp.json pi never reads. Worth its own issue; it predates this branch and affects every
  component the pi installer writes, not just MCP.

## Related issue

None.

## Checklist

- [x] Tests pass locally — `uv run pytest tests/ -q`: 2090 passed, 34 skipped, 54 deselected;
      `uv run pytest tests/installer -q`: 331 passed
- [x] Documentation updated (if applicable) — CHANGELOG entry under `[Unreleased]`
