### PR TITLE
Run the generate-docs pre-commit hook in --check mode

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,8 +9,8 @@ repos:
   - repo: local
     hooks:
       - id: generate-docs
-        name: Generate documentation
-        entry: uv run scripts/generate_docs.py
+        name: Check generated documentation is current
+        entry: uv run scripts/generate_docs.py --check
         language: system
         pass_filenames: false
         files: ^(skills/|commands/|agents/|rules/)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ uv run pytest tests/ -x --override-ini="addopts=" -m "not docker"
 # Run linting
 uv run ruff check .
 
-# Generate documentation (auto-runs via pre-commit hook)
+# Generate documentation (pre-commit only checks freshness; run this yourself)
 uv run scripts/generate_docs.py
 ```
 
@@ -45,14 +45,14 @@ If a pre-release exists that is newer than the last actual release, ask: "There'
 
 ## Pre-commit Hooks
 
-Pre-commit hooks auto-generate documentation files. If a hook fails:
+Only `doctoc` writes files. Every other hook reports and leaves the tree alone. If a hook fails:
 - `doctoc` failures: Table of contents in markdown files needs regeneration. Usually fixes itself on re-commit.
-- `Generate documentation`: Runs `scripts/generate_docs.py` to regenerate `docs/` from skills/commands/agents/rules. Stage the generated files and re-commit.
-- `Check documentation completeness`: Ensures every skill/command has a generated doc page. If you added a new skill/command, the hook generates it automatically.
+- `Check generated documentation is current`: The `docs/` mirror is stale. The hook runs `scripts/generate_docs.py --check`, which names each stale page and writes nothing. Run `uv run scripts/generate_docs.py`, stage the regenerated files, and re-commit.
+- `Check documentation completeness`: A skill/command has no generated doc page. Run `uv run scripts/generate_docs.py` and stage the result; the hook only checks.
 - `Validate skill/command/agent/rule schemas`: Checks YAML frontmatter in skills, commands, agents, and rule modules. Fix the frontmatter.
 - `Scan changeset for security issues`: Security scanner on staged diffs. Fix the flagged issue.
 
-When a pre-commit hook fails, it often generates or modifies files. Stage those files (`git add`) and commit again.
+Apart from `doctoc`, a failing hook does not repair anything for you. Run the command it names, stage the result (`git add`), and commit again.
 
 ## Switching Between Worktrees
 
@@ -166,9 +166,9 @@ uv run install.py --dry-run                       # Test installer
 
 ## Pre-commit Hooks
 
-Updates: TOC in README.md, docs from skills/commands/agents.
+Updates TOC in README.md. Checks -- does not write -- the `docs/` mirror of skills/commands/agents/rules.
 
-**Hook failure**: Stage generated files, retry commit.
+**Hook failure**: Run the command the hook names, stage the result, retry commit.
 
 ## Shell/PowerShell Parity
 
@@ -536,7 +536,7 @@ Before any commit, verify:
 
 1. `uv run pytest tests/` passes (fast tests only, heavy markers auto-skipped)
 2. `uv run install.py --dry-run` succeeds
-3. Allow hooks to regenerate docs
+3. `uv run scripts/generate_docs.py` if you touched `skills/`, `commands/`, `agents/`, or `rules/` (the hook checks freshness; it does not regenerate)
 
 <FINAL_EMPHASIS>
 Every library change ships to users across four platforms. Skipping tests or documentation means breaking real developer environments. Run the checklist. Every time.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The `generate-docs` pre-commit hook runs `scripts/generate_docs.py --check`
+  instead of the write mode. The gate is unchanged in what it catches -- a
+  commit that leaves the `docs/` mirror stale still fails -- but it now detects
+  staleness by comparing in memory rather than by mutating the tree and letting
+  pre-commit notice the modification. A hook that writes makes pre-commit's
+  unstaged-change stash load-bearing on every commit touching `skills/`,
+  `commands/`, `agents/`, or `rules/`; a stash round-trip in this repository has
+  already truncated a source file to 0 bytes and left 13 stray empty files with
+  nothing failing loudly. The accepted cost is that the author now runs the
+  regeneration by hand: `--check` names each stale page and prints
+  `Run: python3 scripts/generate_docs.py`, which pre-commit surfaces verbatim.
+  `AGENTS.md`, `CONTRIBUTING.md`, and `docs/reference/contributing.md` said the
+  mirror regenerated automatically on commit and no longer do.
+
 - `spellbook.core.path_utils.resolve_repo_root` reads the repository root off
   the filesystem for the layouts that are determined by what is on disk (plain
   repository, linked worktree, any subdirectory of either, no repository at

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ A passing run shows something like `X passed` with exit code 0.
    ```
 2. Write the skill body following existing skills as examples
 3. Run `python3 scripts/generate_docs.py` to generate the docs page
-4. Pre-commit hooks will validate the schema and update documentation
+4. Pre-commit hooks will validate the schema and check that the docs mirror is current
 
 ## Adding a Command
 
@@ -54,7 +54,7 @@ A passing run shows something like `X passed` with exit code 0.
    description: "Brief description of the command"
    ---
    ```
-2. Pre-commit hooks will generate docs and update the index
+2. Run `python3 scripts/generate_docs.py` to generate the docs page and update the index
 
 ## Code Style
 
@@ -90,10 +90,10 @@ Code is not the only way to contribute. We welcome:
 
 ## Pre-commit Hooks
 
-Pre-commit hooks auto-generate documentation files. If a hook fails:
+Apart from `doctoc`, pre-commit hooks check files rather than rewrite them. If a hook fails:
 
-1. Check the output for which files were modified
-2. Stage the generated files with `git add`
+1. Read the output for the command it tells you to run -- a stale docs mirror reports `Run: python3 scripts/generate_docs.py`
+2. Run that command, then stage the regenerated files with `git add`
 3. Commit again
 
 This is normal and expected when adding new skills or commands.

--- a/docs/reference/contributing.md
+++ b/docs/reference/contributing.md
@@ -103,7 +103,7 @@ description: Use when [trigger] - [what it does]
 
 The repository uses pre-commit hooks for:
 
-- **generate-docs** - Auto-regenerate skill/command/agent documentation
+- **generate-docs** - Check that skill/command/agent documentation is current (reports stale pages; run `uv run scripts/generate_docs.py` to fix)
 - **check-docs-completeness** - Ensure all items are documented
 
 Run hooks manually:


### PR DESCRIPTION
## What does this PR do?

Switches the `generate-docs` pre-commit hook from write mode to `--check`, so it detects a stale `docs/` mirror without rewriting the tree.

**What was wrong.** The hook ran `scripts/generate_docs.py` in write mode and relied on pre-commit noticing that a hook had modified files. The gate worked, but the detection method was mutation. Pre-commit stashes unstaged changes around hook execution, so a writing hook makes that stash path load-bearing on every commit touching `skills/`, `commands/`, `agents/`, or `rules/`. This repository has a documented incident where a stash round-trip truncated a source file to 0 bytes and left 13 stray empty files, with nothing failing loudly.

**What changed.** Two lines in `.pre-commit-config.yaml`: the entry gains `--check`, and the human-readable `name` now describes checking rather than generating. `--check` reports the same staleness by comparing in memory. It already names each stale page and prints the repair command, which pre-commit surfaces verbatim, so no extra failure message was needed.

**The accepted trade.** An author whose commit staleness the mirror must now run `uv run scripts/generate_docs.py` by hand. Nine documentation claims that the switch made false were corrected across `AGENTS.md`, `CONTRIBUTING.md`, and `docs/reference/contributing.md` — including a Pre-Commit Checklist step reading "Allow hooks to regenerate docs" and a three-step "stage the generated files" recipe that no longer applies.

**Evidence.**

- The hook was proven in both directions. A planted source edit produced a verbatim red naming the stale file and the repair command. `git status --porcelain -uall` captured immediately before and after that failing run is byte-identical, proving the hook wrote nothing — which is the entire point of the change.
- The freshness gate does not depend on the hook alone. `tests/scripts/test_docs_mirror_freshness.py` already shells out to `--check` and asserts exit 0, so a stale mirror fails CI independently. This change makes the hook agree with that test instead of duplicating it in a mutating form.
- CI does not commit regenerated docs back to `main`. The workflow's write-mode run feeds `mike deploy` into `gh-pages` — the built site, not the source mirror.

**One deliberate inconsistency.** The hook's `id` is still `generate-docs` although it no longer generates. Renaming the id would ripple into documentation and into anyone's `pre-commit run generate-docs` habit, so it was left stable on purpose.

## Related issue

None.

## Checklist

- [ ] Tests pass locally
- [ ] Documentation updated (if applicable)
