### PR TITLE
Make version sync report an unusable manifest instead of swallowing it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `1` where it exited `2`. Verified end to end against a corrupt ledger on each
   of the five, with the true exit status captured directly rather than through
   a pipe.
+- `installer.version.sync_version_to_files` raises `VersionSyncError` when a
+  manifest exists but cannot be parsed or read, instead of swallowing
+  `json.JSONDecodeError` and `OSError` and returning an empty list. The empty
+  list is also what a clean tree returns, so a caller that trusted the return
+  value reported "nothing to do" and exited `0` on a broken manifest --
+  measured: a caller of that shape printed `nothing to do; manifests already
+  agree` and exited `0` against a manifest containing `{ this is not json`, and
+  now exits `1` naming the file and the parse position. The exception carries
+  `updated` and `failures`, so a partial sync is still reportable and each
+  unusable manifest is paired with its reason; a payload that parses to a
+  non-object is reported as such rather than reaching `.get()` as an
+  `AttributeError` that names neither file nor cause. A caller that catches
+  `VersionSyncError` is not thereby excused from re-validating against disk.
+  `validate_version_consistency` does not share this defect: it already emits
+  an issue for an unreadable manifest, and is unchanged.
 
 ## [0.89.0] - 2026-08-17
 

--- a/installer/version.py
+++ b/installer/version.py
@@ -109,26 +109,78 @@ def check_upgrade_needed(
         return (False, "version unchanged")
 
 
-def sync_version_to_files(spellbook_dir: Path, version: str) -> List[str]:
-    """
-    Synchronize version across all files that contain it.
-    Returns list of updated files.
-    """
-    updated = []
+def _version_manifests(spellbook_dir: Path) -> List[Path]:
+    """Manifests that carry a copy of ``.version`` and must track it."""
+    return [spellbook_dir / "extensions" / "gemini" / "gemini-extension.json"]
 
-    # 1. gemini-extension.json
-    gemini_ext = spellbook_dir / "extensions" / "gemini" / "gemini-extension.json"
-    if gemini_ext.exists():
+
+class VersionSyncError(Exception):
+    """A manifest could not be read or written during a version sync.
+
+    Raised instead of returning, because the swallowed form of this failure
+    was indistinguishable from a clean tree: both produced an empty list, so
+    a caller reported "nothing to do" and exited 0 on a broken manifest.
+
+    ``updated`` records the manifests that were written before the failure,
+    so a partial sync is still reportable; ``failures`` pairs each unusable
+    manifest with the reason it was unusable.
+    """
+
+    def __init__(self, updated: List[str], failures: List[Tuple[str, str]]) -> None:
+        self.updated = updated
+        self.failures = failures
+        detail = "; ".join(f"{path}: {reason}" for path, reason in failures)
+        super().__init__(f"version sync could not process {len(failures)} manifest(s): {detail}")
+
+
+def sync_version_to_files(spellbook_dir: Path, version: str) -> List[str]:
+    """Synchronize ``version`` across the manifests that carry it.
+
+    Returns the manifests actually written — empty when every manifest
+    already agreed with ``version``.
+
+    Raises:
+        VersionSyncError: a manifest exists but is malformed or unreadable.
+            Every other manifest is still processed first, so the error
+            reports the complete picture rather than the first failure.
+    """
+    updated: List[str] = []
+    failures: List[Tuple[str, str]] = []
+
+    for manifest in _version_manifests(spellbook_dir):
+        if not manifest.exists():
+            continue
         try:
-            data = json.loads(gemini_ext.read_text(encoding="utf-8"))
-            if data.get("version") != version:
-                data["version"] = version
-                gemini_ext.write_text(
-                    json.dumps(data, indent=2) + "\n", encoding="utf-8"
-                )
-                updated.append(str(gemini_ext))
-        except (json.JSONDecodeError, OSError):
-            pass
+            data = json.loads(manifest.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            failures.append((str(manifest), f"invalid JSON ({exc})"))
+            continue
+        except OSError as exc:
+            failures.append((str(manifest), f"could not be read ({exc.strerror})"))
+            continue
+
+        if not isinstance(data, dict):
+            # A non-object payload parses cleanly, so JSONDecodeError never
+            # fires; without this it reaches .get() and dies as an
+            # AttributeError that names neither the file nor the cause.
+            failures.append(
+                (str(manifest), f"expected a JSON object, found {type(data).__name__}")
+            )
+            continue
+
+        if data.get("version") == version:
+            continue
+
+        data["version"] = version
+        try:
+            manifest.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+        except OSError as exc:
+            failures.append((str(manifest), f"could not be written ({exc.strerror})"))
+            continue
+        updated.append(str(manifest))
+
+    if failures:
+        raise VersionSyncError(updated, failures)
 
     return updated
 

--- a/tests/installer/test_version_sync.py
+++ b/tests/installer/test_version_sync.py
@@ -1,0 +1,123 @@
+"""Tests for ``installer.version.sync_version_to_files`` failure signalling.
+
+The function used to swallow ``json.JSONDecodeError`` and ``OSError`` and
+return an empty list, which is exactly what it returns for a clean tree. A
+caller could not tell "nothing needed doing" from "the manifest is broken",
+so a broken manifest produced a green exit. These tests pin the three
+outcomes as distinguishable.
+"""
+
+import json
+import os
+
+import pytest
+
+from installer.version import VersionSyncError, sync_version_to_files
+
+VERSION = "9.9.9"
+MANIFEST_PARTS = ("extensions", "gemini", "gemini-extension.json")
+
+
+def _tree(tmp_path, payload):
+    """Build a spellbook-shaped tree whose gemini manifest holds ``payload``."""
+    (tmp_path / ".version").write_text(VERSION + "\n", encoding="utf-8")
+    manifest = tmp_path.joinpath(*MANIFEST_PARTS)
+    manifest.parent.mkdir(parents=True)
+    manifest.write_text(payload, encoding="utf-8")
+    return manifest
+
+
+def test_clean_tree_returns_empty_list(tmp_path):
+    """A manifest already at ``version`` is not rewritten and reports no change."""
+    manifest = _tree(tmp_path, json.dumps({"version": VERSION, "name": "spellbook"}))
+    before = manifest.read_text(encoding="utf-8")
+
+    assert sync_version_to_files(tmp_path, VERSION) == []
+    assert manifest.read_text(encoding="utf-8") == before
+
+
+def test_stale_tree_returns_the_written_path(tmp_path):
+    """A stale manifest is rewritten, reported, and keeps its other keys."""
+    manifest = _tree(tmp_path, json.dumps({"version": "0.1.0", "name": "spellbook"}))
+
+    assert sync_version_to_files(tmp_path, VERSION) == [str(manifest)]
+    assert json.loads(manifest.read_text(encoding="utf-8")) == {
+        "version": VERSION,
+        "name": "spellbook",
+    }
+
+
+def test_malformed_manifest_raises_and_names_the_file(tmp_path):
+    """Invalid JSON raises rather than reporting the clean-tree empty list."""
+    manifest = _tree(tmp_path, "{not json")
+
+    with pytest.raises(VersionSyncError) as excinfo:
+        sync_version_to_files(tmp_path, VERSION)
+
+    error = excinfo.value
+    assert error.updated == []
+    assert [path for path, _ in error.failures] == [str(manifest)]
+    assert "invalid JSON" in error.failures[0][1]
+    assert str(manifest) in str(error)
+
+
+def test_non_object_manifest_raises_with_the_found_type(tmp_path):
+    """A JSON array parses cleanly but is still an unusable manifest."""
+    _tree(tmp_path, "[]")
+
+    with pytest.raises(VersionSyncError) as excinfo:
+        sync_version_to_files(tmp_path, VERSION)
+
+    assert "expected a JSON object, found list" in excinfo.value.failures[0][1]
+
+
+@pytest.mark.posix_only
+@pytest.mark.skipif(
+    getattr(os, "getuid", lambda: 1)() == 0,
+    reason="root bypasses file permission bits",
+)
+def test_unreadable_manifest_raises_distinctly_from_malformed(tmp_path):
+    """A permission failure raises with a read-failure reason, not a parse one."""
+    manifest = _tree(tmp_path, json.dumps({"version": "0.1.0"}))
+    manifest.chmod(0o000)
+    try:
+        with pytest.raises(VersionSyncError) as excinfo:
+            sync_version_to_files(tmp_path, VERSION)
+    finally:
+        manifest.chmod(0o644)
+
+    reason = excinfo.value.failures[0][1]
+    assert "could not be read" in reason
+    assert "invalid JSON" not in reason
+
+
+def test_absent_manifest_is_not_a_failure(tmp_path):
+    """A tree that does not carry the manifest at all has nothing to sync."""
+    (tmp_path / ".version").write_text(VERSION + "\n", encoding="utf-8")
+
+    assert sync_version_to_files(tmp_path, VERSION) == []
+
+
+def test_three_outcomes_are_mutually_distinguishable(tmp_path):
+    """Clean, changed, and broken must not collapse onto one signal.
+
+    This is the regression the module carried: all three produced ``[]``.
+    """
+    clean = tmp_path / "clean"
+    stale = tmp_path / "stale"
+    broken = tmp_path / "broken"
+    for d in (clean, stale, broken):
+        d.mkdir()
+    _tree(clean, json.dumps({"version": VERSION}))
+    stale_manifest = _tree(stale, json.dumps({"version": "0.1.0"}))
+    _tree(broken, "{not json")
+
+    clean_result = sync_version_to_files(clean, VERSION)
+    stale_result = sync_version_to_files(stale, VERSION)
+    with pytest.raises(VersionSyncError) as excinfo:
+        sync_version_to_files(broken, VERSION)
+
+    assert clean_result == []
+    assert stale_result == [str(stale_manifest)]
+    assert clean_result != stale_result
+    assert isinstance(excinfo.value, VersionSyncError)


### PR DESCRIPTION
## What does this PR do?

Makes `sync_version_to_files` report an unusable manifest instead of swallowing it.

**What was wrong.** The function caught `json.JSONDecodeError` and `OSError` with a bare `pass`, so a malformed or unreadable manifest returned the empty list — which is also what a clean tree returns. Malformed, unreadable, and clean all produced one signal. A caller that trusted the return value reported "nothing to do" and exited 0 on a broken file. Measured against a manifest containing `{ this is not json`: such a caller printed `nothing to do; manifests already agree` and exited 0. It now exits 1 naming the file and the parse position.

**What changed.**

- The function raises `VersionSyncError` after processing every manifest, so the error reports the complete picture rather than the first failure.
- The exception carries `updated` (manifests written before the failure, so a partial sync stays reportable) and `failures` (each unusable manifest paired with its reason: invalid JSON, unreadable, unwritable, or a payload that parses to a non-object). The non-object case previously reached `.get()` as an `AttributeError` naming neither file nor cause.
- `validate_version_consistency` does not share the defect — it already appends `gemini-extension.json could not be read` for the same except clause, so its broken outcome differs from its clean one. It is unchanged.

**Guard evidence.** The tests pin the three outcomes as mutually distinguishable. Verified red by restoring only the swallow while leaving `VersionSyncError` defined: 4 of 7 tests fail, including `DID NOT RAISE` on the three-outcome test.

**Merge-order note.** The only caller of `sync_version_to_files` is `scripts/check_version_consistency.py`, which exists on the unmerged branch `fix-changelog-audit`. That caller does not catch `VersionSyncError`, so if this branch merges first it emits a raw traceback instead of its formatted report. Both paths still exit 1, so nothing becomes silently wrong, but the output regresses. Whichever of the two branches merges second needs a `try/except VersionSyncError` added around the `sync_version_to_files` call in `scripts/check_version_consistency.py`.

## Related issue

None.

## Checklist

- [ ] Tests pass locally
- [ ] Documentation updated (if applicable)
