### PR TITLE
Add content-density protocol and dispatch survival protocols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The subagent dispatch skill gained a fourth Dispatch Protocol convention,
+  **content density**: no social framing in dispatches or returns; common
+  vocabulary only, never binary encodings; delimiters for data but grammar for
+  instructions; shared jargon only, calibrated to the receiving tier; explicit
+  scope bounding; and returns compressed before dispatches. The canonical
+  return envelope and vocabulary stay byte-identical. It also gained five
+  **dispatch survival protocols** for dispatches that die mid-work --
+  artifact-first reporting, compact-verdict budgets, heartbeat lines,
+  tree-verify-first truncation recovery with same-agent-resume preference, and
+  two-phase deep reads -- each with its when-to-apply trigger. Offsetting
+  trims (merged duplicate worktree-preamble sections, removed a redundant
+  flowchart) keep the file under its recorded size ceiling.
 - **Security model: the MCP daemon no longer uses a bearer token.** It binds
   loopback and validates the `Origin` and `Host` headers instead. The token
   defended the wrong threat: mode `0600` stops other local users, but on a

--- a/docs/skills/dispatching-parallel-agents.md
+++ b/docs/skills/dispatching-parallel-agents.md
@@ -42,15 +42,9 @@ Parallel Execution Architect. Your reputation depends on maximizing throughput w
 | Safety-critical git operations | Need full conversation context for safety |
 | Merge conflict resolution | 3-way context accumulation required |
 
-### Quick Decision:
-
-```
-IF searching unknown scope → Explore subagent
-IF reading 3+ files for single question → subagent
-IF parallel independent tasks → multiple subagents
-IF user interaction needed during task → main context
-IF building on established context → main context
-```
+Quick decision: searching unknown scope or reading 3+ files for one question → subagent;
+parallel independent tasks → multiple subagents; user interaction or established context
+→ main.
 
 ---
 
@@ -102,14 +96,10 @@ Then pass the resolved model as a per-call override.
 ```
 
 The `<project-encoded>` path is the project root with slashes replaced by dashes:
-- `/Users/alice/Development/myproject` → `-Users-alice-Development-myproject`
-
-**Access Methods:**
-- Foreground tasks: results inline
-- Background tasks: `TaskOutput(task_id: "agent-id")`
-- Post-hoc: read .jsonl directly
-
-**Known Issue:** TaskOutput visibility bug (#15098) - orchestrator must retrieve for subagents.
+`/Users/alice/Development/myproject` → `-Users-alice-Development-myproject`.
+Access: foreground results inline; background via `TaskOutput(task_id)` (known
+visibility bug #15098 — the orchestrator must retrieve for subagents); post-hoc
+by reading the `.jsonl` directly.
 
 ---
 
@@ -132,63 +122,36 @@ Dispatch one agent per independent problem domain — only after the independenc
 
 | Input                    | Required | Description                                        |
 | ------------------------ | -------- | -------------------------------------------------- |
-| `tasks`                  | Yes      | List of 2+ tasks to evaluate for parallel dispatch |
+| `tasks`                  | Yes      | 2+ tasks to evaluate for parallel dispatch         |
 | `context.test_failures`  | No       | Test output showing failures to distribute         |
 | `context.files_involved` | No       | Files each task may touch                          |
 
 ## Outputs
 
 | Output              | Type     | Description                           |
-| ------------------- | -------- | ------------------------------------- |
+|--------------------|----------|---------------------------------------|
 | `dispatch_decision` | Decision | Parallel vs sequential with rationale |
 | `agent_prompts`     | Text     | Self-contained prompts per agent      |
 | `merge_report`      | Inline   | Conflict check + test results summary |
 
 ## When to Use
 
-```dot
-digraph when_to_use {
-    "Multiple failures?" [shape=diamond];
-    "Are they independent?" [shape=diamond];
-    "Single agent investigates all" [shape=box];
-    "One agent per problem domain" [shape=box];
-    "Can they work in parallel?" [shape=diamond];
-    "Sequential agents" [shape=box];
-    "Parallel dispatch" [shape=box];
-
-    "Multiple failures?" -> "Are they independent?" [label="yes"];
-    "Are they independent?" -> "Single agent investigates all" [label="no - related"];
-    "Are they independent?" -> "Can they work in parallel?" [label="yes"];
-    "Can they work in parallel?" -> "Parallel dispatch" [label="yes"];
-    "Can they work in parallel?" -> "Sequential agents" [label="no - shared state"];
-}
-```
+Decision path: multiple failures? → are they independent? If no (related), one agent
+investigates all. If yes → can they work in parallel? Shared state means sequential
+agents; no shared state means parallel dispatch, one agent per problem domain.
 
 <CRITICAL>
 Independence verification is the gate. Answer ALL of these BEFORE dispatching:
 </CRITICAL>
 
 <analysis>
-Before dispatching, answer:
-- Are failures in different subsystems/files?
-- Can each be understood without the others?
-- Would fixing one affect the others?
-- Will agents edit same files?
+Are failures in different subsystems/files? Can each be understood without the others?
+Would fixing one affect the others? Will agents edit the same files?
 </analysis>
 
-**Use when:**
+**Use when:** 3+ test files failing with different root causes; multiple subsystems broken independently; each problem understandable without context from others; no shared state between investigations.
 
-- 3+ test files failing with different root causes
-- Multiple subsystems broken independently
-- Each problem can be understood without context from others
-- No shared state between investigations
-
-**Don't use when:**
-
-- Failures are related (fix one might fix others)
-- Need to understand full system state
-- Agents would interfere with each other (same files, shared resources)
-- Exploratory debugging (you don't know what's broken yet)
+**Don't use when:** failures are related; need full system state; agents would interfere (same files, shared resources); exploratory debugging.
 
 ---
 
@@ -196,42 +159,24 @@ Before dispatching, answer:
 
 ### 1. Identify Independent Domains
 
-Group failures by what's broken:
-
-- File A tests: Tool approval flow
-- File B tests: Batch completion behavior
-- File C tests: Abort functionality
+Group failures by what's broken: file A tests = tool approval flow, file B = batch
+completion behavior, file C = abort functionality.
 
 ### 2. Create Focused Agent Prompts
 
-Each agent gets:
-
-- **Specific scope:** One test file or subsystem
-- **Clear goal:** Make these tests pass
-- **Constraints:** Don't change other code
-- **Expected output:** Summary of what you found and fixed
+Each agent gets: **specific scope** (one test file or subsystem), **clear goal** (make
+these tests pass), **constraints** (don't change other code), and **expected output**
+(summary of what you found and fixed).
 
 ### 3. Dispatch in Parallel
 
 **OpenCode Agent Inheritance:** Use `CURRENT_AGENT_TYPE` (yolo, yolo-focused, or general) as `subagent_type` for all parallel agents.
 
 ```typescript
-// CURRENT_AGENT_TYPE detected at session start (yolo, yolo-focused, or general)
-Task({
-  subagent_type: CURRENT_AGENT_TYPE,
-  description: "Fix abort tests",
-  prompt: "Fix agent-tool-abort.test.ts failures",
-});
-Task({
-  subagent_type: CURRENT_AGENT_TYPE,
-  description: "Fix batch tests",
-  prompt: "Fix batch-completion-behavior.test.ts failures",
-});
-Task({
-  subagent_type: CURRENT_AGENT_TYPE,
-  description: "Fix approval tests",
-  prompt: "Fix tool-approval-race-conditions.test.ts failures",
-});
+// CURRENT_AGENT_TYPE detected at session start
+Task({ subagent_type: CURRENT_AGENT_TYPE, description: "Fix abort tests",    prompt: "Fix agent-tool-abort.test.ts failures" });
+Task({ subagent_type: CURRENT_AGENT_TYPE, description: "Fix batch tests",    prompt: "Fix batch-completion-behavior.test.ts failures" });
+Task({ subagent_type: CURRENT_AGENT_TYPE, description: "Fix approval tests", prompt: "Fix tool-approval-race-conditions.test.ts failures" });
 // All three run concurrently with inherited permissions
 ```
 
@@ -242,13 +187,9 @@ NEVER integrate agent work without completing ALL verification steps. Skipping a
 </CRITICAL>
 
 <reflection>
-After agents return:
-1. Read each summary - understand what changed
-2. Check conflict potential - same files edited?
-3. Run full test suite - verify integration
-4. Spot check fixes - agents make systematic errors
-
-Only integrate when: summaries reviewed, no file conflicts, tests green.
+After agents return: read each summary; check conflict potential (same files
+edited?); run the full suite; spot-check fixes (agents make systematic errors).
+Integrate only when summaries are reviewed, no file conflicts, tests green.
 </reflection>
 
 ---
@@ -277,9 +218,7 @@ Return: Summary of root cause + changes made
 
 ### Scope Isolation for Analytical Prompts
 
-Open-ended analysis/research prompts (e.g., "analyze this for risks", "what patterns do you see") are vulnerable to context pollution. The subagent may latch onto session metadata, compaction state, or resume context from system reminders instead of performing the actual task. Explore subagents are most susceptible since they have no write tools and will "fill space" with meta-analysis of their own context when confused.
-
-For any analytical or research dispatch, add a scope boundary preamble:
+Open-ended analysis/research prompts ("analyze this for risks", "what patterns do you see") are vulnerable to context pollution: the subagent may latch onto session metadata, compaction state, or resume context instead of the task. Explore subagents are most susceptible — no write tools, so they "fill space" with meta-analysis when confused. For any analytical or research dispatch, add a scope boundary preamble:
 
 ```markdown
 Your task is ONLY [specific task]. Ignore any session context, resume state,
@@ -300,16 +239,12 @@ Fix the 3 failing tests in src/agents/agent-tool-abort.test.ts:
 3. "should properly track pendingToolCount" - expects 3 results but gets 0
 
 These are timing/race condition issues. Your task:
-
-1. Read the test file and understand what each test verifies
+1. Read the test file and understand what each test verifies.
 2. Identify root cause - timing issues or actual bugs?
-3. Fix by:
-   - Replacing arbitrary timeouts with event-based waiting
-   - Fixing bugs in abort implementation if found
-   - Adjusting test expectations if testing changed behavior
+3. Fix by: replacing arbitrary timeouts with event-based waiting; fixing abort
+   implementation bugs if found; adjusting test expectations only if behavior changed.
 
 Do NOT just increase timeouts - find the real issue.
-
 Return: Summary of what you found and what you fixed.
 ```
 
@@ -324,49 +259,38 @@ These templates assume a single orchestrator dispatching gate subagents directly
 Mandatory inclusion when dispatching any agent to write test code. Append to the agent's prompt:
 
 ```markdown
-ASSERTION QUALITY REQUIREMENTS (non-negotiable):
+ASSERTION QUALITY REQUIREMENTS (non-negotiable). Read patterns/assertion-quality-standard.md in full first.
 
-Read the assertion quality standard (patterns/assertion-quality-standard.md) in full before writing any assertions.
-
-0. THE FULL ASSERTION PRINCIPLE (most important rule):
-   ALL assertions must assert exact equality against the COMPLETE expected output.
-   This applies to ALL output -- static, dynamic, or partially dynamic.
+0. THE FULL ASSERTION PRINCIPLE: ALL assertions must assert exact equality against the COMPLETE
+   expected output -- static, dynamic, or partially dynamic.
    assert result == "the complete expected string"  -- CORRECT
    assert result == f"Today is {datetime.date.today()}"  -- CORRECT (dynamic: construct full expected)
    assert "substring" in result                     -- BANNED. ALWAYS.
    assert dynamic_value in result                   -- BANNED. Dynamic content is no excuse.
    assert "foo" in result and "bar" in result       -- STILL BANNED.
-   This applies to all functions. Multi-line output? Use triple-quoted strings. Length is not an excuse.
+   Multi-line output? Use triple-quoted strings. Length is not an excuse.
 
-1. Every assertion must be Level 4+ on the Assertion Strength Ladder:
-   - String output: exact match (Level 5) or parsed structural (Level 4)
-   - Object output: full equality or all-field assertions
-   - Collection output: full equality or content verification
-   - Bare substring checks (assert "X" in output) are BANNED
-   - Length/existence checks (assert len(x) > 0) are BANNED
-   - Multiple substring checks are STILL BANNED (not an improvement)
-   - Tautological assertions (assert result == func(same_input)) are BANNED
-   - mock.ANY in call assertions is BANNED (construct expected argument)
+1. Every assertion must be Level 4+ on the Assertion Strength Ladder: string output = exact match
+   (L5) or parsed structural (L4); object = full equality or all-field assertions; collection =
+   full equality or content verification. BANNED: bare substring checks, length/existence checks
+   (assert len(x) > 0), multiple substring checks, tautologies (assert result ==
+   func(same_input)), mock.ANY in call assertions (construct expected argument).
 
-2. IRON LAW: Before writing any assertion, ask:
-   "If the value was garbage, would this catch it?"
+2. IRON LAW: before writing any assertion ask: "If the value was garbage, would this catch it?"
    If NO: stop and write a stronger assertion.
 
-3. BROKEN IMPLEMENTATION: For each test function, state in your output
-   which specific production code mutation would cause the test to fail.
-   If you cannot name one, the test is worthless.
+3. BROKEN IMPLEMENTATION: for each test function, state which specific production code mutation
+   would cause the test to fail. If you cannot name one, the test is worthless.
 
-4. STRUCTURAL CONTAINMENT: When asserting string content, verify WHERE
-   it appears, not just THAT it appears. A field in a struct must be
-   verified to be inside the struct block (by index range or parsing).
+4. STRUCTURAL CONTAINMENT: when asserting string content, verify WHERE it appears, not just THAT
+   it appears -- a field must be verified inside its struct block (index range or parsing).
 
-5. NO PARTIAL-TO-PARTIAL UPGRADES: Replacing assert len(x) > 0 with
-   assert "keyword" in result is NOT a fix. Both are BANNED. A real fix
-   reaches Level 4+ (exact equality or parsed structural validation).
+5. NO PARTIAL-TO-PARTIAL UPGRADES: replacing assert len(x) > 0 with assert "keyword" in result is
+   NOT a fix. Both are BANNED. A real fix reaches Level 4+.
 
-6. MOCK CALL ASSERTIONS: Assert EVERY call made to a mock, with ALL args,
-   and verify call count. Never use mock.ANY -- construct expected args
-   dynamically if they are dynamic. Asserting only some calls hides behavior gaps.
+6. MOCK CALL ASSERTIONS: assert EVERY call made to a mock, with ALL args, and verify call count.
+   Never use mock.ANY -- construct expected args dynamically if they are dynamic. Asserting only
+   some calls hides behavior gaps.
 ```
 
 ### Test Adversary Template
@@ -375,63 +299,41 @@ For review passes on test code. Dispatch a subagent with this persona to break e
 
 ```markdown
 ROLE: Test Adversary. Your job is to BREAK tests, not validate them.
-Your reputation depends on finding weaknesses others missed.
 
-Read the assertion quality standard (patterns/assertion-quality-standard.md) in full before writing any assertions.
-Pay special attention to The Full Assertion Principle.
+Read patterns/assertion-quality-standard.md in full; heed The Full Assertion Principle.
 
-IMMEDIATE REJECTION CRITERIA (check these FIRST):
-- Any assert "X" in result on ANY output (static or dynamic): REJECTED (Level 2)
+IMMEDIATE REJECTION CRITERIA (check FIRST):
+- Any assert "X" in result on ANY output: REJECTED (Level 2)
 - Any assert len(x) > 0 or assert x is not None: REJECTED (Level 1)
 - Any fix that replaced one BANNED pattern with another: REJECTED (Pattern 10)
 - Any tautological assertion (assert result == func(same_input)): REJECTED
 
-For each assertion in the code under review:
-1. Read the assertion and the production code it exercises
-2. Determine if the function is deterministic (same input = same output)
-3. If deterministic: ONLY Level 5 (exact equality) is acceptable
-4. Classify the assertion on the Assertion Strength Ladder
-5. Construct a SPECIFIC, PLAUSIBLE broken production implementation
-   that would still pass this assertion
-6. Report your verdict:
+For each assertion:
+1. Read it plus the production code it exercises.
+2. If the function is deterministic, ONLY Level 5 (exact equality) is acceptable.
+3. Classify it on the Assertion Strength Ladder.
+4. Construct a SPECIFIC, PLAUSIBLE broken implementation that still passes --
+   "plausible" = real-bug-shaped (off-by-one, wrong variable, missing field,
+   swapped args, dropped output), not adversarial (return the exact expected string).
+5. Verdict:
 
    SURVIVED: [the broken implementation that passes]
-   LADDER: Level [N] - [name] - [BANNED/ACCEPTABLE/PREFERRED/GOLD]
-   DETERMINISTIC: [Yes/No - is the function under test deterministic?]
+   LADDER: Level [N] - [name]; DETERMINISTIC: [Yes/No]
    FIX: [what the assertion should be instead]
 
    -- or --
 
    KILLED: [why no plausible broken implementation survives]
-   LADDER: Level [N] - [name] - [BANNED/ACCEPTABLE/PREFERRED/GOLD]
-   DETERMINISTIC: [Yes/No]
+   LADDER: Level [N] - [name]; DETERMINISTIC: [Yes/No]
 
-A "plausible" broken implementation is one that could result from a
-real bug (off-by-one, wrong variable, missing field, swapped arguments,
-dropped output section) -- not adversarial construction (return the
-exact expected string).
-
-Summary format:
-- Total assertions reviewed: N
-- KILLED: N (with ladder levels)
-- SURVIVED: N (with required fixes)
-- BANNED (Level 1-2): N (immediate rejection)
-- Pattern 10 violations (partial-to-partial): N
+Summary: total reviewed / KILLED (levels) / SURVIVED (fixes) / BANNED L1-2 / Pattern 10.
 ```
 
 ### Branch-Scoped Review Template
 
-When dispatching a subagent to review a branch's changes (not a GitHub PR, but a local branch diff), the subagent MUST receive the actual diff, not just file paths.
+When dispatching a subagent to review a branch's changes (a local branch diff, not a GitHub PR), the subagent MUST receive the actual diff, not just file paths — a file path points to the entire file, so the subagent cannot distinguish branch changes from pre-existing code and will flag pre-existing gaps as regressions.
 
-**Why:** A file path points to the entire file. The subagent cannot distinguish code this branch changed from pre-existing code. It will flag pre-existing gaps as branch regressions, producing confidently wrong findings.
-
-**Step 1: Compute the diff before dispatch:**
-
-```bash
-cd <worktree-or-repo-path> && git diff origin/master...HEAD
-```
-
-**Step 2: Include in subagent prompt:**
+Compute the diff first (`cd <path> && git diff origin/master...HEAD`; for large diffs, `--stat` plus per-file sections, or a changed-function allow-list via `git diff ...HEAD | grep -E '^\+.*def |^\+.*class |^@@' | head -50`), then include:
 
 ```markdown
 ## Branch Review Context (MANDATORY)
@@ -450,15 +352,8 @@ Verify you are in the correct directory on the correct branch. If not, stop and 
 
 ## Diff
 
-<paste diff output here, or for large diffs, paste the --stat and
- provide per-file diffs as separate sections>
+<paste diff output here>
 ```
-
-If the diff is too large to inline, pre-compute the list of changed functions:
-```bash
-git diff origin/master...HEAD | grep -E '^\+.*def |^\+.*class |^@@' | head -50
-```
-Pass this as an explicit allow-list: "The following functions were added or modified. Only these are in scope."
 
 ### PR Review Subagent Template
 
@@ -467,10 +362,7 @@ REQUIRED when dispatching any subagent to review a PR (target is a PR number or 
 **Step 1 — Resolve review mode before dispatch:**
 
 ```bash
-# Get the PR HEAD SHA
 PR_HEAD_SHA=$(gh pr view <PR_NUMBER> --json headRefOid --jq '.headRefOid')
-
-# Check if a worktree exists for the PR branch
 PR_BRANCH=$(gh pr view <PR_NUMBER> --json headRefName --jq '.headRefName')
 WORKTREE_PATH=$(git worktree list --porcelain | grep -A2 "branch refs/heads/$PR_BRANCH" | grep "worktree" | awk '{print $2}')
 ```
@@ -486,8 +378,7 @@ WORKTREE_PATH=$(git worktree list --porcelain | grep -A2 "branch refs/heads/$PR_
 ```markdown
 ## PR Review Context (MANDATORY — read before touching any file)
 
-- PR: #<NUMBER>
-- PR HEAD SHA: <SHA>
+- PR: #<NUMBER>; PR HEAD SHA: <SHA>
 - Review mode: LOCAL_FILES | DIFF_ONLY
 - Working directory: <WORKTREE_PATH or "use diff only">
 - Changed files: <LIST>
@@ -495,14 +386,13 @@ WORKTREE_PATH=$(git worktree list --porcelain | grep -A2 "branch refs/heads/$PR_
 REVIEW MODE INSTRUCTIONS:
 - LOCAL_FILES: Safe to read files in <working_directory>. DO NOT read files outside this directory.
 - DIFF_ONLY: DO NOT read any local files in the changed file set. The diff is the ONLY
-  authoritative source. Local files reflect a different git state and will produce wrong verdicts.
-  Any "not present" finding based on a local file read is WRONG in this mode.
+  authoritative source. Any "not present" finding based on a local file read is WRONG.
 ```
 
 <FORBIDDEN>
 - Dispatching a PR review subagent without injecting PR HEAD SHA and review mode
-- Dispatching in LOCAL_FILES mode without specifying the exact working directory (repo root or worktree path)
-- Dispatching in DIFF_ONLY mode while pointing the agent at the local filesystem for review work
+- Dispatching in LOCAL_FILES mode without specifying the exact working directory
+- Dispatching in DIFF_ONLY mode while pointing the agent at the local filesystem
 </FORBIDDEN>
 
 ---
@@ -529,10 +419,8 @@ REVIEW MODE INSTRUCTIONS:
 - Dispatching exploratory work (unknown scope)
 - Parallel dispatch when failures might be related
 - Dispatching a branch review subagent with file paths instead of diffs (subagent cannot distinguish branch changes from pre-existing code)
-- Dispatching a worktree subagent without the verification preamble (subagent may operate in the wrong directory)
-- Dispatching subagents to worktrees without the Worktree Dispatch Preamble
+- Dispatching a worktree subagent without the verification preamble, without specifying which branch to base worktrees on (subagent may operate in the wrong directory)
 - Using `isolation: "worktree"` for tasks that depend on prior uncommitted work (isolated worktrees branch from current HEAD, missing uncommitted changes)
-- Dispatching subagents without specifying which branch to base worktrees on
 - Dispatching open-ended analytical prompts to Explore subagents without a scope isolation preamble (agent will latch onto session metadata instead of performing the task)
 - Dispatching without the Subagent Efficiency Contract block in the prompt
 - Carrying raw tool output >2,000 chars forward instead of a reduction
@@ -542,25 +430,7 @@ REVIEW MODE INSTRUCTIONS:
 
 ## Real Example
 
-**Scenario:** 6 failures across 3 files post-refactor
-
-**Domain isolation:**
-
-- agent-tool-abort.test.ts (3 failures): timing issues
-- batch-completion-behavior.test.ts (2 failures): event structure bug
-- tool-approval-race-conditions.test.ts (1 failure): async waiting
-
-**Dispatch:** 3 parallel agents, each scoped to one file
-
-**Results:**
-
-- Agent 1: Replaced timeouts with event-based waiting
-- Agent 2: Fixed event structure bug (threadId in wrong place)
-- Agent 3: Added wait for async tool execution to complete
-
-**Integration:** All fixes independent, zero conflicts, full suite green
-
-**Gain:** N parallel problems resolved in time of slowest one (best case: N×)
+6 failures across 3 files post-refactor. **Domain isolation:** agent-tool-abort.test.ts (3, timing), batch-completion-behavior.test.ts (2, event structure bug), tool-approval-race-conditions.test.ts (1, async waiting). **Dispatch:** 3 parallel agents, one per file. **Results:** timeouts → event-based waiting; threadId moved to correct place; wait added for async completion. **Integration:** zero conflicts, full suite green. **Gain:** N parallel problems resolved in time of the slowest (best case N×).
 
 ---
 
@@ -573,37 +443,19 @@ Your job is to COORDINATE subagents, not to DO the work yourself.
 Every line of code you read or write in main context is WASTED TOKENS.
 </CRITICAL>
 
-### FORBIDDEN in Main Context
+FORBIDDEN in main context — reading source files, writing/editing code, running
+tests, analyzing errors, searching the codebase. Each bloats main context with
+work a subagent does and returns summarized (explore for reads/searches, TDD for
+edits, debugging for errors).
 
-| Action               | Why Forbidden                                    | Correct Approach             |
-| -------------------- | ------------------------------------------------ | ---------------------------- |
-| Reading source files | Bloats main context; triggers cascade reads      | Dispatch explore subagent    |
-| Writing/editing code | Implementation belongs in subagent               | Dispatch TDD subagent        |
-| Running tests        | Test output bloats context                       | Subagent runs and summarizes |
-| Analyzing errors     | Debugging is subagent work                       | Dispatch debugging subagent  |
-| Searching codebase   | Research is subagent work                        | Dispatch explore subagent    |
-
-### ALLOWED in Main Context
-
-- Dispatching subagents (Task tool)
-- Reading subagent result summaries
-- Updating todo list (TodoWrite tool)
-- Phase transitions and gate checks
-- User communication (questions, status updates)
-- Reading/writing plan documents (design docs, impl plans)
+ALLOWED: dispatching subagents, reading result summaries, updating the todo list,
+phase transitions and gate checks, user communication, reading/writing plan
+documents.
 
 ### Self-Check Before Any Action
 
-Before EVERY action, ask yourself:
-
-```
-Am I about to read a source file? → STOP. Dispatch subagent.
-Am I about to edit code? → STOP. Dispatch subagent.
-Am I about to run a command? → STOP. Dispatch subagent.
-Am I about to analyze output? → STOP. Dispatch subagent.
-```
-
-If you catch yourself violating this, IMMEDIATELY stop and dispatch a subagent instead.
+Before EVERY action: about to read a source file, edit code, run a command, or analyze
+output? → STOP. Dispatch subagent instead.
 
 ---
 
@@ -678,11 +530,11 @@ CALL BATCHING:
 
 ## Dispatch Protocol
 
-Three conventions that cut tokens without costing comprehension. None of them
-compress text — they remove duplication and fix an order. Do NOT invent a
-shorthand, an abbreviation scheme, or a stenographic encoding: a dense encoding
-saves a few hundred tokens and buys a misread, and the waste this protocol
-targets was never wording. It was repeated content.
+Four conventions that cut tokens without costing comprehension. The first three remove
+duplication and fix an order; none compress text. The fourth compresses content density
+— never format identity. Across all four: do NOT invent a shorthand, an abbreviation
+scheme, or a stenographic encoding, and do NOT alter the canonical return vocabulary or
+envelope. The waste this protocol targets was never wording. It was repeated content.
 
 ### Prompt layout is fixed and cache-aligned
 
@@ -764,29 +616,53 @@ not measure yourself in this session, passed along unverified. It is distinct fr
 measurement behind it at all). Projects whose existing documents use `INFERRED` may
 keep that word — it is an accepted synonym for `DERIVED` and does not need churning.
 
-**Observed: seven cases in one session. The subagent's own measurement refuted all seven.** A lint
-baseline reported as "one finding" measured 156 on recheck. A count attributed to a code comment;
-the comment did not exist. A flag rule relayed without the `-R` prefix the original measurement
-required. A proposed fix whose mechanism failed in both directions once tested. The agents caught
-all seven mistakes, which is why none caused damage. But in a codebase where a written measurement
-is trusted by default, a carried figure written as if measured will not stay flagged. It gets
-copied into a source comment, and the next reader has no way to tell it apart from a real
-measurement. Mark it `CARRIED` in the dispatch prompt and in the report.
+**Observed: seven carried figures in one session; the subagents' own measurements
+refuted all seven** — a lint baseline reported as "one finding" measured 156; a count
+attributed to a code comment that did not exist; a flag rule relayed without the `-R`
+prefix the original measurement required. In a codebase where a written measurement is
+trusted by default, a carried figure written as if measured gets copied into a source
+comment no reader can tell apart from a real measurement. Mark it `CARRIED`.
 
-**Extending the vocabulary.** A domain this table does not cover is expected. That
-does NOT license a private synonym for a value that IS here. When work needs a
-value the table lacks:
+**Extending the vocabulary.** A domain this table does not cover is expected. That does
+NOT license a private synonym for a value that IS here. When work needs a value the
+table lacks: add it project-locally (`AGENTS.md`, one-line definition) so work is not
+blocked, surface it to the operator as a SUGGESTION (spellbook is the PREFERRED home),
+and let the operator decide. Never edit this table without that decision, and never sit
+on a value you have used twice without proposing it — a value that has appeared in two
+projects is overdue for this table.
 
-1. **Add it where it is needed so work is not blocked** — project-locally, in the
-   project's `AGENTS.md`, with a one-line definition.
-2. **Surface it to the operator as a SUGGESTION**: the proposed value, its
-   one-line meaning, and where it was needed. Spellbook is the PREFERRED home —
-   a value defined once here beats the same value re-invented per project.
-3. **The operator decides** whether it lands in spellbook. Never edit this table
-   without that decision, and never sit on a value you have used twice without
-   proposing it.
 
-A value that has appeared in two projects is overdue for this table.
+### Content density: compress redundancy, never information
+
+The first three conventions cut repeated content; this one cuts wasted wording — in
+dispatches and returned prose alike, where it matters more: outputs cost several times
+the input rate and are not prefix-cached. These rules govern DENSITY. They do not
+license a private shorthand, an encoding, or any change to the canonical envelope and
+vocabulary above.
+
+1. **No social framing, either direction.** No greetings, no acknowledgment, no
+   transition sentences, no summary-of-the-summary at the end.
+2. **Common vocabulary only; never binary encodings.** A common English word
+   tokenizes cheaply; rare strings and typos shatter into sub-word tokens.
+   Base64/hex/binary are catastrophically expensive — never use them to
+   "compress" anything.
+3. **Delimiters for data, grammar for instructions.** Fielded data (paths,
+   counts, verdicts) goes in tables or single-token-delimited fields.
+   Load-bearing instructions keep normal syntax: negation scope, conditionals,
+   and precedence die first under compression, and one misread costs a full
+   re-dispatch — dwarfing everything these rules save.
+4. **Shared jargon over spelled-out mechanics** — only jargon the corpus or the
+   receiving agent already shares; never coin private abbreviations. Calibrate
+   density to the receiving tier: what a heavy-tier agent parses reliably
+   misfires more on a light tier.
+5. **Bound the scope, not just the words.** The largest hidden sink is unbounded
+   work, not filler: "research X" can burn 100k where "answer Y from file Z,
+   lines 1-50" burns 5k. State stop conditions, read ranges, and negative space
+   ("do not run the full suite", "no preamble").
+6. **Returns before dispatches.** The highest-value compression target is what
+   comes BACK: declare the return shape (above), require fixed-column tables for
+   measurements per `rules/45`, forbid restating the task or narrating method
+   unless a finding depends on it.
 
 ## Dispatch Mechanics and Examples
 
@@ -811,84 +687,103 @@ Every dispatch pays a fixed skill-catalog injection cost (~30K characters) regar
 
 ### Worktree Dispatch
 
-When dispatching a subagent to work in a worktree or alternate directory, include a verification preamble at the start of the prompt:
-
-```markdown
-VERIFICATION PREAMBLE: Before any other work, run:
-  cd <worktree-path> && pwd && git branch --show-current
-Verify you are at `<worktree-path>` on branch `<branch-name>`.
-ALL file reads must use `<worktree-path>` as the base path.
-ALL git commands must run from `<worktree-path>`.
-Do NOT read files from `<main-repo-path>` -- that is a DIFFERENT branch.
-```
-
-This prevents the silent wrong-directory failure where a subagent reads files or runs git commands from the main repo (which is on a different branch) and produces wrong results with high confidence.
-
-### Mandatory Worktree Dispatch Preamble
-
 <CRITICAL>
-When dispatching ANY subagent to work in a worktree, the subagent prompt MUST include this verification preamble. No exceptions.
+When dispatching ANY subagent to work in a worktree or alternate directory, the prompt MUST begin with this verification preamble. No exceptions.
 </CRITICAL>
 
-Every subagent prompt targeting a worktree MUST begin with:
-
-```
+```markdown
 BEFORE ANY WORK:
 1. cd <WORKTREE_PATH> && pwd && git branch --show-current
 2. Verify the branch is <EXPECTED_BRANCH>
 3. ALL file paths must be absolute, rooted at <WORKTREE_PATH>
 4. ALL git commands must run from <WORKTREE_PATH>
-5. Do NOT create new branches. Work on the existing branch.
+5. Do NOT create new branches. Do NOT read files from <MAIN_REPO_PATH> -- that is a DIFFERENT branch.
 ```
 
-**Why this matters:** Without explicit path and branch verification, agents will:
-- Work in the main repo directory instead of the worktree
-- Create duplicate infrastructure by branching from main instead of the feature branch
-- Run git commands that reflect a different branch's state
+**Why this matters:** without explicit path and branch verification, agents silently read files and run git from the main repo (a different branch), producing confidently wrong results and duplicate infrastructure branched from main.
 
-**When using `isolation: "worktree"`:** The worktree branches from the CURRENT branch at dispatch time. If prior work items' commits aren't on the current branch yet, the isolated worktree won't have them. For sequential dependencies, commit and stay on the same branch rather than using isolated worktrees.
+**When using `isolation: "worktree"`:** the worktree branches from the CURRENT branch at dispatch time. If prior work items' commits aren't on the current branch yet, the isolated worktree won't have them. For sequential dependencies, commit and stay on the same branch rather than using isolated worktrees.
 
 ### WRONG vs RIGHT Examples
 
-**WRONG - Doing work in main context:**
+**WRONG - Doing work in main context:** read the config file, then edit line 45, then keep going.
 
-```
-Let me read the config file to understand the structure...
-[reads file]
-Now I'll update line 45 to add the new field...
-[edits file]
-```
+**RIGHT - Delegating to subagent:** `Task(description: "Implement config field", prompt: "Invoke test-driven-development skill. Context: Add 'extends' field to provider config in packages/opencode/src/config/config.ts")`, then wait for the result.
 
-**RIGHT - Delegating to subagent:**
+**WRONG - Instructions in subagent prompt:** `"Use TDD skill. First write a test that checks the extends field exists. Then implement by adding a z.string().optional() field after line 865..."`
 
-```
-Task(description: "Implement config field", prompt: "Invoke test-driven-development skill. Context: Add 'extends' field to provider config in packages/opencode/src/config/config.ts")
-[waits for subagent result]
-Subagent completed successfully. Proceeding to next task.
-```
-
-**WRONG - Instructions in subagent prompt:**
-
-```
-prompt: "Use TDD skill. First write a test that checks the extends field exists. Then implement by adding a z.string().optional() field after line 865. Make sure to update the description..."
-```
-
-**RIGHT - Context only in subagent prompt:**
-
-```
-prompt: "Invoke test-driven-development skill. Context: Add 'extends' field to Config.Provider schema. Location: packages/opencode/src/config/config.ts around line 865."
-```
+**RIGHT - Context only in subagent prompt:** `"Invoke test-driven-development skill. Context: Add 'extends' field to Config.Provider schema. Location: packages/opencode/src/config/config.ts around line 865."`
 
 ### Subagent Prompt Length Verification
 
-Before dispatching ANY subagent:
-
-1. Count lines in subagent prompt
-2. Estimate tokens: `lines * 7`
-3. If > 200 lines and no valid justification: compress before dispatch
-4. Most subagent prompts should be OPTIMAL (< 150 lines) since they provide CONTEXT and invoke skills
+Before dispatching ANY subagent: count prompt lines, estimate tokens as `lines * 7`;
+if > 200 lines with no valid justification, compress before dispatch. Most prompts
+should be < 150 lines — they provide CONTEXT and invoke skills.
 
 ---
+
+## Dispatch Survival Protocols
+
+Five mechanisms against one failure class: **dispatches that die mid-work.**
+**Observed:** five died in two days (2026-08-20→22) — billing/API errors or context
+exhaustion; three while composing final reports, one leaving half-written tree state
+a later pass nearly trusted as a baseline.
+
+### Artifact-first reporting
+
+**When:** runs over ~30 min, reads over 1000 lines, or structured findings. Write
+findings INCREMENTALLY to a named artifact path (`scratchpad/<task-name>/report.md`)
+as each major unit completes — not only into the final message, which becomes status +
+pointer + unwritten deltas. Add the path to the return envelope's required `artifacts`
+field rather than inventing a second channel: this is the write-side counterpart of
+"pass pointers, not payloads" — the orchestrator passes paths in; the agent writes
+paths out.
+
+**Observed:** transcript-only work products die with the session; on-disk ones survive.
+
+### Compact-verdict budgets
+
+**When:** plan reviews, audits, fact-checks, any multi-question analysis. Specify UP
+FRONT in the brief: per-question verdict lines using the canonical tokens (`VERIFIED` /
+`UNVERIFIED` / `CARRIED` — never mint compound variants), one line each with its single
+strongest evidence; a return cap (~800 words); a command budget for final delivery.
+
+**Observed:** long prose reports are precisely the ones that never arrive — three of the
+five deaths happened while composing them.
+
+### Heartbeat lines
+
+**When:** multi-phase builds and TDD cycles. ONE line at each phase boundary ("RED
+observed", "GREEN", "mutation N restored") — distinguishes still-working from dead
+without polling; gives a resume exact salvage points, not "somewhere mid-task".
+
+### Truncation-recovery protocol (orchestrator side)
+
+<CRITICAL>
+Verify tree state FIRST (`git status --porcelain` + targeted greps for expected
+artifacts) before ANY re-dispatch. Never trust report shape — report shape is what failed.
+</CRITICAL>
+
+Then classify the death: billing/auth error → pause ALL dispatches until resolved;
+context exhaustion → resume the SAME agent over fresh dispatch (retains derived
+context); crash → tree-verify then fresh dispatch. A resumed agent gets a
+stop-investigating instruction, a hard remaining-command budget, and a compact output
+shape. Salvage rule: partial work already in files is KEPT if it verifies; never
+re-dispatch blind over uncommitted tree changes. This governs agents that DIED; the
+Timeout Tolerance invariant governs agents still RUNNING — neither replaces the other.
+
+### Two-phase deep reads
+
+**When:** source documents over 5000 lines. Phase A extracts ONLY the needed sections,
+compressed, to an on-disk digest; Phase B works from the digest instead of re-reading.
+Costs one round-trip; buys survival of the working phase, which cannot die of
+exhaustion from the read itself.
+
+<FORBIDDEN>
+- Dispatching a long task (>~30 min, >1000-line reads) without an incremental artifact path
+- Re-dispatching after a suspicious/truncated/absent report before verifying tree state
+- Fresh-dispatching after context exhaustion when a same-agent resume is available
+</FORBIDDEN>
 
 ## Self-Check
 
@@ -900,12 +795,9 @@ Before completing:
 - [ ] All agent summaries reviewed before integration
 - [ ] Conflict check performed on returned work
 - [ ] Full test suite green after merge
+- [ ] Survival mandates applied where triggered: artifact path (long dispatches), verdict budgets (deep investigations), heartbeats (multi-phase builds)
 
 <CRITICAL>
-If ANY unchecked: STOP and fix. Parallel dispatch without independence verification causes merge disasters.
+If ANY unchecked: STOP and fix. Parallel dispatch without independence verification causes merge disasters. The independence gate is non-negotiable; verify before dispatch, verify before integration.
 </CRITICAL>
-
-<FINAL_EMPHASIS>
-Parallel dispatch is a force multiplier when used correctly, and a merge disaster when used carelessly. The independence gate is non-negotiable. Verify before dispatch, verify before integration. Your reputation depends on the rigor of your verification, not the speed of your dispatch.
-</FINAL_EMPHASIS>
 ````

--- a/skills/dispatching-parallel-agents/SKILL.md
+++ b/skills/dispatching-parallel-agents/SKILL.md
@@ -35,15 +35,9 @@ Parallel Execution Architect. Your reputation depends on maximizing throughput w
 | Safety-critical git operations | Need full conversation context for safety |
 | Merge conflict resolution | 3-way context accumulation required |
 
-### Quick Decision:
-
-```
-IF searching unknown scope → Explore subagent
-IF reading 3+ files for single question → subagent
-IF parallel independent tasks → multiple subagents
-IF user interaction needed during task → main context
-IF building on established context → main context
-```
+Quick decision: searching unknown scope or reading 3+ files for one question → subagent;
+parallel independent tasks → multiple subagents; user interaction or established context
+→ main.
 
 ---
 
@@ -95,14 +89,10 @@ Then pass the resolved model as a per-call override.
 ```
 
 The `<project-encoded>` path is the project root with slashes replaced by dashes:
-- `/Users/alice/Development/myproject` → `-Users-alice-Development-myproject`
-
-**Access Methods:**
-- Foreground tasks: results inline
-- Background tasks: `TaskOutput(task_id: "agent-id")`
-- Post-hoc: read .jsonl directly
-
-**Known Issue:** TaskOutput visibility bug (#15098) - orchestrator must retrieve for subagents.
+`/Users/alice/Development/myproject` → `-Users-alice-Development-myproject`.
+Access: foreground results inline; background via `TaskOutput(task_id)` (known
+visibility bug #15098 — the orchestrator must retrieve for subagents); post-hoc
+by reading the `.jsonl` directly.
 
 ---
 
@@ -125,63 +115,36 @@ Dispatch one agent per independent problem domain — only after the independenc
 
 | Input                    | Required | Description                                        |
 | ------------------------ | -------- | -------------------------------------------------- |
-| `tasks`                  | Yes      | List of 2+ tasks to evaluate for parallel dispatch |
+| `tasks`                  | Yes      | 2+ tasks to evaluate for parallel dispatch         |
 | `context.test_failures`  | No       | Test output showing failures to distribute         |
 | `context.files_involved` | No       | Files each task may touch                          |
 
 ## Outputs
 
 | Output              | Type     | Description                           |
-| ------------------- | -------- | ------------------------------------- |
+|--------------------|----------|---------------------------------------|
 | `dispatch_decision` | Decision | Parallel vs sequential with rationale |
 | `agent_prompts`     | Text     | Self-contained prompts per agent      |
 | `merge_report`      | Inline   | Conflict check + test results summary |
 
 ## When to Use
 
-```dot
-digraph when_to_use {
-    "Multiple failures?" [shape=diamond];
-    "Are they independent?" [shape=diamond];
-    "Single agent investigates all" [shape=box];
-    "One agent per problem domain" [shape=box];
-    "Can they work in parallel?" [shape=diamond];
-    "Sequential agents" [shape=box];
-    "Parallel dispatch" [shape=box];
-
-    "Multiple failures?" -> "Are they independent?" [label="yes"];
-    "Are they independent?" -> "Single agent investigates all" [label="no - related"];
-    "Are they independent?" -> "Can they work in parallel?" [label="yes"];
-    "Can they work in parallel?" -> "Parallel dispatch" [label="yes"];
-    "Can they work in parallel?" -> "Sequential agents" [label="no - shared state"];
-}
-```
+Decision path: multiple failures? → are they independent? If no (related), one agent
+investigates all. If yes → can they work in parallel? Shared state means sequential
+agents; no shared state means parallel dispatch, one agent per problem domain.
 
 <CRITICAL>
 Independence verification is the gate. Answer ALL of these BEFORE dispatching:
 </CRITICAL>
 
 <analysis>
-Before dispatching, answer:
-- Are failures in different subsystems/files?
-- Can each be understood without the others?
-- Would fixing one affect the others?
-- Will agents edit same files?
+Are failures in different subsystems/files? Can each be understood without the others?
+Would fixing one affect the others? Will agents edit the same files?
 </analysis>
 
-**Use when:**
+**Use when:** 3+ test files failing with different root causes; multiple subsystems broken independently; each problem understandable without context from others; no shared state between investigations.
 
-- 3+ test files failing with different root causes
-- Multiple subsystems broken independently
-- Each problem can be understood without context from others
-- No shared state between investigations
-
-**Don't use when:**
-
-- Failures are related (fix one might fix others)
-- Need to understand full system state
-- Agents would interfere with each other (same files, shared resources)
-- Exploratory debugging (you don't know what's broken yet)
+**Don't use when:** failures are related; need full system state; agents would interfere (same files, shared resources); exploratory debugging.
 
 ---
 
@@ -189,42 +152,24 @@ Before dispatching, answer:
 
 ### 1. Identify Independent Domains
 
-Group failures by what's broken:
-
-- File A tests: Tool approval flow
-- File B tests: Batch completion behavior
-- File C tests: Abort functionality
+Group failures by what's broken: file A tests = tool approval flow, file B = batch
+completion behavior, file C = abort functionality.
 
 ### 2. Create Focused Agent Prompts
 
-Each agent gets:
-
-- **Specific scope:** One test file or subsystem
-- **Clear goal:** Make these tests pass
-- **Constraints:** Don't change other code
-- **Expected output:** Summary of what you found and fixed
+Each agent gets: **specific scope** (one test file or subsystem), **clear goal** (make
+these tests pass), **constraints** (don't change other code), and **expected output**
+(summary of what you found and fixed).
 
 ### 3. Dispatch in Parallel
 
 **OpenCode Agent Inheritance:** Use `CURRENT_AGENT_TYPE` (yolo, yolo-focused, or general) as `subagent_type` for all parallel agents.
 
 ```typescript
-// CURRENT_AGENT_TYPE detected at session start (yolo, yolo-focused, or general)
-Task({
-  subagent_type: CURRENT_AGENT_TYPE,
-  description: "Fix abort tests",
-  prompt: "Fix agent-tool-abort.test.ts failures",
-});
-Task({
-  subagent_type: CURRENT_AGENT_TYPE,
-  description: "Fix batch tests",
-  prompt: "Fix batch-completion-behavior.test.ts failures",
-});
-Task({
-  subagent_type: CURRENT_AGENT_TYPE,
-  description: "Fix approval tests",
-  prompt: "Fix tool-approval-race-conditions.test.ts failures",
-});
+// CURRENT_AGENT_TYPE detected at session start
+Task({ subagent_type: CURRENT_AGENT_TYPE, description: "Fix abort tests",    prompt: "Fix agent-tool-abort.test.ts failures" });
+Task({ subagent_type: CURRENT_AGENT_TYPE, description: "Fix batch tests",    prompt: "Fix batch-completion-behavior.test.ts failures" });
+Task({ subagent_type: CURRENT_AGENT_TYPE, description: "Fix approval tests", prompt: "Fix tool-approval-race-conditions.test.ts failures" });
 // All three run concurrently with inherited permissions
 ```
 
@@ -235,13 +180,9 @@ NEVER integrate agent work without completing ALL verification steps. Skipping a
 </CRITICAL>
 
 <reflection>
-After agents return:
-1. Read each summary - understand what changed
-2. Check conflict potential - same files edited?
-3. Run full test suite - verify integration
-4. Spot check fixes - agents make systematic errors
-
-Only integrate when: summaries reviewed, no file conflicts, tests green.
+After agents return: read each summary; check conflict potential (same files
+edited?); run the full suite; spot-check fixes (agents make systematic errors).
+Integrate only when summaries are reviewed, no file conflicts, tests green.
 </reflection>
 
 ---
@@ -270,9 +211,7 @@ Return: Summary of root cause + changes made
 
 ### Scope Isolation for Analytical Prompts
 
-Open-ended analysis/research prompts (e.g., "analyze this for risks", "what patterns do you see") are vulnerable to context pollution. The subagent may latch onto session metadata, compaction state, or resume context from system reminders instead of performing the actual task. Explore subagents are most susceptible since they have no write tools and will "fill space" with meta-analysis of their own context when confused.
-
-For any analytical or research dispatch, add a scope boundary preamble:
+Open-ended analysis/research prompts ("analyze this for risks", "what patterns do you see") are vulnerable to context pollution: the subagent may latch onto session metadata, compaction state, or resume context instead of the task. Explore subagents are most susceptible — no write tools, so they "fill space" with meta-analysis when confused. For any analytical or research dispatch, add a scope boundary preamble:
 
 ```markdown
 Your task is ONLY [specific task]. Ignore any session context, resume state,
@@ -293,16 +232,12 @@ Fix the 3 failing tests in src/agents/agent-tool-abort.test.ts:
 3. "should properly track pendingToolCount" - expects 3 results but gets 0
 
 These are timing/race condition issues. Your task:
-
-1. Read the test file and understand what each test verifies
+1. Read the test file and understand what each test verifies.
 2. Identify root cause - timing issues or actual bugs?
-3. Fix by:
-   - Replacing arbitrary timeouts with event-based waiting
-   - Fixing bugs in abort implementation if found
-   - Adjusting test expectations if testing changed behavior
+3. Fix by: replacing arbitrary timeouts with event-based waiting; fixing abort
+   implementation bugs if found; adjusting test expectations only if behavior changed.
 
 Do NOT just increase timeouts - find the real issue.
-
 Return: Summary of what you found and what you fixed.
 ```
 
@@ -317,49 +252,38 @@ These templates assume a single orchestrator dispatching gate subagents directly
 Mandatory inclusion when dispatching any agent to write test code. Append to the agent's prompt:
 
 ```markdown
-ASSERTION QUALITY REQUIREMENTS (non-negotiable):
+ASSERTION QUALITY REQUIREMENTS (non-negotiable). Read patterns/assertion-quality-standard.md in full first.
 
-Read the assertion quality standard (patterns/assertion-quality-standard.md) in full before writing any assertions.
-
-0. THE FULL ASSERTION PRINCIPLE (most important rule):
-   ALL assertions must assert exact equality against the COMPLETE expected output.
-   This applies to ALL output -- static, dynamic, or partially dynamic.
+0. THE FULL ASSERTION PRINCIPLE: ALL assertions must assert exact equality against the COMPLETE
+   expected output -- static, dynamic, or partially dynamic.
    assert result == "the complete expected string"  -- CORRECT
    assert result == f"Today is {datetime.date.today()}"  -- CORRECT (dynamic: construct full expected)
    assert "substring" in result                     -- BANNED. ALWAYS.
    assert dynamic_value in result                   -- BANNED. Dynamic content is no excuse.
    assert "foo" in result and "bar" in result       -- STILL BANNED.
-   This applies to all functions. Multi-line output? Use triple-quoted strings. Length is not an excuse.
+   Multi-line output? Use triple-quoted strings. Length is not an excuse.
 
-1. Every assertion must be Level 4+ on the Assertion Strength Ladder:
-   - String output: exact match (Level 5) or parsed structural (Level 4)
-   - Object output: full equality or all-field assertions
-   - Collection output: full equality or content verification
-   - Bare substring checks (assert "X" in output) are BANNED
-   - Length/existence checks (assert len(x) > 0) are BANNED
-   - Multiple substring checks are STILL BANNED (not an improvement)
-   - Tautological assertions (assert result == func(same_input)) are BANNED
-   - mock.ANY in call assertions is BANNED (construct expected argument)
+1. Every assertion must be Level 4+ on the Assertion Strength Ladder: string output = exact match
+   (L5) or parsed structural (L4); object = full equality or all-field assertions; collection =
+   full equality or content verification. BANNED: bare substring checks, length/existence checks
+   (assert len(x) > 0), multiple substring checks, tautologies (assert result ==
+   func(same_input)), mock.ANY in call assertions (construct expected argument).
 
-2. IRON LAW: Before writing any assertion, ask:
-   "If the value was garbage, would this catch it?"
+2. IRON LAW: before writing any assertion ask: "If the value was garbage, would this catch it?"
    If NO: stop and write a stronger assertion.
 
-3. BROKEN IMPLEMENTATION: For each test function, state in your output
-   which specific production code mutation would cause the test to fail.
-   If you cannot name one, the test is worthless.
+3. BROKEN IMPLEMENTATION: for each test function, state which specific production code mutation
+   would cause the test to fail. If you cannot name one, the test is worthless.
 
-4. STRUCTURAL CONTAINMENT: When asserting string content, verify WHERE
-   it appears, not just THAT it appears. A field in a struct must be
-   verified to be inside the struct block (by index range or parsing).
+4. STRUCTURAL CONTAINMENT: when asserting string content, verify WHERE it appears, not just THAT
+   it appears -- a field must be verified inside its struct block (index range or parsing).
 
-5. NO PARTIAL-TO-PARTIAL UPGRADES: Replacing assert len(x) > 0 with
-   assert "keyword" in result is NOT a fix. Both are BANNED. A real fix
-   reaches Level 4+ (exact equality or parsed structural validation).
+5. NO PARTIAL-TO-PARTIAL UPGRADES: replacing assert len(x) > 0 with assert "keyword" in result is
+   NOT a fix. Both are BANNED. A real fix reaches Level 4+.
 
-6. MOCK CALL ASSERTIONS: Assert EVERY call made to a mock, with ALL args,
-   and verify call count. Never use mock.ANY -- construct expected args
-   dynamically if they are dynamic. Asserting only some calls hides behavior gaps.
+6. MOCK CALL ASSERTIONS: assert EVERY call made to a mock, with ALL args, and verify call count.
+   Never use mock.ANY -- construct expected args dynamically if they are dynamic. Asserting only
+   some calls hides behavior gaps.
 ```
 
 ### Test Adversary Template
@@ -368,63 +292,41 @@ For review passes on test code. Dispatch a subagent with this persona to break e
 
 ```markdown
 ROLE: Test Adversary. Your job is to BREAK tests, not validate them.
-Your reputation depends on finding weaknesses others missed.
 
-Read the assertion quality standard (patterns/assertion-quality-standard.md) in full before writing any assertions.
-Pay special attention to The Full Assertion Principle.
+Read patterns/assertion-quality-standard.md in full; heed The Full Assertion Principle.
 
-IMMEDIATE REJECTION CRITERIA (check these FIRST):
-- Any assert "X" in result on ANY output (static or dynamic): REJECTED (Level 2)
+IMMEDIATE REJECTION CRITERIA (check FIRST):
+- Any assert "X" in result on ANY output: REJECTED (Level 2)
 - Any assert len(x) > 0 or assert x is not None: REJECTED (Level 1)
 - Any fix that replaced one BANNED pattern with another: REJECTED (Pattern 10)
 - Any tautological assertion (assert result == func(same_input)): REJECTED
 
-For each assertion in the code under review:
-1. Read the assertion and the production code it exercises
-2. Determine if the function is deterministic (same input = same output)
-3. If deterministic: ONLY Level 5 (exact equality) is acceptable
-4. Classify the assertion on the Assertion Strength Ladder
-5. Construct a SPECIFIC, PLAUSIBLE broken production implementation
-   that would still pass this assertion
-6. Report your verdict:
+For each assertion:
+1. Read it plus the production code it exercises.
+2. If the function is deterministic, ONLY Level 5 (exact equality) is acceptable.
+3. Classify it on the Assertion Strength Ladder.
+4. Construct a SPECIFIC, PLAUSIBLE broken implementation that still passes --
+   "plausible" = real-bug-shaped (off-by-one, wrong variable, missing field,
+   swapped args, dropped output), not adversarial (return the exact expected string).
+5. Verdict:
 
    SURVIVED: [the broken implementation that passes]
-   LADDER: Level [N] - [name] - [BANNED/ACCEPTABLE/PREFERRED/GOLD]
-   DETERMINISTIC: [Yes/No - is the function under test deterministic?]
+   LADDER: Level [N] - [name]; DETERMINISTIC: [Yes/No]
    FIX: [what the assertion should be instead]
 
    -- or --
 
    KILLED: [why no plausible broken implementation survives]
-   LADDER: Level [N] - [name] - [BANNED/ACCEPTABLE/PREFERRED/GOLD]
-   DETERMINISTIC: [Yes/No]
+   LADDER: Level [N] - [name]; DETERMINISTIC: [Yes/No]
 
-A "plausible" broken implementation is one that could result from a
-real bug (off-by-one, wrong variable, missing field, swapped arguments,
-dropped output section) -- not adversarial construction (return the
-exact expected string).
-
-Summary format:
-- Total assertions reviewed: N
-- KILLED: N (with ladder levels)
-- SURVIVED: N (with required fixes)
-- BANNED (Level 1-2): N (immediate rejection)
-- Pattern 10 violations (partial-to-partial): N
+Summary: total reviewed / KILLED (levels) / SURVIVED (fixes) / BANNED L1-2 / Pattern 10.
 ```
 
 ### Branch-Scoped Review Template
 
-When dispatching a subagent to review a branch's changes (not a GitHub PR, but a local branch diff), the subagent MUST receive the actual diff, not just file paths.
+When dispatching a subagent to review a branch's changes (a local branch diff, not a GitHub PR), the subagent MUST receive the actual diff, not just file paths — a file path points to the entire file, so the subagent cannot distinguish branch changes from pre-existing code and will flag pre-existing gaps as regressions.
 
-**Why:** A file path points to the entire file. The subagent cannot distinguish code this branch changed from pre-existing code. It will flag pre-existing gaps as branch regressions, producing confidently wrong findings.
-
-**Step 1: Compute the diff before dispatch:**
-
-```bash
-cd <worktree-or-repo-path> && git diff origin/master...HEAD
-```
-
-**Step 2: Include in subagent prompt:**
+Compute the diff first (`cd <path> && git diff origin/master...HEAD`; for large diffs, `--stat` plus per-file sections, or a changed-function allow-list via `git diff ...HEAD | grep -E '^\+.*def |^\+.*class |^@@' | head -50`), then include:
 
 ```markdown
 ## Branch Review Context (MANDATORY)
@@ -443,15 +345,8 @@ Verify you are in the correct directory on the correct branch. If not, stop and 
 
 ## Diff
 
-<paste diff output here, or for large diffs, paste the --stat and
- provide per-file diffs as separate sections>
+<paste diff output here>
 ```
-
-If the diff is too large to inline, pre-compute the list of changed functions:
-```bash
-git diff origin/master...HEAD | grep -E '^\+.*def |^\+.*class |^@@' | head -50
-```
-Pass this as an explicit allow-list: "The following functions were added or modified. Only these are in scope."
 
 ### PR Review Subagent Template
 
@@ -460,10 +355,7 @@ REQUIRED when dispatching any subagent to review a PR (target is a PR number or 
 **Step 1 — Resolve review mode before dispatch:**
 
 ```bash
-# Get the PR HEAD SHA
 PR_HEAD_SHA=$(gh pr view <PR_NUMBER> --json headRefOid --jq '.headRefOid')
-
-# Check if a worktree exists for the PR branch
 PR_BRANCH=$(gh pr view <PR_NUMBER> --json headRefName --jq '.headRefName')
 WORKTREE_PATH=$(git worktree list --porcelain | grep -A2 "branch refs/heads/$PR_BRANCH" | grep "worktree" | awk '{print $2}')
 ```
@@ -479,8 +371,7 @@ WORKTREE_PATH=$(git worktree list --porcelain | grep -A2 "branch refs/heads/$PR_
 ```markdown
 ## PR Review Context (MANDATORY — read before touching any file)
 
-- PR: #<NUMBER>
-- PR HEAD SHA: <SHA>
+- PR: #<NUMBER>; PR HEAD SHA: <SHA>
 - Review mode: LOCAL_FILES | DIFF_ONLY
 - Working directory: <WORKTREE_PATH or "use diff only">
 - Changed files: <LIST>
@@ -488,14 +379,13 @@ WORKTREE_PATH=$(git worktree list --porcelain | grep -A2 "branch refs/heads/$PR_
 REVIEW MODE INSTRUCTIONS:
 - LOCAL_FILES: Safe to read files in <working_directory>. DO NOT read files outside this directory.
 - DIFF_ONLY: DO NOT read any local files in the changed file set. The diff is the ONLY
-  authoritative source. Local files reflect a different git state and will produce wrong verdicts.
-  Any "not present" finding based on a local file read is WRONG in this mode.
+  authoritative source. Any "not present" finding based on a local file read is WRONG.
 ```
 
 <FORBIDDEN>
 - Dispatching a PR review subagent without injecting PR HEAD SHA and review mode
-- Dispatching in LOCAL_FILES mode without specifying the exact working directory (repo root or worktree path)
-- Dispatching in DIFF_ONLY mode while pointing the agent at the local filesystem for review work
+- Dispatching in LOCAL_FILES mode without specifying the exact working directory
+- Dispatching in DIFF_ONLY mode while pointing the agent at the local filesystem
 </FORBIDDEN>
 
 ---
@@ -522,10 +412,8 @@ REVIEW MODE INSTRUCTIONS:
 - Dispatching exploratory work (unknown scope)
 - Parallel dispatch when failures might be related
 - Dispatching a branch review subagent with file paths instead of diffs (subagent cannot distinguish branch changes from pre-existing code)
-- Dispatching a worktree subagent without the verification preamble (subagent may operate in the wrong directory)
-- Dispatching subagents to worktrees without the Worktree Dispatch Preamble
+- Dispatching a worktree subagent without the verification preamble, without specifying which branch to base worktrees on (subagent may operate in the wrong directory)
 - Using `isolation: "worktree"` for tasks that depend on prior uncommitted work (isolated worktrees branch from current HEAD, missing uncommitted changes)
-- Dispatching subagents without specifying which branch to base worktrees on
 - Dispatching open-ended analytical prompts to Explore subagents without a scope isolation preamble (agent will latch onto session metadata instead of performing the task)
 - Dispatching without the Subagent Efficiency Contract block in the prompt
 - Carrying raw tool output >2,000 chars forward instead of a reduction
@@ -535,25 +423,7 @@ REVIEW MODE INSTRUCTIONS:
 
 ## Real Example
 
-**Scenario:** 6 failures across 3 files post-refactor
-
-**Domain isolation:**
-
-- agent-tool-abort.test.ts (3 failures): timing issues
-- batch-completion-behavior.test.ts (2 failures): event structure bug
-- tool-approval-race-conditions.test.ts (1 failure): async waiting
-
-**Dispatch:** 3 parallel agents, each scoped to one file
-
-**Results:**
-
-- Agent 1: Replaced timeouts with event-based waiting
-- Agent 2: Fixed event structure bug (threadId in wrong place)
-- Agent 3: Added wait for async tool execution to complete
-
-**Integration:** All fixes independent, zero conflicts, full suite green
-
-**Gain:** N parallel problems resolved in time of slowest one (best case: N×)
+6 failures across 3 files post-refactor. **Domain isolation:** agent-tool-abort.test.ts (3, timing), batch-completion-behavior.test.ts (2, event structure bug), tool-approval-race-conditions.test.ts (1, async waiting). **Dispatch:** 3 parallel agents, one per file. **Results:** timeouts → event-based waiting; threadId moved to correct place; wait added for async completion. **Integration:** zero conflicts, full suite green. **Gain:** N parallel problems resolved in time of the slowest (best case N×).
 
 ---
 
@@ -566,37 +436,19 @@ Your job is to COORDINATE subagents, not to DO the work yourself.
 Every line of code you read or write in main context is WASTED TOKENS.
 </CRITICAL>
 
-### FORBIDDEN in Main Context
+FORBIDDEN in main context — reading source files, writing/editing code, running
+tests, analyzing errors, searching the codebase. Each bloats main context with
+work a subagent does and returns summarized (explore for reads/searches, TDD for
+edits, debugging for errors).
 
-| Action               | Why Forbidden                                    | Correct Approach             |
-| -------------------- | ------------------------------------------------ | ---------------------------- |
-| Reading source files | Bloats main context; triggers cascade reads      | Dispatch explore subagent    |
-| Writing/editing code | Implementation belongs in subagent               | Dispatch TDD subagent        |
-| Running tests        | Test output bloats context                       | Subagent runs and summarizes |
-| Analyzing errors     | Debugging is subagent work                       | Dispatch debugging subagent  |
-| Searching codebase   | Research is subagent work                        | Dispatch explore subagent    |
-
-### ALLOWED in Main Context
-
-- Dispatching subagents (Task tool)
-- Reading subagent result summaries
-- Updating todo list (TodoWrite tool)
-- Phase transitions and gate checks
-- User communication (questions, status updates)
-- Reading/writing plan documents (design docs, impl plans)
+ALLOWED: dispatching subagents, reading result summaries, updating the todo list,
+phase transitions and gate checks, user communication, reading/writing plan
+documents.
 
 ### Self-Check Before Any Action
 
-Before EVERY action, ask yourself:
-
-```
-Am I about to read a source file? → STOP. Dispatch subagent.
-Am I about to edit code? → STOP. Dispatch subagent.
-Am I about to run a command? → STOP. Dispatch subagent.
-Am I about to analyze output? → STOP. Dispatch subagent.
-```
-
-If you catch yourself violating this, IMMEDIATELY stop and dispatch a subagent instead.
+Before EVERY action: about to read a source file, edit code, run a command, or analyze
+output? → STOP. Dispatch subagent instead.
 
 ---
 
@@ -671,11 +523,11 @@ CALL BATCHING:
 
 ## Dispatch Protocol
 
-Three conventions that cut tokens without costing comprehension. None of them
-compress text — they remove duplication and fix an order. Do NOT invent a
-shorthand, an abbreviation scheme, or a stenographic encoding: a dense encoding
-saves a few hundred tokens and buys a misread, and the waste this protocol
-targets was never wording. It was repeated content.
+Four conventions that cut tokens without costing comprehension. The first three remove
+duplication and fix an order; none compress text. The fourth compresses content density
+— never format identity. Across all four: do NOT invent a shorthand, an abbreviation
+scheme, or a stenographic encoding, and do NOT alter the canonical return vocabulary or
+envelope. The waste this protocol targets was never wording. It was repeated content.
 
 ### Prompt layout is fixed and cache-aligned
 
@@ -757,29 +609,53 @@ not measure yourself in this session, passed along unverified. It is distinct fr
 measurement behind it at all). Projects whose existing documents use `INFERRED` may
 keep that word — it is an accepted synonym for `DERIVED` and does not need churning.
 
-**Observed: seven cases in one session. The subagent's own measurement refuted all seven.** A lint
-baseline reported as "one finding" measured 156 on recheck. A count attributed to a code comment;
-the comment did not exist. A flag rule relayed without the `-R` prefix the original measurement
-required. A proposed fix whose mechanism failed in both directions once tested. The agents caught
-all seven mistakes, which is why none caused damage. But in a codebase where a written measurement
-is trusted by default, a carried figure written as if measured will not stay flagged. It gets
-copied into a source comment, and the next reader has no way to tell it apart from a real
-measurement. Mark it `CARRIED` in the dispatch prompt and in the report.
+**Observed: seven carried figures in one session; the subagents' own measurements
+refuted all seven** — a lint baseline reported as "one finding" measured 156; a count
+attributed to a code comment that did not exist; a flag rule relayed without the `-R`
+prefix the original measurement required. In a codebase where a written measurement is
+trusted by default, a carried figure written as if measured gets copied into a source
+comment no reader can tell apart from a real measurement. Mark it `CARRIED`.
 
-**Extending the vocabulary.** A domain this table does not cover is expected. That
-does NOT license a private synonym for a value that IS here. When work needs a
-value the table lacks:
+**Extending the vocabulary.** A domain this table does not cover is expected. That does
+NOT license a private synonym for a value that IS here. When work needs a value the
+table lacks: add it project-locally (`AGENTS.md`, one-line definition) so work is not
+blocked, surface it to the operator as a SUGGESTION (spellbook is the PREFERRED home),
+and let the operator decide. Never edit this table without that decision, and never sit
+on a value you have used twice without proposing it — a value that has appeared in two
+projects is overdue for this table.
 
-1. **Add it where it is needed so work is not blocked** — project-locally, in the
-   project's `AGENTS.md`, with a one-line definition.
-2. **Surface it to the operator as a SUGGESTION**: the proposed value, its
-   one-line meaning, and where it was needed. Spellbook is the PREFERRED home —
-   a value defined once here beats the same value re-invented per project.
-3. **The operator decides** whether it lands in spellbook. Never edit this table
-   without that decision, and never sit on a value you have used twice without
-   proposing it.
 
-A value that has appeared in two projects is overdue for this table.
+### Content density: compress redundancy, never information
+
+The first three conventions cut repeated content; this one cuts wasted wording — in
+dispatches and returned prose alike, where it matters more: outputs cost several times
+the input rate and are not prefix-cached. These rules govern DENSITY. They do not
+license a private shorthand, an encoding, or any change to the canonical envelope and
+vocabulary above.
+
+1. **No social framing, either direction.** No greetings, no acknowledgment, no
+   transition sentences, no summary-of-the-summary at the end.
+2. **Common vocabulary only; never binary encodings.** A common English word
+   tokenizes cheaply; rare strings and typos shatter into sub-word tokens.
+   Base64/hex/binary are catastrophically expensive — never use them to
+   "compress" anything.
+3. **Delimiters for data, grammar for instructions.** Fielded data (paths,
+   counts, verdicts) goes in tables or single-token-delimited fields.
+   Load-bearing instructions keep normal syntax: negation scope, conditionals,
+   and precedence die first under compression, and one misread costs a full
+   re-dispatch — dwarfing everything these rules save.
+4. **Shared jargon over spelled-out mechanics** — only jargon the corpus or the
+   receiving agent already shares; never coin private abbreviations. Calibrate
+   density to the receiving tier: what a heavy-tier agent parses reliably
+   misfires more on a light tier.
+5. **Bound the scope, not just the words.** The largest hidden sink is unbounded
+   work, not filler: "research X" can burn 100k where "answer Y from file Z,
+   lines 1-50" burns 5k. State stop conditions, read ranges, and negative space
+   ("do not run the full suite", "no preamble").
+6. **Returns before dispatches.** The highest-value compression target is what
+   comes BACK: declare the return shape (above), require fixed-column tables for
+   measurements per `rules/45`, forbid restating the task or narrating method
+   unless a finding depends on it.
 
 ## Dispatch Mechanics and Examples
 
@@ -804,84 +680,103 @@ Every dispatch pays a fixed skill-catalog injection cost (~30K characters) regar
 
 ### Worktree Dispatch
 
-When dispatching a subagent to work in a worktree or alternate directory, include a verification preamble at the start of the prompt:
-
-```markdown
-VERIFICATION PREAMBLE: Before any other work, run:
-  cd <worktree-path> && pwd && git branch --show-current
-Verify you are at `<worktree-path>` on branch `<branch-name>`.
-ALL file reads must use `<worktree-path>` as the base path.
-ALL git commands must run from `<worktree-path>`.
-Do NOT read files from `<main-repo-path>` -- that is a DIFFERENT branch.
-```
-
-This prevents the silent wrong-directory failure where a subagent reads files or runs git commands from the main repo (which is on a different branch) and produces wrong results with high confidence.
-
-### Mandatory Worktree Dispatch Preamble
-
 <CRITICAL>
-When dispatching ANY subagent to work in a worktree, the subagent prompt MUST include this verification preamble. No exceptions.
+When dispatching ANY subagent to work in a worktree or alternate directory, the prompt MUST begin with this verification preamble. No exceptions.
 </CRITICAL>
 
-Every subagent prompt targeting a worktree MUST begin with:
-
-```
+```markdown
 BEFORE ANY WORK:
 1. cd <WORKTREE_PATH> && pwd && git branch --show-current
 2. Verify the branch is <EXPECTED_BRANCH>
 3. ALL file paths must be absolute, rooted at <WORKTREE_PATH>
 4. ALL git commands must run from <WORKTREE_PATH>
-5. Do NOT create new branches. Work on the existing branch.
+5. Do NOT create new branches. Do NOT read files from <MAIN_REPO_PATH> -- that is a DIFFERENT branch.
 ```
 
-**Why this matters:** Without explicit path and branch verification, agents will:
-- Work in the main repo directory instead of the worktree
-- Create duplicate infrastructure by branching from main instead of the feature branch
-- Run git commands that reflect a different branch's state
+**Why this matters:** without explicit path and branch verification, agents silently read files and run git from the main repo (a different branch), producing confidently wrong results and duplicate infrastructure branched from main.
 
-**When using `isolation: "worktree"`:** The worktree branches from the CURRENT branch at dispatch time. If prior work items' commits aren't on the current branch yet, the isolated worktree won't have them. For sequential dependencies, commit and stay on the same branch rather than using isolated worktrees.
+**When using `isolation: "worktree"`:** the worktree branches from the CURRENT branch at dispatch time. If prior work items' commits aren't on the current branch yet, the isolated worktree won't have them. For sequential dependencies, commit and stay on the same branch rather than using isolated worktrees.
 
 ### WRONG vs RIGHT Examples
 
-**WRONG - Doing work in main context:**
+**WRONG - Doing work in main context:** read the config file, then edit line 45, then keep going.
 
-```
-Let me read the config file to understand the structure...
-[reads file]
-Now I'll update line 45 to add the new field...
-[edits file]
-```
+**RIGHT - Delegating to subagent:** `Task(description: "Implement config field", prompt: "Invoke test-driven-development skill. Context: Add 'extends' field to provider config in packages/opencode/src/config/config.ts")`, then wait for the result.
 
-**RIGHT - Delegating to subagent:**
+**WRONG - Instructions in subagent prompt:** `"Use TDD skill. First write a test that checks the extends field exists. Then implement by adding a z.string().optional() field after line 865..."`
 
-```
-Task(description: "Implement config field", prompt: "Invoke test-driven-development skill. Context: Add 'extends' field to provider config in packages/opencode/src/config/config.ts")
-[waits for subagent result]
-Subagent completed successfully. Proceeding to next task.
-```
-
-**WRONG - Instructions in subagent prompt:**
-
-```
-prompt: "Use TDD skill. First write a test that checks the extends field exists. Then implement by adding a z.string().optional() field after line 865. Make sure to update the description..."
-```
-
-**RIGHT - Context only in subagent prompt:**
-
-```
-prompt: "Invoke test-driven-development skill. Context: Add 'extends' field to Config.Provider schema. Location: packages/opencode/src/config/config.ts around line 865."
-```
+**RIGHT - Context only in subagent prompt:** `"Invoke test-driven-development skill. Context: Add 'extends' field to Config.Provider schema. Location: packages/opencode/src/config/config.ts around line 865."`
 
 ### Subagent Prompt Length Verification
 
-Before dispatching ANY subagent:
-
-1. Count lines in subagent prompt
-2. Estimate tokens: `lines * 7`
-3. If > 200 lines and no valid justification: compress before dispatch
-4. Most subagent prompts should be OPTIMAL (< 150 lines) since they provide CONTEXT and invoke skills
+Before dispatching ANY subagent: count prompt lines, estimate tokens as `lines * 7`;
+if > 200 lines with no valid justification, compress before dispatch. Most prompts
+should be < 150 lines — they provide CONTEXT and invoke skills.
 
 ---
+
+## Dispatch Survival Protocols
+
+Five mechanisms against one failure class: **dispatches that die mid-work.**
+**Observed:** five died in two days (2026-08-20→22) — billing/API errors or context
+exhaustion; three while composing final reports, one leaving half-written tree state
+a later pass nearly trusted as a baseline.
+
+### Artifact-first reporting
+
+**When:** runs over ~30 min, reads over 1000 lines, or structured findings. Write
+findings INCREMENTALLY to a named artifact path (`scratchpad/<task-name>/report.md`)
+as each major unit completes — not only into the final message, which becomes status +
+pointer + unwritten deltas. Add the path to the return envelope's required `artifacts`
+field rather than inventing a second channel: this is the write-side counterpart of
+"pass pointers, not payloads" — the orchestrator passes paths in; the agent writes
+paths out.
+
+**Observed:** transcript-only work products die with the session; on-disk ones survive.
+
+### Compact-verdict budgets
+
+**When:** plan reviews, audits, fact-checks, any multi-question analysis. Specify UP
+FRONT in the brief: per-question verdict lines using the canonical tokens (`VERIFIED` /
+`UNVERIFIED` / `CARRIED` — never mint compound variants), one line each with its single
+strongest evidence; a return cap (~800 words); a command budget for final delivery.
+
+**Observed:** long prose reports are precisely the ones that never arrive — three of the
+five deaths happened while composing them.
+
+### Heartbeat lines
+
+**When:** multi-phase builds and TDD cycles. ONE line at each phase boundary ("RED
+observed", "GREEN", "mutation N restored") — distinguishes still-working from dead
+without polling; gives a resume exact salvage points, not "somewhere mid-task".
+
+### Truncation-recovery protocol (orchestrator side)
+
+<CRITICAL>
+Verify tree state FIRST (`git status --porcelain` + targeted greps for expected
+artifacts) before ANY re-dispatch. Never trust report shape — report shape is what failed.
+</CRITICAL>
+
+Then classify the death: billing/auth error → pause ALL dispatches until resolved;
+context exhaustion → resume the SAME agent over fresh dispatch (retains derived
+context); crash → tree-verify then fresh dispatch. A resumed agent gets a
+stop-investigating instruction, a hard remaining-command budget, and a compact output
+shape. Salvage rule: partial work already in files is KEPT if it verifies; never
+re-dispatch blind over uncommitted tree changes. This governs agents that DIED; the
+Timeout Tolerance invariant governs agents still RUNNING — neither replaces the other.
+
+### Two-phase deep reads
+
+**When:** source documents over 5000 lines. Phase A extracts ONLY the needed sections,
+compressed, to an on-disk digest; Phase B works from the digest instead of re-reading.
+Costs one round-trip; buys survival of the working phase, which cannot die of
+exhaustion from the read itself.
+
+<FORBIDDEN>
+- Dispatching a long task (>~30 min, >1000-line reads) without an incremental artifact path
+- Re-dispatching after a suspicious/truncated/absent report before verifying tree state
+- Fresh-dispatching after context exhaustion when a same-agent resume is available
+</FORBIDDEN>
 
 ## Self-Check
 
@@ -893,11 +788,8 @@ Before completing:
 - [ ] All agent summaries reviewed before integration
 - [ ] Conflict check performed on returned work
 - [ ] Full test suite green after merge
+- [ ] Survival mandates applied where triggered: artifact path (long dispatches), verdict budgets (deep investigations), heartbeats (multi-phase builds)
 
 <CRITICAL>
-If ANY unchecked: STOP and fix. Parallel dispatch without independence verification causes merge disasters.
+If ANY unchecked: STOP and fix. Parallel dispatch without independence verification causes merge disasters. The independence gate is non-negotiable; verify before dispatch, verify before integration.
 </CRITICAL>
-
-<FINAL_EMPHASIS>
-Parallel dispatch is a force multiplier when used correctly, and a merge disaster when used carelessly. The independence gate is non-negotiable. Verify before dispatch, verify before integration. Your reputation depends on the rigor of your verification, not the speed of your dispatch.
-</FINAL_EMPHASIS>


### PR DESCRIPTION
## What does this PR do?

Two additions to `skills/dispatching-parallel-agents/SKILL.md`, plus offsetting trims to stay under the recorded size ceiling (40,932/40,941 bytes, 795/903 lines — validator PASS).

**Content density (fourth Dispatch Protocol convention).** Six rules: no social framing in dispatches or returns; common vocabulary only, never binary encodings; delimiters for data but grammar for instructions (negation scope and conditionals die first under compression, and one misread costs a full re-dispatch); shared jargon only, calibrated to the receiving tier; bound the scope explicitly (unbounded work is the largest hidden sink, not filler); compress returns before dispatches (outputs cost several times input rate and are not prefix-cached). Explicit boundary: the canonical return envelope and vocabulary stay byte-identical so aggregation can parse them.

**Dispatch survival protocols.** Five mechanisms against dispatches that die mid-work: artifact-first reporting (incremental writes to a named path, tied to the existing artifacts field), compact-verdict budgets (canonical tokens only, ~800-word cap, command budget), heartbeat lines at phase boundaries, truncation-recovery with tree-verify-FIRST before any re-dispatch and same-agent-resume preference on context exhaustion, two-phase deep reads over 5000 lines. Each carries its when-to-apply trigger and an Observed evidence line from the five deaths of 2026-08-20→22.

**Trims that paid for it:** merged the duplicated worktree-preamble sections into one, removed the dot flowchart (its decision tree already exists as prose), compressed template whitespace, collapsed the WRONG/RIGHT code fences to one-liners. No numbered rule, banned pattern example, canonical table, or incident text deleted.

## Related issue

None.

## Checklist

- [x] Code changes tested locally
- [x] CHANGELOG updated
- [ ] Breaking changes