### PR TITLE
Remove dead config_schema_entries from the rule module loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- `config_schema_entries()` in `installer/components/rule_modules.py`, which
+  built one boolean config-schema entry per preference module for the deleted
+  web admin UI's config schema. No production call site remained: the only
+  references in the tree were its own definition and the single test that
+  exercised it, which is removed with it. The preference modules themselves,
+  their `config_key` property, and `CONFIG_KEY_PREFIX` are unaffected -- they
+  are still read by `resolve_selection()` off recorded config values.
+
 - Dead installer surface for the web admin interface, whose implementation was
   deleted in `7a8e9ab1`. `render_admin_info` on `InstallerRenderer`,
   `RichRenderer`, and `PlainTextRenderer`, and the `render_admin_info` panel in

--- a/installer/components/rule_modules.py
+++ b/installer/components/rule_modules.py
@@ -391,19 +391,3 @@ def resolve_selection(
         unanswered_ids=unanswered,
     )
 
-
-def config_schema_entries(modules: Sequence[RuleModule]) -> List[Dict[str, Any]]:
-    """Generate one boolean config-schema entry per preference module.
-
-    The entry format supports only boolean, number, and string, so a per-module
-    map is not expressible; one boolean key per preference module is.
-    """
-    return [
-        {
-            "key": module.config_key,
-            "type": "boolean",
-            "description": module.benefit,
-            "default": module.default_on,
-        }
-        for module in preference_modules(modules)
-    ]

--- a/tests/installer/test_rule_modules.py
+++ b/tests/installer/test_rule_modules.py
@@ -34,7 +34,6 @@ from installer.components.rule_migration import (
 )
 from installer.components.rule_modules import (
     RuleModuleError,
-    config_schema_entries,
     get_rules_dir,
     load_rule_modules,
     parse_rule_module,
@@ -256,19 +255,6 @@ class TestSelection:
         assert "session-modes" not in selection.selected_ids
         assert "session-modes" in selection.declined_ids
         assert "session-modes" not in selection.unanswered_ids
-
-    def test_schema_entries_cover_exactly_the_preference_modules(self, rules_dir: Path):
-        modules = load_rule_modules(rules_dir)
-        entries = config_schema_entries(modules)
-
-        assert {e["key"] for e in entries} == {
-            "rules.module.session",
-            "rules.module.autonomy",
-            "rules.module.review-posture",
-        }
-        assert all(e["type"] == "boolean" for e in entries)
-        posture = next(e for e in entries if e["key"].endswith("review-posture"))
-        assert posture["default"] is False
 
 
 class TestBundle:


### PR DESCRIPTION
## What does this PR do?

Deletes `config_schema_entries` from the rule module loader, dead since the admin UI was removed.

**Stacked branch.** This targets `remove-dead-admin-installer-surface`, not `main`. That branch removes the installer's admin surface and deliberately leaves this helper alone as a separate decision; this is that decision.

**What was wrong.** `config_schema_entries()` built one boolean config-schema entry per preference module for the web admin UI's config schema. That UI is gone, and the function had no production call site — the only references in the tree were its own definition and the single test that called it.

**Verification.** Checked with `rg` over the full worktree including untracked and ignored files (`--hidden --no-ignore`), not `git grep`, which skips untracked files and returns an empty result indistinguishable from a genuine absence. Three hits, all accounted for.

Nothing else is orphaned. `preference_modules()`, `RuleModule.config_key`, `RuleModule.benefit`, `RuleModule.default_on`, and `CONFIG_KEY_PREFIX` each retain callers on the live `resolve_selection()` path, and every name in the typing import remains in use.

## Related issue

None.

## Checklist

- [ ] Tests pass locally
- [ ] Documentation updated (if applicable)
