### PR TITLE
Give gate 4.6.5 a dispatch-table row and its own ledger line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Gate 4.6.5 (Pre-PR Claim Validation and Embarrassment Sweep) is now
+  dispatchable. It is a `Task:` dispatch in `commands/feature-implement-execute.md`
+  but owned no row of the develop dispatch table, so the Phase Declaration
+  requirement that a dispatch cover "EXACTLY ONE row of the dispatch table" was
+  unsatisfiable and every dispatch of it was malformed -- taking the 8-point
+  embarrassment sweep with it. The ceremony menu compounded this with a single
+  line, `Comprehensive fact-checking (4.6.4/4.6.5)`, naming two gates: running
+  them separately produced two dispatches citing one ledger line, and combining
+  them tripped the ban on phrasings that merge two dispatch-table rows. A
+  `4.6.5` row now exists, and the menu line is split into
+  `Comprehensive fact-checking (4.6.4)` and `Pre-PR claim validation (4.6.5)`,
+  so "Verbatim or invalid" resolves for both. Dispatch-table rows are also back in ordinal
+  order (`2.4` preceded `2.5`), which is where a missing row hides.
+- Gate 4.6.5 no longer hardcodes `main` as its diff base. `rules/55-diff-semantics.md`
+  forbids the literal by name; on a repository whose default branch is `master`
+  the gate scoped itself to a nonexistent ref. It now detects the target and
+  uses `git diff $(git merge-base HEAD <target>)...HEAD`, matching the skill it
+  delegates to.
+- Invariant Principle 5 of `commands/feature-implement-execute.md` named the
+  per-task gate set as "4.4 through 4.6.3". The range end rotted when 4.5.1 was
+  inserted, and 4.6 is headed "Quality Gates After All Tasks" -- read literally
+  it demanded a full test-suite run and a green-mirage audit per task. It now
+  names 4.4, 4.5, and 4.5.1, matching the file's own two other statements of
+  that set.
+
 - `scripts/develop_gate_ledger.py` now applies its documented exit-code split
   on every subcommand. `1` means the STORED ledger is not what the operation
   needs, `2` means the CALLER asked for something the ledger does not accept.

--- a/commands/feature-config.md
+++ b/commands/feature-config.md
@@ -573,7 +573,7 @@ failure. Every other dimension's implied gates are freely selectable.
 | D1 unfamiliarity | Research (Phase 1) + Discovery (1.5) + dehallucination (1.5.7) |
 | D2 fuzziness | Discovery (1.5) + devil's advocate (1.6) |
 | D3 blast radius | Design review (2.2) + impl-plan review (3.2) + comprehensive audit (4.6.1) |
-| D4 coupling | Impl-plan review (3.2) + comprehensive fact-checking (4.6.4/4.6.5) |
+| D4 coupling | Impl-plan review (3.2) + fact-checking (4.6.4, 4.6.5) |
 | D5 verification difficulty | Checkability passes (2.1.5 / 3.1.5) + green-mirage (4.6.3) — **LOCKED** |
 | D6 silent-failure potential | Completion verification (4.4) + comprehensive audit (4.6.1) + green-mirage (4.6.3) + TDD-first (4.3), waiver revoked — **LOCKED** |
 | D7 precedent absent | Research (Phase 1) + Design (Phase 2) |
@@ -740,9 +740,8 @@ Store the answer as `develop_gate_ledger.ceremony.gate_position ∈ {"per_task",
 #### Step 2: Build the menu from the assessment (do NOT show a fixed 12-item list)
 
 Offer ONLY components the assessment made relevant. A change with every dimension
-`low` gets a two-item menu or none at all; do not tax a small request with a long
-questionnaire. Candidate components, each shown only when its dimension row fired or
-its need-flag is set:
+`low` gets a two-item menu or none; never tax a small request with a long
+questionnaire. Show a component only when its dimension row fired or its flag set:
 
 | Component | Offered when |
 |---|---|
@@ -756,12 +755,13 @@ its need-flag is set:
 | Per-task fact-checking (4.5.1) | `needs_research` or `needs_design` |
 | Completion verification (4.4) | D6 high — **LOCKED, shown as already-on** |
 | Comprehensive audit (4.6.1) | D3/D6 high |
-| Comprehensive fact-checking (4.6.4/4.6.5) | `needs_research` or `needs_design`, or D4 high |
-| Roundtable dialectic | never auto-recommended; offered only if the operator asked for it in §0.4 |
+| Comprehensive fact-checking (4.6.4) | `needs_research` or `needs_design`, or D4 high |
+| Pre-PR claim validation (4.6.5) | `needs_research` or `needs_design`, or D4 high |
+| Roundtable dialectic | never auto-recommended; only if the operator asked in §0.4 |
 
-LOCKED rows are DISPLAYED (so the operator can see what they are getting and why) but
-carry no deselect option. State the reason inline: "locked because silent-failure
-potential is high — this is the gate that catches a success report over a no-op."
+LOCKED rows are DISPLAYED (so the operator sees what they get) but carry no
+deselect option. State the reason inline: "locked because silent-failure potential is
+high — the gate that catches a success report over a no-op."
 
 #### Step 3: Ask (via AskUserQuestion)
 

--- a/commands/feature-implement-execute.md
+++ b/commands/feature-implement-execute.md
@@ -29,7 +29,7 @@ is never zero.
 2. **Delegate actual work** - Main context orchestrates; subagents write code, run tests, perform reviews
 3. **Quality gates are mandatory** - Code review, fact-checking, and green mirage audit after every task; no exceptions
 4. **Behavior preservation in refactoring** - Test verification at every transformation; no behavior changes without approval
-5. **No batch exemption** - A batched or multi-task dispatch exempts NOTHING: every task the batch covers passes gates 4.4 (Implementation Completion Verification) through 4.6.3 (Green Mirage Audit) individually before it may be marked complete. Batch size never substitutes for per-task gating.
+5. **No batch exemption** - A batched or multi-task dispatch exempts NOTHING: every task the batch covers passes the per-task gates 4.4, 4.5, and 4.5.1 individually before it may be marked complete. Batch size never substitutes for per-task gating.
 
 <analysis>
 Before executing Phase 4:
@@ -41,7 +41,7 @@ Before executing Phase 4:
 <reflection>
 After executing Phase 4:
 - Was every per-task gate (4.4, 4.5, 4.5.1) dispatched to a subagent, for EVERY task?
-- Did all end-of-phase gates (4.6.1 - 4.6.5) run and reach clean?
+- Did all five end-of-phase gates (4.6.1-4.6.5; 4.6.2 is a direct test-suite run, the rest Task dispatches) run and reach clean?
 - Did I use Write, Edit, or Bash directly in main context at any point? If yes, the workflow failed.
 </reflection>
 
@@ -821,7 +821,7 @@ If issues found: Fix, re-run until clean.
 
 #### 4.6.5 Pre-PR Claim Validation and Embarrassment Sweep
 
-<RULE>Before any PR creation, run the final fact-checking pass AND the embarrassment sweep. The fact-check validates that claims are TRUE; the sweep validates that the diff is CLEAN. Both gate the PR.</RULE>
+<RULE>Before any PR, run the final fact-check AND the embarrassment sweep. The fact-check validates claims are TRUE; the sweep validates the diff is CLEAN. Both gate the PR.</RULE>
 
 ```
 Task:
@@ -832,18 +832,18 @@ Task:
 
     ## Context for the Skill
 
-    Scope: Branch changes (all commits since merge-base with main)
+    Scope: `git diff $(git merge-base HEAD <target>)...HEAD`, `<target>`
+    DETECTED per `rules/55-diff-semantics.md` -- never assumed `main`.
 
-    This is the absolute last line of defense.
-    Nothing ships with false claims.
+    Last line of defense. Nothing ships with false claims.
 
     ## Embarrassment sweep (diff hygiene)
 
     After fact-checking, run the embarrassment sweep over the same branch
-    diff. This is the named pre-PR diff-hygiene pass — the things that are
-    embarrassing to ship, separate from whether claims are true. The full
-    8-point checklist lives in the finishing-a-development-branch skill;
-    apply it here. Each point is scoped to what the branch introduced:
+    diff — the things that are embarrassing to ship, separate from whether
+    claims are true. The full 8-point checklist lives in the
+    finishing-a-development-branch skill; apply it here. Each point is
+    scoped to what the branch introduced:
 
     1. Debug leftovers (print/console.log/debugger/breakpoints added by the branch)
     2. Branch-introduced TODO/FIXME/XXX/HACK markers promising nonexistent work

--- a/docs/commands/feature-config.md
+++ b/docs/commands/feature-config.md
@@ -573,7 +573,7 @@ failure. Every other dimension's implied gates are freely selectable.
 | D1 unfamiliarity | Research (Phase 1) + Discovery (1.5) + dehallucination (1.5.7) |
 | D2 fuzziness | Discovery (1.5) + devil's advocate (1.6) |
 | D3 blast radius | Design review (2.2) + impl-plan review (3.2) + comprehensive audit (4.6.1) |
-| D4 coupling | Impl-plan review (3.2) + comprehensive fact-checking (4.6.4/4.6.5) |
+| D4 coupling | Impl-plan review (3.2) + fact-checking (4.6.4, 4.6.5) |
 | D5 verification difficulty | Checkability passes (2.1.5 / 3.1.5) + green-mirage (4.6.3) — **LOCKED** |
 | D6 silent-failure potential | Completion verification (4.4) + comprehensive audit (4.6.1) + green-mirage (4.6.3) + TDD-first (4.3), waiver revoked — **LOCKED** |
 | D7 precedent absent | Research (Phase 1) + Design (Phase 2) |
@@ -740,9 +740,8 @@ Store the answer as `develop_gate_ledger.ceremony.gate_position ∈ {"per_task",
 #### Step 2: Build the menu from the assessment (do NOT show a fixed 12-item list)
 
 Offer ONLY components the assessment made relevant. A change with every dimension
-`low` gets a two-item menu or none at all; do not tax a small request with a long
-questionnaire. Candidate components, each shown only when its dimension row fired or
-its need-flag is set:
+`low` gets a two-item menu or none; never tax a small request with a long
+questionnaire. Show a component only when its dimension row fired or its flag set:
 
 | Component | Offered when |
 |---|---|
@@ -756,12 +755,13 @@ its need-flag is set:
 | Per-task fact-checking (4.5.1) | `needs_research` or `needs_design` |
 | Completion verification (4.4) | D6 high — **LOCKED, shown as already-on** |
 | Comprehensive audit (4.6.1) | D3/D6 high |
-| Comprehensive fact-checking (4.6.4/4.6.5) | `needs_research` or `needs_design`, or D4 high |
-| Roundtable dialectic | never auto-recommended; offered only if the operator asked for it in §0.4 |
+| Comprehensive fact-checking (4.6.4) | `needs_research` or `needs_design`, or D4 high |
+| Pre-PR claim validation (4.6.5) | `needs_research` or `needs_design`, or D4 high |
+| Roundtable dialectic | never auto-recommended; only if the operator asked in §0.4 |
 
-LOCKED rows are DISPLAYED (so the operator can see what they are getting and why) but
-carry no deselect option. State the reason inline: "locked because silent-failure
-potential is high — this is the gate that catches a success report over a no-op."
+LOCKED rows are DISPLAYED (so the operator sees what they get) but carry no
+deselect option. State the reason inline: "locked because silent-failure potential is
+high — the gate that catches a success report over a no-op."
 
 #### Step 3: Ask (via AskUserQuestion)
 

--- a/docs/commands/feature-implement-execute.md
+++ b/docs/commands/feature-implement-execute.md
@@ -29,7 +29,7 @@ is never zero.
 2. **Delegate actual work** - Main context orchestrates; subagents write code, run tests, perform reviews
 3. **Quality gates are mandatory** - Code review, fact-checking, and green mirage audit after every task; no exceptions
 4. **Behavior preservation in refactoring** - Test verification at every transformation; no behavior changes without approval
-5. **No batch exemption** - A batched or multi-task dispatch exempts NOTHING: every task the batch covers passes gates 4.4 (Implementation Completion Verification) through 4.6.3 (Green Mirage Audit) individually before it may be marked complete. Batch size never substitutes for per-task gating.
+5. **No batch exemption** - A batched or multi-task dispatch exempts NOTHING: every task the batch covers passes the per-task gates 4.4, 4.5, and 4.5.1 individually before it may be marked complete. Batch size never substitutes for per-task gating.
 
 <analysis>
 Before executing Phase 4:
@@ -41,7 +41,7 @@ Before executing Phase 4:
 <reflection>
 After executing Phase 4:
 - Was every per-task gate (4.4, 4.5, 4.5.1) dispatched to a subagent, for EVERY task?
-- Did all end-of-phase gates (4.6.1 - 4.6.5) run and reach clean?
+- Did all five end-of-phase gates (4.6.1-4.6.5; 4.6.2 is a direct test-suite run, the rest Task dispatches) run and reach clean?
 - Did I use Write, Edit, or Bash directly in main context at any point? If yes, the workflow failed.
 </reflection>
 
@@ -821,7 +821,7 @@ If issues found: Fix, re-run until clean.
 
 #### 4.6.5 Pre-PR Claim Validation and Embarrassment Sweep
 
-<RULE>Before any PR creation, run the final fact-checking pass AND the embarrassment sweep. The fact-check validates that claims are TRUE; the sweep validates that the diff is CLEAN. Both gate the PR.</RULE>
+<RULE>Before any PR, run the final fact-check AND the embarrassment sweep. The fact-check validates claims are TRUE; the sweep validates the diff is CLEAN. Both gate the PR.</RULE>
 
 ```
 Task:
@@ -832,18 +832,18 @@ Task:
 
     ## Context for the Skill
 
-    Scope: Branch changes (all commits since merge-base with main)
+    Scope: `git diff $(git merge-base HEAD <target>)...HEAD`, `<target>`
+    DETECTED per `rules/55-diff-semantics.md` -- never assumed `main`.
 
-    This is the absolute last line of defense.
-    Nothing ships with false claims.
+    Last line of defense. Nothing ships with false claims.
 
     ## Embarrassment sweep (diff hygiene)
 
     After fact-checking, run the embarrassment sweep over the same branch
-    diff. This is the named pre-PR diff-hygiene pass — the things that are
-    embarrassing to ship, separate from whether claims are true. The full
-    8-point checklist lives in the finishing-a-development-branch skill;
-    apply it here. Each point is scoped to what the branch introduced:
+    diff — the things that are embarrassing to ship, separate from whether
+    claims are true. The full 8-point checklist lives in the
+    finishing-a-development-branch skill; apply it here. Each point is
+    scoped to what the branch introduced:
 
     1. Debug leftovers (print/console.log/debugger/breakpoints added by the branch)
     2. Branch-introduced TODO/FIXME/XXX/HACK markers promising nonexistent work

--- a/docs/skills/develop.md
+++ b/docs/skills/develop.md
@@ -673,11 +673,10 @@ even if the work product is correct.
 ## CRITICAL: Subagent Dispatch Points
 
 <CRITICAL>
-The following steps MUST use subagents. Direct execution in main context is FORBIDDEN.
-If you find yourself using Write, Edit, or Bash tools directly during these steps: STOP.
-Dispatch a subagent instead.
+These steps MUST use subagents; direct execution in main context is FORBIDDEN.
+If you use Write, Edit, or Bash directly during these steps: STOP. Dispatch a subagent.
 
-If a subagent fails or returns empty results: re-dispatch with additional context. After 3 consecutive failures on the same step, STOP and ask the user before continuing.
+If a subagent fails or returns empty: re-dispatch with more context. After 3 consecutive failures on the same step, STOP and ask the user.
 </CRITICAL>
 
 | Phase | Step                     | Skill to Invoke                  | Direct Execution |
@@ -688,8 +687,8 @@ If a subagent fails or returns empty results: re-dispatch with additional contex
 | 2.1   | Design creation          | design-exploration (SYNTHESIS MODE) | FORBIDDEN     |
 | 2.1.5 | Checkability pass (design) | (inline mechanization prompt, no skill) | FORBIDDEN |
 | 2.2   | Design review            | reviewing-design-docs            | FORBIDDEN        |
-| 2.5   | Assumption verification  | fact-checking                    | FORBIDDEN        |
 | 2.4   | Fix design               | executing-plans                  | FORBIDDEN        |
+| 2.5   | Assumption verification  | fact-checking                    | FORBIDDEN        |
 | 3.1   | Plan creation            | writing-plans                    | FORBIDDEN        |
 | 3.1.5 | Checkability pass (plan) | (inline mechanization prompt, no skill) | FORBIDDEN  |
 | 3.2   | Plan review              | reviewing-impl-plans             | FORBIDDEN        |
@@ -701,14 +700,14 @@ If a subagent fails or returns empty results: re-dispatch with additional contex
 | 4.6.1 | Comprehensive audit      | (inline audit prompt, no skill)  | FORBIDDEN        |
 | 4.6.3 | Green mirage             | auditing-green-mirage            | FORBIDDEN        |
 | 4.6.4 | Comprehensive fact-check | fact-checking                    | FORBIDDEN        |
+| 4.6.5 | Pre-PR claim validation  | fact-checking                    | FORBIDDEN        |
 | 4.7   | Finishing                | finishing-a-development-branch   | FORBIDDEN        |
 
 ### Conditional Companion Skills
 
-These do not own a row of the table: each rides along inside the dispatch for the
-phase named, and only when its trigger is present. A dispatch that meets a
-trigger MUST name the companion skill in its prompt alongside the phase's own
-skill; the Phase Declaration is unchanged, because the row is unchanged.
+These own no row: each rides along inside the dispatch for the phase named, when
+its trigger is present. A dispatch meeting a trigger MUST name the companion
+skill alongside the phase's own skill. The Phase Declaration is unchanged.
 
 | Trigger | Phase | Skill to name in the dispatch |
 | ------- | ----- | ----------------------------- |
@@ -1349,7 +1348,7 @@ Phase 4: Implementation (direct or delegated)
   ├─ 4.6.2: Run test suite (invoke systematic-debugging if failures)
   ├─ 4.6.3: Subagent invokes audit-green-mirage
   ├─ 4.6.4: Comprehensive fact-checking (if needs_research OR needs_design)
-  ├─ 4.6.5: Pre-PR fact-checking
+  ├─ 4.6.5: Pre-PR claim validation
   └─ 4.7: Subagent invokes finishing-a-development-branch
 
 Direct/Lightweight Path (zero flags — develop STAYS RESIDENT, never exits):
@@ -1881,7 +1880,7 @@ Session: <session id or git branch>
 ## Pending
 - Tasks 11–24 (see plan.md §<task list>)
 - Per-task gate 4.5 (code review) for all tasks
-- End-of-Phase-4 gates 4.6.1–4.6.5
+- End-of-Phase-4 gates 4.6.1–4.6.5 (4.6.2 is a direct run, not a dispatch)
 
 ## Blockers
 - Redis not available locally; integration tests skipped

--- a/skills/develop/SKILL.md
+++ b/skills/develop/SKILL.md
@@ -671,11 +671,10 @@ even if the work product is correct.
 ## CRITICAL: Subagent Dispatch Points
 
 <CRITICAL>
-The following steps MUST use subagents. Direct execution in main context is FORBIDDEN.
-If you find yourself using Write, Edit, or Bash tools directly during these steps: STOP.
-Dispatch a subagent instead.
+These steps MUST use subagents; direct execution in main context is FORBIDDEN.
+If you use Write, Edit, or Bash directly during these steps: STOP. Dispatch a subagent.
 
-If a subagent fails or returns empty results: re-dispatch with additional context. After 3 consecutive failures on the same step, STOP and ask the user before continuing.
+If a subagent fails or returns empty: re-dispatch with more context. After 3 consecutive failures on the same step, STOP and ask the user.
 </CRITICAL>
 
 | Phase | Step                     | Skill to Invoke                  | Direct Execution |
@@ -686,8 +685,8 @@ If a subagent fails or returns empty results: re-dispatch with additional contex
 | 2.1   | Design creation          | design-exploration (SYNTHESIS MODE) | FORBIDDEN     |
 | 2.1.5 | Checkability pass (design) | (inline mechanization prompt, no skill) | FORBIDDEN |
 | 2.2   | Design review            | reviewing-design-docs            | FORBIDDEN        |
-| 2.5   | Assumption verification  | fact-checking                    | FORBIDDEN        |
 | 2.4   | Fix design               | executing-plans                  | FORBIDDEN        |
+| 2.5   | Assumption verification  | fact-checking                    | FORBIDDEN        |
 | 3.1   | Plan creation            | writing-plans                    | FORBIDDEN        |
 | 3.1.5 | Checkability pass (plan) | (inline mechanization prompt, no skill) | FORBIDDEN  |
 | 3.2   | Plan review              | reviewing-impl-plans             | FORBIDDEN        |
@@ -699,14 +698,14 @@ If a subagent fails or returns empty results: re-dispatch with additional contex
 | 4.6.1 | Comprehensive audit      | (inline audit prompt, no skill)  | FORBIDDEN        |
 | 4.6.3 | Green mirage             | auditing-green-mirage            | FORBIDDEN        |
 | 4.6.4 | Comprehensive fact-check | fact-checking                    | FORBIDDEN        |
+| 4.6.5 | Pre-PR claim validation  | fact-checking                    | FORBIDDEN        |
 | 4.7   | Finishing                | finishing-a-development-branch   | FORBIDDEN        |
 
 ### Conditional Companion Skills
 
-These do not own a row of the table: each rides along inside the dispatch for the
-phase named, and only when its trigger is present. A dispatch that meets a
-trigger MUST name the companion skill in its prompt alongside the phase's own
-skill; the Phase Declaration is unchanged, because the row is unchanged.
+These own no row: each rides along inside the dispatch for the phase named, when
+its trigger is present. A dispatch meeting a trigger MUST name the companion
+skill alongside the phase's own skill. The Phase Declaration is unchanged.
 
 | Trigger | Phase | Skill to name in the dispatch |
 | ------- | ----- | ----------------------------- |
@@ -1347,7 +1346,7 @@ Phase 4: Implementation (direct or delegated)
   ├─ 4.6.2: Run test suite (invoke systematic-debugging if failures)
   ├─ 4.6.3: Subagent invokes audit-green-mirage
   ├─ 4.6.4: Comprehensive fact-checking (if needs_research OR needs_design)
-  ├─ 4.6.5: Pre-PR fact-checking
+  ├─ 4.6.5: Pre-PR claim validation
   └─ 4.7: Subagent invokes finishing-a-development-branch
 
 Direct/Lightweight Path (zero flags — develop STAYS RESIDENT, never exits):
@@ -1879,7 +1878,7 @@ Session: <session id or git branch>
 ## Pending
 - Tasks 11–24 (see plan.md §<task list>)
 - Per-task gate 4.5 (code review) for all tasks
-- End-of-Phase-4 gates 4.6.1–4.6.5
+- End-of-Phase-4 gates 4.6.1–4.6.5 (4.6.2 is a direct run, not a dispatch)
 
 ## Blockers
 - Redis not available locally; integration tests skipped


### PR DESCRIPTION
## What does this PR do?

Gives gate 4.6.5 a dispatch-table row, so dispatching it stops being mechanically invalid under the develop skill's own rules.

**What was wrong.** Gate 4.6.5 (Pre-PR Claim Validation and Embarrassment Sweep) is a `Task:` dispatch in `commands/feature-implement-execute.md` but owned no row of the develop dispatch table. The Phase Declaration requires a dispatch to cover "EXACTLY ONE ledger line and EXACTLY ONE row of the dispatch table", so the row half was unsatisfiable and every dispatch of 4.6.5 was malformed — taking the 8-point embarrassment sweep down with it.

The ceremony menu compounded it. One line, "Comprehensive fact-checking (4.6.4/4.6.5)", named two gates. Dispatching them separately produced two declarations citing the same ledger line; combining them tripped the ban on phrasings that merge two dispatch-table rows. Both paths malformed.

**What changed.**

- Adds the 4.6.5 row, splits the menu line in two, and restores ordinal order to the table — 2.4 followed 2.5, which is exactly where a missing row hides.
- 4.6.5 scoped itself to "merge-base with main". `rules/55-diff-semantics.md` forbids that literal by name; on a master-default repository the gate ran against a nonexistent ref. It now detects the merge target.
- Invariant Principle 5 named the per-task gate set as "4.4 through 4.6.3". The range end rotted when 4.5.1 was inserted, and 4.6 is headed "After All Tasks" — read literally it demanded a full suite run per task. Now stated as 4.4, 4.5, 4.5.1, matching the file's two other statements of that set.
- "End-of-Phase-4 gates 4.6.1-4.6.5" hid that 4.6.2 is a direct test-suite run rather than a Task dispatch. Stated explicitly.

The three files sit under recorded size ceilings that only ratchet down, so the additions are paid for by tightening prose in the same sections.

## Related issue

None.

## Checklist

- [ ] Tests pass locally
- [ ] Documentation updated (if applicable)
