### PR TITLE
Remove the dead admin-interface surface from the installer

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -8,6 +8,4 @@ code_review:
     code_review: true
 ignore_patterns:
   - "package-lock.json"
-  # Masks the bundle-deletion hunks in transition PRs and any stray build artifacts.
-  - "spellbook/admin/static/**"
   - "**/.build-hash"

--- a/.gitignore
+++ b/.gitignore
@@ -154,9 +154,6 @@ Thumbs.db
 # Node
 node_modules/
 
-# Admin SPA bundle — built at install time (npm run build), not committed.
-spellbook/admin/static/
-
 # ============================================
 # Spellbook-specific ignores
 # ============================================

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -185,7 +185,7 @@ Any changes to shell scripts (`.sh` files in `hooks/`, `scripts/`, or elsewhere)
 ## Adding Config Options
 
 <CRITICAL>
-Any new user-facing config key MUST satisfy all three points below. Missing any point means a silently-unseen feature, a spammy re-prompt, or a config that only the admin UI can ever set.
+Any new user-facing config key MUST satisfy all three points below. Missing any point means a silently-unseen feature, a spammy re-prompt, or a config the user can only set by hand-editing `~/.config/spellbook/spellbook.json`.
 </CRITICAL>
 
 A "user-facing config" is anything that governs behavior the user cares about (feature flags, endpoints, modes, thresholds). Internal state and cached values are not user-facing.
@@ -285,15 +285,15 @@ Spellbook stores persistent key-value data in two places. Pick the right one:
 | `~/.local/spellbook/state.json` | `spellbook.core.state` | Runtime state (what the code wrote for itself) |
 
 **Config** keys are user-facing preferences and feature flags: `auto_update`,
-`session_mode`, `notify_enabled`, `worker_llm_*`. They appear in the admin UI
-(`CONFIG_SCHEMA`) and on install wizards. Reading uses `config_get(key)`,
-writing uses `config_set(key, value)`.
+`session_mode`, `notify_enabled`, `worker_llm_*`. They are surfaced by the
+install wizards. Reading uses `config_get(key)`, writing uses
+`config_set(key, value)`.
 
 **State** keys are facts the code discovered or counters the code maintains:
 `auto_update_branch` (auto-detected from git), `update_check_failures`
-(watcher failure counter). They must never appear in wizards and must never be
-edited via the admin UI. Reading uses `get_state(key)`, writing uses
-`set_state(key, value)`.
+(watcher failure counter). They must never appear in wizards and must never
+be presented to the user as a configurable option. Reading uses
+`get_state(key)`, writing uses `set_state(key, value)`.
 
 When you add a new persistent key, decide up front:
 * Did the user choose this? -> config
@@ -324,8 +324,7 @@ cannot be computed without doing real work at import time MUST NOT go in
 `CONFIG_DEFAULTS`. `spellbook/core/config.py` is imported by the MCP server and
 the hooks, so an import-time computation is paid by every consumer whether or not
 it ever reads that key. Register such families through
-`config_default_for()` instead, backed by a memoized resolver, and keep the
-`CONFIG_SCHEMA` entry as normal so admin-UI visibility is unchanged.
+`config_default_for()` instead, backed by a memoized resolver.
 
 The one family using this today is `rules.module.*`
 (`rule_module_config_defaults()`): resolving it means globbing and parsing every

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Dead installer surface for the web admin interface, whose implementation was
+  deleted in `7a8e9ab1`. `render_admin_info` on `InstallerRenderer`,
+  `RichRenderer`, and `PlainTextRenderer`, and the `render_admin_info` panel in
+  `installer/tui.py`, had no call site anywhere in the tree: the plain-text
+  renderer's `Admin interface: {url}` line and the Rich panel advertising
+  `http://localhost:8765/admin`, `spellbook admin open`, and a `--no-admin`
+  flag were unreachable, and none of those three targets still exist. Also
+  removed the `spellbook/admin/static/` rule from `.gitignore`, which ignored a
+  path that no longer exists. Prose in `AGENTS.md`,
+  `installer/wizards/defaults.py`, `installer/components/rule_modules.py`, and
+  `spellbook/core/config.py` that described config keys as reachable through
+  the admin UI, or that cited the deleted `CONFIG_SCHEMA` symbol, now states
+  the surviving convention -- every user-facing key is reached through the
+  install wizards -- without naming the removed interface.
+
 ### Changed
 
 - `spellbook.core.path_utils.resolve_repo_root` reads the repository root off

--- a/installer/components/rule_modules.py
+++ b/installer/components/rule_modules.py
@@ -393,9 +393,9 @@ def resolve_selection(
 
 
 def config_schema_entries(modules: Sequence[RuleModule]) -> List[Dict[str, Any]]:
-    """Generate one boolean admin-schema entry per preference module.
+    """Generate one boolean config-schema entry per preference module.
 
-    ``CONFIG_SCHEMA`` supports only boolean, number, and string, so a per-module
+    The entry format supports only boolean, number, and string, so a per-module
     map is not expressible; one boolean key per preference module is.
     """
     return [

--- a/installer/renderer.py
+++ b/installer/renderer.py
@@ -5,13 +5,6 @@ implement. Two concrete implementations are provided elsewhere:
 
 - ``installer/rich_renderer.py`` -- Rich-based TUI renderer
 - ``installer/plain_renderer.py`` -- Plain-text renderer for non-TTY / CI use
-
-Superseded design decisions reflected here:
-
-SD-1: ``render_admin_info`` accepts ``admin_url: str`` and ``show_token: bool``
-    rather than the original ``(admin_url, token)`` from the design doc. The
-    raw token is never passed to the renderer; the caller controls whether
-    token visibility is requested.
 """
 
 from __future__ import annotations
@@ -272,25 +265,6 @@ class InstallerRenderer(ABC):
         Args:
             results: ``InstallSession`` instance from ``Installer.run()``.
             elapsed: Total elapsed time in seconds.
-        """
-        ...
-
-    @abstractmethod
-    def render_admin_info(
-        self, admin_url: str, show_token: bool = False
-    ) -> None:
-        """Display admin web interface information.
-
-        Shows the admin URL and optionally indicates that a token is
-        available. The raw token string is never passed to this method;
-        the caller controls ``show_token`` (SD-1).
-
-        Args:
-            admin_url: URL of the admin interface (e.g.
-                ``"http://localhost:8765/admin"``). Pass an empty string
-                when admin is disabled.
-            show_token: If ``True``, indicate that an auth token exists and
-                where to find it (e.g. ``~/.local/spellbook/.mcp-token``).
         """
         ...
 
@@ -732,19 +706,6 @@ class RichRenderer(InstallerRenderer):
             elapsed_seconds=elapsed,
         )
 
-    def render_admin_info(self, admin_url: str, show_token: bool = False) -> None:
-        from .tui import render_admin_info as _tui_admin
-        console = self._get_console()
-        admin_enabled = bool(admin_url)
-        _tui_admin(console, admin_enabled=admin_enabled)
-        if show_token and admin_enabled:
-            from rich.panel import Panel
-            console.print(Panel(
-                "Auth token: [dim]~/.local/spellbook/.mcp-token[/dim]",
-                border_style="dim",
-                padding=(0, 2),
-            ))
-
     def render_post_install(self, notes: list[str]) -> None:
         if not notes:
             return
@@ -1066,14 +1027,6 @@ class PlainTextRenderer(InstallerRenderer):
             print(f"  [OK]     {p}")
         for p in failed:
             print(f"  [FAILED] {p}")
-
-    def render_admin_info(self, admin_url: str, show_token: bool = False) -> None:
-        if admin_url:
-            print(f"\nAdmin interface: {admin_url}")
-        else:
-            print("\nAdmin interface: disabled")
-        if show_token and admin_url:
-            print("Auth token: ~/.local/spellbook/.mcp-token")
 
     def render_post_install(self, notes: list[str]) -> None:
         if not notes:

--- a/installer/tui.py
+++ b/installer/tui.py
@@ -359,27 +359,6 @@ def render_completion_summary(
     console.print(panel)
 
 
-def render_admin_info(console: "Any", admin_enabled: bool) -> None:
-    """Render admin web interface info as a Rich panel."""
-    from rich.panel import Panel
-
-    if admin_enabled:
-        body = (
-            "Status:  [green]enabled[/green]\n"
-            "URL:     http://localhost:8765/admin\n"
-            "Open:    [cyan]spellbook admin open[/cyan]\n"
-            "Disable: set admin_enabled=false or reinstall with --no-admin"
-        )
-        panel = Panel(body, title="Admin Web Interface", border_style="blue", padding=(0, 2))
-    else:
-        body = (
-            "Status:  [yellow]disabled[/yellow]\n"
-            "Enable:  set admin_enabled=true or reinstall without --no-admin"
-        )
-        panel = Panel(body, title="Admin Web Interface", border_style="dim", padding=(0, 2))
-    console.print(panel)
-
-
 def render_post_install_notes(
     console: "Any",
     platforms: List[str],

--- a/installer/wizards/defaults.py
+++ b/installer/wizards/defaults.py
@@ -1,9 +1,9 @@
 """Shared defaults wizard for previously never-prompted config keys.
 
-Several keys have entries in ``CONFIG_SCHEMA`` but no installer prompt:
+Several keys have a runtime default but no installer prompt:
 ``security_gates_enabled``, ``notify_enabled``, ``notify_title``,
-``auto_update``. Without a prompt users discover them only via the admin
-UI or by reading source.
+``auto_update``. Without a prompt users discover them only by reading
+source.
 
 This wizard closes the gap by walking the user through each key on
 fresh installs. It respects the idempotency rule defined in AGENTS.md:

--- a/spellbook/core/config.py
+++ b/spellbook/core/config.py
@@ -33,8 +33,7 @@ CONFIG_DEFAULTS: dict[str, Any] = {
     "hook_observability_purge_interval_seconds": 300,
     # PreToolUse security gates (bash/spawn/state-sanitize + tool-safety sniff).
     # Disabled by default (opt-in); the installer defaults wizard asks about it.
-    # Read live by hooks/spellbook_hook.py::_gates_disabled. Matches CONFIG_SCHEMA
-    # in the config schema.
+    # Read live by hooks/spellbook_hook.py::_gates_disabled.
     "security_gates_enabled": False,
 }
 


### PR DESCRIPTION
## What does this PR do?

Removes the dead admin-interface surface the installer still carried after the web admin implementation was deleted.

**What was wrong.** `render_admin_info` existed on `InstallerRenderer` (abstract), `RichRenderer`, and `PlainTextRenderer`, backed by a Rich panel in `installer/tui.py`. None of the four had a call site anywhere in the tree, so nothing ever printed — the surface was unreachable rather than merely misleading. Everything it advertised is also gone: the plain renderer's `Admin interface: {url}` line, the panel's `http://localhost:8765/admin` URL, the `spellbook admin open` command, and the `--no-admin` flag all name targets that no longer exist.

**What changed.**

- Deletes the four `render_admin_info` definitions and the Rich panel behind them.
- `CONFIG_SCHEMA` went with the admin app — it was defined in `spellbook/admin/routes/config.py` — so prose citing it named a symbol with no definition. `AGENTS.md` described config keys as appearing in and being edited through the admin UI. That prose encoded a convention that outlived the UI: user-facing keys are reachable through the install wizards, and state keys are never presented as configurable. Those statements now say that directly. The one instruction that was genuinely UI-only — keep a `CONFIG_SCHEMA` entry so admin-UI visibility is unchanged — is dropped, since it cannot be followed.
- Drops the `.gitignore` rule for `spellbook/admin/static/`, a build output path deleted with the admin app, and the matching stale ignore in the Gemini review config. That pattern existed to keep bundle-deletion hunks out of review diffs during the removal; the transition it describes is finished and it now matches nothing.

`config_schema_entries` in `installer/components/rule_modules.py` is deliberately left in place here — it is now reached only from its own test, and removing a tested helper is a separate decision. That removal is the follow-up branch stacked on this one.

## Related issue

None.

## Checklist

- [ ] Tests pass locally
- [ ] Documentation updated (if applicable)
