### PR TITLE
Add joint-acceptance work-item granularity rule to plan skills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -182,6 +182,8 @@ Any changes to shell scripts (`.sh` files in `hooks/`, `scripts/`, or elsewhere)
 
 **Commands**: Create `commands/<name>.md` with `description` frontmatter. Hooks generate docs.
 
+Regenerating the `docs/` mirror is a required, normal part of any change to `skills/`, `commands/`, `agents/`, or `rules/` — not scope creep. After such an edit, run `uv run scripts/generate_docs.py` and commit the regenerated `docs/` pages in the SAME commit as the source. The blocking `generate-docs` pre-commit hook checks freshness, so a commit that omits the regenerated pages fails; the extra generated files are the deterministic product of your source change, never an out-of-scope addition.
+
 ## Adding Config Options
 
 <CRITICAL>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   record with the philosophy that was active at the moment each was made, copied in
   rather than joined later -- the active philosophy can change mid-session, and a
   late join would reattribute every earlier decision to whatever was chosen last.
+- A joint-acceptance work-item granularity rule in the plan skills. `writing-plans`
+  gains a "Work-Item Granularity (Revert Test)": work is not split below its
+  joint-acceptance boundary -- a cluster whose members have no meaningful,
+  behavior-level `Check:` when their siblings are reverted is one work item, not
+  several. `review-plan-completeness` gains a mirrored "Cluster Collapse Check" as a
+  backstop. The rule is un-gated across every `task_granularity` mode, anchors
+  strictly on joint acceptance rather than on shared files, shared setup, or size,
+  and distinguishes a joint deliverable -- members that only earn a check together
+  -- from a layered `Depends:` prerequisite, which keeps its own check and stays a
+  separate item.
+- A "Research backing" section in the README and an expanded
+  `docs/reference/citations.md`, documenting where independent research supports
+  spellbook's existing ceremonies: green-mirage and reward-hacking, mutation as a
+  measure of check strength, constrained orchestration, acceptance-boundary
+  granularity, and spec-before-code. The ceremonies were not derived from the
+  research; the citations record that the two converged.
+- An AGENTS.md note clarifying that regenerating the `docs/` mirror is required,
+  normal work rather than scope creep, and is enforced by the `generate-docs`
+  pre-commit hook -- so a diff that touches source and its regenerated mirror
+  together is expected, not a sign the change overreached.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@
 - [Development](#development)
   - [Serve Documentation Locally](#serve-documentation-locally)
   - [Run MCP Server Directly](#run-mcp-server-directly)
+- [Research backing](#research-backing)
 - [Documentation](#documentation)
 - [Contributing](#contributing)
 - [Acknowledgments](#acknowledgments)
@@ -956,6 +957,18 @@ claude mcp add --transport http spellbook http://127.0.0.1:8765/mcp
 ```
 
 This runs a single MCP server instance that all sessions connect to via HTTP.
+
+## Research backing
+
+Spellbook's ceremonies grew from practice, not from the literature — but independent research supports many of them. Where that research is real and on point:
+
+- **The "green mirage" — tests that pass without verifying behavior.** Spellbook's green-mirage audit asks of every test, *would this fail if the code were broken?* This is the coding face of *reward hacking* / *specification gaming*, a documented failure mode where an agent satisfies the literal metric without the intended outcome (Amodei et al., *Concrete Problems in AI Safety*, arXiv:1606.06565; Krakovna et al., DeepMind, *Specification gaming*, 2020). It's not hypothetical: an audit found a material share of SWE-bench patches pass their tests yet are wrong or incomplete (*SWE-Bench+*, arXiv:2410.06992 — 9.26% incorrect / 5.56% incomplete on Lite; 12.5% / 9.82% on Verified), and mutation analysis found 77% of SWE-bench Verified instances admit a surviving mutant (arXiv:2604.01518).
+- **Mutation as the measure of a test's strength.** Spellbook's TDD rule — every assertion names the mutation it kills, and no check counts until it has gone red on deliberately broken code — is mutation testing, established since the late 1970s (DeMillo, Lipton & Sayward, 1978; framework: Stryker). A test that still passes when the code is broken proves nothing.
+- **Constrained beats unconstrained autonomy.** Spellbook runs one orchestrator dispatching narrowly-scoped subagents, each with only its local context, the reviewer never the author. Research finds unconstrained multi-turn autonomy amplifies early mistakes (*Agentless*, arXiv:2407.01489, FSE'25) and that hierarchical orchestration with per-subagent context isolation manages exactly this (*BOAD*, arXiv:2512.23631; *Confucius Code Agent*, arXiv:2512.10398).
+- **Granularity at the acceptance boundary.** Spellbook's plan skills collapse work items that are only jointly acceptable, resisting over-decomposition — consistent with the Agentless finding that excess decomposition inflates context and compounds error (arXiv:2407.01489).
+- **Specification before code.** Spellbook's design-doc → plan → TDD flow, its discovery/clarify pass, and its loading of project governance (AGENTS.md) as binding constraints parallel spec-driven development — an executable contract before code, a "constitution" of principles, a clarify step that interrogates the spec before building (*Spec-Driven Development*, arXiv:2602.00180; GitHub Spec Kit). This part of the literature *argues* the case rather than measuring it.
+
+Full bibliography: [Research Citations](docs/reference/citations.md).
 
 ## Documentation
 

--- a/commands/review-plan-completeness.md
+++ b/commands/review-plan-completeness.md
@@ -31,6 +31,64 @@ If YES, verify:
 If NO/PARTIAL: [what acceptance criteria must be added]
 ```
 
+### Cluster Collapse Check (work-item granularity)
+
+A candidate cluster is items linked by `Depends:` edges, a shared deliverable, or
+an overlapping file union; apply the per-item revert test within each candidate.
+Joint acceptance remains the actual decider.
+
+Apply the revert test PER ITEM: is THIS item independently acceptable — does its
+own MEANINGFUL, behavior-level `Check:` pass with ALL other candidate items
+reverted? An item that is NOT independently acceptable must share a work item with
+the sibling(s) it MUTUALLY requires — each fails the revert test because of the
+other. Take the MAXIMAL set of such
+mutually-dependent-for-acceptance items: flag that set as a decomposition finding
+and recommend collapsing it into ONE work item with a single joint `Check:`.
+Items that ARE independently acceptable stay separate, even when adjacent to a
+joint set — a cluster of one independent item plus a jointly-acceptable pair
+splits into the joint pair (flag to collapse) and the independent item (leave
+alone). Do NOT require that NONE be independent before flagging; a mixed cluster
+still has a joint subset to collapse.
+
+A behavior-level `Check:` asserts an observable OUTPUT VALUE for a specified
+input, or an observable state change. Checks that only assert
+existence/importability/type/attribute-presence, a constant equality, an internal
+count or length, or echo back a hard-coded literal are NOT behavior-level — they
+pass with siblings reverted while proving no behavior, so they do not make a
+member independently acceptable.
+
+```
+Candidate cluster: [member item names]
+Per item — independently acceptable (MEANINGFUL behavior-level Check passes with all others reverted): item: YES/NO ...
+Maximal mutually-dependent-for-acceptance subset: [members] -> DECOMPOSITION FINDING, collapse into one work item with one joint Check
+Independently-acceptable members: [members] -> leave separate
+```
+
+Negative controls (must NOT be flagged):
+- Items that merely share a file but each carry an independent, behavior-level
+  `Check:`. The signal is joint acceptance, not shared files or shared setup.
+- Items linked by a one-directional `Depends:` PREREQUISITE edge where the
+  downstream check needs the upstream merely PRESENT/available at runtime (e.g., a
+  DB migration behind a GET endpoint whose check exercises the endpoint's
+  behavior). The upstream is a separate DELIVERABLE — keep them separate. The
+  upstream's own check being weak is a SEPARATE concern, out of scope for this
+  lint; do not turn it into a collapse.
+
+  This carve-out does NOT apply — the pair IS joint and MUST be flagged to
+  collapse — when the downstream check's CORRECTNESS is co-produced by the
+  upstream: round-trip, encode/decode, or any "two halves of one contract" shape
+  (e.g., `serialize` upstream, `deserialize` downstream whose check asserts
+  round-trip equality). The deciding question is what the downstream check
+  verifies: does it verify ONE deliverable's own behavior (the upstream is a
+  separate deliverable it merely relies on being available → prerequisite, keep
+  separate), or the CONJOINED behavior of both (neither's behavior is observable
+  without the other → joint, collapse)?
+
+Severity: Important (should fix) — a mis-decomposed cluster produces work items
+that cannot be verified or executed independently. This is a prose instrument the
+reviewer applies by judgment; there is no mechanical backstop, consistent with
+the other checks in this command.
+
 ## Risk Assessment per Phase
 
 ```

--- a/docs/commands/review-plan-completeness.md
+++ b/docs/commands/review-plan-completeness.md
@@ -31,6 +31,64 @@ If YES, verify:
 If NO/PARTIAL: [what acceptance criteria must be added]
 ```
 
+### Cluster Collapse Check (work-item granularity)
+
+A candidate cluster is items linked by `Depends:` edges, a shared deliverable, or
+an overlapping file union; apply the per-item revert test within each candidate.
+Joint acceptance remains the actual decider.
+
+Apply the revert test PER ITEM: is THIS item independently acceptable — does its
+own MEANINGFUL, behavior-level `Check:` pass with ALL other candidate items
+reverted? An item that is NOT independently acceptable must share a work item with
+the sibling(s) it MUTUALLY requires — each fails the revert test because of the
+other. Take the MAXIMAL set of such
+mutually-dependent-for-acceptance items: flag that set as a decomposition finding
+and recommend collapsing it into ONE work item with a single joint `Check:`.
+Items that ARE independently acceptable stay separate, even when adjacent to a
+joint set — a cluster of one independent item plus a jointly-acceptable pair
+splits into the joint pair (flag to collapse) and the independent item (leave
+alone). Do NOT require that NONE be independent before flagging; a mixed cluster
+still has a joint subset to collapse.
+
+A behavior-level `Check:` asserts an observable OUTPUT VALUE for a specified
+input, or an observable state change. Checks that only assert
+existence/importability/type/attribute-presence, a constant equality, an internal
+count or length, or echo back a hard-coded literal are NOT behavior-level — they
+pass with siblings reverted while proving no behavior, so they do not make a
+member independently acceptable.
+
+```
+Candidate cluster: [member item names]
+Per item — independently acceptable (MEANINGFUL behavior-level Check passes with all others reverted): item: YES/NO ...
+Maximal mutually-dependent-for-acceptance subset: [members] -> DECOMPOSITION FINDING, collapse into one work item with one joint Check
+Independently-acceptable members: [members] -> leave separate
+```
+
+Negative controls (must NOT be flagged):
+- Items that merely share a file but each carry an independent, behavior-level
+  `Check:`. The signal is joint acceptance, not shared files or shared setup.
+- Items linked by a one-directional `Depends:` PREREQUISITE edge where the
+  downstream check needs the upstream merely PRESENT/available at runtime (e.g., a
+  DB migration behind a GET endpoint whose check exercises the endpoint's
+  behavior). The upstream is a separate DELIVERABLE — keep them separate. The
+  upstream's own check being weak is a SEPARATE concern, out of scope for this
+  lint; do not turn it into a collapse.
+
+  This carve-out does NOT apply — the pair IS joint and MUST be flagged to
+  collapse — when the downstream check's CORRECTNESS is co-produced by the
+  upstream: round-trip, encode/decode, or any "two halves of one contract" shape
+  (e.g., `serialize` upstream, `deserialize` downstream whose check asserts
+  round-trip equality). The deciding question is what the downstream check
+  verifies: does it verify ONE deliverable's own behavior (the upstream is a
+  separate deliverable it merely relies on being available → prerequisite, keep
+  separate), or the CONJOINED behavior of both (neither's behavior is observable
+  without the other → joint, collapse)?
+
+Severity: Important (should fix) — a mis-decomposed cluster produces work items
+that cannot be verified or executed independently. This is a prose instrument the
+reviewer applies by judgment; there is no mechanical backstop, consistent with
+the other checks in this command.
+
 ## Risk Assessment per Phase
 
 ```

--- a/docs/reference/citations.md
+++ b/docs/reference/citations.md
@@ -115,6 +115,96 @@ This page documents the research that informs spellbook's design, particularly t
 - **Link**: [https://arxiv.org/abs/2408.08631](https://arxiv.org/abs/2408.08631)
 - Proposes "Jekyll & Hyde" framework that ensembles persona and neutral perspectives to mitigate persona drawbacks.
 
+## Development ceremonies (research backing)
+
+Spellbook's development ceremonies grew from practice, not from the literature, but independent research supports many of them. The five items below map each ceremony to the research that validates it.
+
+### The green mirage: tests that pass without verifying behavior
+
+Spellbook's green-mirage audit asks of every test whether it would fail if the code were broken. This is the coding face of *reward hacking* / *specification gaming*, a documented failure mode where an agent satisfies the literal metric without the intended outcome. It is not hypothetical: audits find a material share of SWE-bench patches pass their tests yet are wrong or incomplete, and mutation analysis finds most SWE-bench Verified instances admit a surviving mutant.
+
+**Amodei, D., Olah, C., Steinhardt, J., Christiano, P., Schulman, J., & Mané, D.** (2016). Concrete Problems in AI Safety. *arXiv preprint arXiv:1606.06565*.
+
+- **Link**: [https://arxiv.org/abs/1606.06565](https://arxiv.org/abs/1606.06565)
+- **Key finding**: Catalogues concrete AI safety failure modes, including reward hacking, where a system satisfies the literal specification of an objective without achieving the intended outcome.
+- **Relevance**: Frames the green-mirage audit as detection of the coding-domain form of reward hacking: a test that passes while the code is wrong.
+
+**Krakovna, V., et al.** (2020). Specification gaming: the flip side of AI ingenuity. *DeepMind blog*.
+
+- **Link**: [https://deepmind.google/discover/blog/specification-gaming-the-flip-side-of-ai-ingenuity/](https://deepmind.google/discover/blog/specification-gaming-the-flip-side-of-ai-ingenuity/)
+- **Key finding**: Documents specification gaming, where an agent exploits the literal statement of an objective to score well without doing the intended task.
+- **Relevance**: Names the general pattern the green-mirage audit guards against in test suites.
+
+**Skalse, J., Howe, N. H. R., Krasheninnikov, D., & Krueger, D.** (2022). Defining and Characterizing Reward Hacking. *Advances in Neural Information Processing Systems 35 (NeurIPS 2022)*.
+
+- **Link**: [https://arxiv.org/abs/2209.13085](https://arxiv.org/abs/2209.13085)
+- **Key finding**: Provides a formal definition of reward hacking and characterizes when a proxy objective can be gamed relative to the true objective.
+- **Relevance**: Theoretical grounding for why a test (a proxy for correctness) can be satisfied without the code being correct.
+
+**Aleithan, R., et al.** (2024). SWE-Bench+: Enhanced Coding Benchmark for LLMs. *arXiv preprint arXiv:2410.06992*.
+
+- **Link**: [https://arxiv.org/abs/2410.06992](https://arxiv.org/abs/2410.06992)
+- **Key finding**: An audit of SWE-bench patches finds many pass their tests yet are wrong or incomplete: 9.26% incorrect / 5.56% incomplete on SWE-bench Lite, and 12.5% / 9.82% on SWE-bench Verified.
+- **Relevance**: Empirical evidence that passing tests do not guarantee correct code, motivating the green-mirage audit.
+
+**Are Benchmark Tests Strong Enough? Mutation-Guided Diagnosis and Augmentation of Regression Suites** (tool: STING; alt. "Probe to Generate", tool PROBE). *arXiv preprint arXiv:2604.01518*.
+
+- **Link**: [https://arxiv.org/abs/2604.01518](https://arxiv.org/abs/2604.01518)
+- **Key finding**: Mutation-guided analysis finds that 77% of SWE-bench Verified instances admit at least one surviving mutant, meaning the accompanying tests fail to detect a deliberately broken implementation.
+- **Relevance**: Quantifies test weakness in a widely used benchmark, the exact condition the green-mirage audit and mutation discipline target.
+
+### Mutation as the measure of a test's strength
+
+Spellbook's TDD rule requires every assertion to name the mutation it kills, and no check counts until it has gone red on deliberately broken code. This is mutation testing, established since the late 1970s. A test that still passes when the code is broken proves nothing.
+
+**DeMillo, R. A., Lipton, R. J., & Sayward, F. G.** (1978). Hints on Test Data Selection: Help for the Practicing Programmer. *IEEE Computer*, 11(4), 34-41.
+
+- **Link**: [https://doi.org/10.1109/C-M.1978.218136](https://doi.org/10.1109/C-M.1978.218136)
+- **Key finding**: Introduces mutation testing: deliberately altering a program to produce mutants, then measuring whether the test suite detects (kills) them as a measure of test adequacy.
+- **Relevance**: Origin of the mutation-as-check-strength discipline spellbook applies to TDD. Framework: [Stryker](https://stryker-mutator.io/).
+
+### Constrained beats unconstrained autonomy
+
+Spellbook runs one orchestrator dispatching narrowly-scoped subagents, each with only its local context, and keeps the reviewer separate from the author. Research finds unconstrained multi-turn autonomy amplifies early mistakes, and that hierarchical orchestration with per-subagent context isolation manages exactly this.
+
+**Xia, C. S., Deng, Y., Dunn, S., & Zhang, L.** (2025). Agentless: Demystifying LLM-based Software Engineering Agents. *Proceedings of FSE 2025*. arXiv:2407.01489.
+
+- **Link**: [https://arxiv.org/abs/2407.01489](https://arxiv.org/abs/2407.01489)
+- **Key finding**: A simple, constrained three-phase approach reaches 32.00% on SWE-bench Lite, outperforming more autonomous agents; unconstrained multi-turn autonomy compounds early errors and inflates context.
+- **Relevance**: Supports spellbook's constrained orchestration and its resistance to over-decomposition.
+
+**BOAD: Discovering Hierarchical Software Engineering Agents via Bandit Optimization** (2026). *Proceedings of ICLR 2026*. arXiv:2512.23631.
+
+- **Link**: [https://arxiv.org/abs/2512.23631](https://arxiv.org/abs/2512.23631)
+- **Key finding**: Hierarchical agent structures discovered via bandit optimization improve software engineering task performance through structured decomposition and coordination.
+- **Relevance**: Supports the orchestrator-plus-subagents structure spellbook uses.
+
+**Confucius Code Agent: Scalable Agent Scaffolding for Real-World SWE** (2026). *arXiv preprint arXiv:2512.10398*.
+
+- **Link**: [https://arxiv.org/abs/2512.10398](https://arxiv.org/abs/2512.10398)
+- **Key finding**: Agent scaffolding with per-subagent context isolation scales to real-world software engineering tasks by managing context per subagent rather than accumulating it in one loop.
+- **Relevance**: Supports spellbook's per-subagent context isolation and reviewer/author separation.
+
+### Granularity at the acceptance boundary
+
+Spellbook's plan skills collapse work items that are only jointly acceptable, resisting over-decomposition. This is consistent with the Agentless finding that excess decomposition inflates context and compounds error (Xia et al., 2025, arXiv:2407.01489, cited above).
+
+### Specification before code
+
+Spellbook's design-doc → plan → TDD flow, its discovery/clarify pass, and its loading of project governance (AGENTS.md) as binding constraints parallel spec-driven development: an executable contract before code, a "constitution" of principles, and a clarify step that interrogates the spec before building. This part of the literature argues the case rather than measuring it.
+
+**Piskala, D. B.** (2026). Spec-Driven Development: From Code to Contract in the Age of AI Coding Assistants. *arXiv preprint arXiv:2602.00180*.
+
+- **Link**: [https://arxiv.org/abs/2602.00180](https://arxiv.org/abs/2602.00180)
+- **Key finding**: Argues (as a technical report, not an empirical measurement) for treating a specification as an executable contract that precedes and governs code generation.
+- **Relevance**: Parallels spellbook's design-doc → plan → TDD flow.
+
+**GitHub Spec Kit**.
+
+- **Link**: [https://github.com/github/spec-kit](https://github.com/github/spec-kit)
+- **Key finding**: A toolkit for spec-driven development built around a project "constitution" of principles and a `/clarify` workflow that interrogates the spec before implementation.
+- **Relevance**: Parallels spellbook's clarify pass and its loading of project governance (AGENTS.md) as binding constraints.
+
 ---
 
 ## Summary

--- a/docs/skills/writing-plans.md
+++ b/docs/skills/writing-plans.md
@@ -23,7 +23,7 @@ Implementation Planner. Reputation depends on plans that engineers execute witho
 ## Invariant Principles
 
 1. **Zero-Context Assumption** - Engineer reading plan knows nothing about codebase, toolset, or domain
-2. **Atomic Tasks** - Each step is one action (2-5 min): write test, run test, implement, verify, commit
+2. **Atomic Tasks** - Each step is one action (2-5 min): write test, run test, implement, verify, commit. This governs STEP granularity WITHIN a work item; the revert test (see Work-Item Granularity, adjacent to Capability Groups) governs WORK-ITEM boundaries — the two do not conflict.
 3. **Complete Specification** - Full code, exact paths, expected outputs; never "add validation" or similar
 4. **TDD Flow** - RED (failing test) -> GREEN (minimal pass) -> commit; repeat
 5. **Traceable Decisions** - Link to design doc so reviewers can trace requirements -> plan -> code
@@ -135,6 +135,55 @@ Every task carries these fields, in this order, between `**Files:**` and `**Step
 | `**Check:**` | The SINGLE proving command for this task, as one inline code span. This is the single source of truth: Step 4's `Run:` line is copied from it at generation time, never retyped. |
 | `**Schema:** planlint-v1` | Opts this plan into `spellbook-planlint`. Every plan this skill generates carries it. An author who wants a plan excluded writes `**Schema:** legacy` instead — a decision recorded, not an absence. |
 | `**Subject:**` | Required on measurement-type tasks. One of `fixed_artifact`, `instrumented_run`, `physical_access` — the snake_case tokens `feature-config` §0.7.6 names. Records the measurement's subject kind as a real, greppable field rather than prose. |
+
+## Work-Item Granularity (Revert Test)
+
+This rule is UN-GATED: it applies in both `task_granularity` modes (`file` and
+`capability`), independent of whether capability groups are declared below.
+
+Apply the revert test PER ITEM: is THIS item independently acceptable — does its
+own MEANINGFUL, behavior-level `Check:` pass with ALL other candidate items
+reverted? An item that is NOT independently acceptable must live in the same work
+item as the sibling(s) it MUTUALLY requires — each fails the revert test because
+of the other. Take the MAXIMAL set of such mutually-dependent-for-acceptance
+items: that set is ONE work
+item, with one joint `Check:`. Items that ARE independently acceptable stay their
+own work items, even when adjacent to a joint set. So a cluster of one
+independent item plus a jointly-acceptable pair partitions into two work items:
+the joint pair (one item, one joint `Check:`) and the independent item (its own).
+
+A behavior-level `Check:` asserts an observable OUTPUT VALUE for a specified
+input, or an observable state change. Checks that only assert
+existence/importability/type/attribute-presence, a constant equality, an internal
+count or length, or echo back a hard-coded literal are NOT behavior-level — they
+pass with siblings reverted while proving no behavior.
+
+Anchor collapse on MUTUAL joint acceptance WITHIN A SINGLE DELIVERABLE, not on a
+one-directional prerequisite. A `Depends:` edge alone does not decide it — ask
+what the downstream check needs from the upstream. The prerequisite carve-out
+(keep separate) applies ONLY when the downstream check needs the upstream merely
+PRESENT/available at runtime (e.g., a DB migration behind a GET endpoint whose
+check exercises the endpoint's behavior); the upstream is a distinct DELIVERABLE.
+It does NOT apply when the downstream check's CORRECTNESS is co-produced by the
+upstream — round-trip, encode/decode, or any "two halves of one contract" shape;
+that pair is jointly acceptable and MUST be collapsed. The upstream's own check
+being weak is a SEPARATE concern. The deciding question is what the downstream
+check verifies: does it verify ONE deliverable's own behavior (the upstream is a
+separate deliverable it merely relies on being available → prerequisite, keep
+separate), or the CONJOINED behavior of both (neither's behavior is observable
+without the other → joint, collapse)?
+Likewise do NOT merge items merely because they share a file, share setup, or are
+individually small — items touching the same file that each carry an independent,
+behavior-level `Check:` stay separate. This is the guard against over-merging.
+
+In `file` mode a work item is a single Task; in `capability` mode a
+jointly-acceptable set is realized as a capability group (Tasks stay separate,
+the group carries the one joint `Check:`) — see Capability Groups below. "One
+work item" means one joint-acceptance unit, not necessarily one Task.
+
+The revert test IS the named check for this rule; it is a prose instrument the
+author applies by judgment — there is no mechanical backstop, consistent with the
+other rules in this skill.
 
 ## Capability Groups
 

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -16,7 +16,7 @@ Implementation Planner. Reputation depends on plans that engineers execute witho
 ## Invariant Principles
 
 1. **Zero-Context Assumption** - Engineer reading plan knows nothing about codebase, toolset, or domain
-2. **Atomic Tasks** - Each step is one action (2-5 min): write test, run test, implement, verify, commit
+2. **Atomic Tasks** - Each step is one action (2-5 min): write test, run test, implement, verify, commit. This governs STEP granularity WITHIN a work item; the revert test (see Work-Item Granularity, adjacent to Capability Groups) governs WORK-ITEM boundaries — the two do not conflict.
 3. **Complete Specification** - Full code, exact paths, expected outputs; never "add validation" or similar
 4. **TDD Flow** - RED (failing test) -> GREEN (minimal pass) -> commit; repeat
 5. **Traceable Decisions** - Link to design doc so reviewers can trace requirements -> plan -> code
@@ -128,6 +128,55 @@ Every task carries these fields, in this order, between `**Files:**` and `**Step
 | `**Check:**` | The SINGLE proving command for this task, as one inline code span. This is the single source of truth: Step 4's `Run:` line is copied from it at generation time, never retyped. |
 | `**Schema:** planlint-v1` | Opts this plan into `spellbook-planlint`. Every plan this skill generates carries it. An author who wants a plan excluded writes `**Schema:** legacy` instead — a decision recorded, not an absence. |
 | `**Subject:**` | Required on measurement-type tasks. One of `fixed_artifact`, `instrumented_run`, `physical_access` — the snake_case tokens `feature-config` §0.7.6 names. Records the measurement's subject kind as a real, greppable field rather than prose. |
+
+## Work-Item Granularity (Revert Test)
+
+This rule is UN-GATED: it applies in both `task_granularity` modes (`file` and
+`capability`), independent of whether capability groups are declared below.
+
+Apply the revert test PER ITEM: is THIS item independently acceptable — does its
+own MEANINGFUL, behavior-level `Check:` pass with ALL other candidate items
+reverted? An item that is NOT independently acceptable must live in the same work
+item as the sibling(s) it MUTUALLY requires — each fails the revert test because
+of the other. Take the MAXIMAL set of such mutually-dependent-for-acceptance
+items: that set is ONE work
+item, with one joint `Check:`. Items that ARE independently acceptable stay their
+own work items, even when adjacent to a joint set. So a cluster of one
+independent item plus a jointly-acceptable pair partitions into two work items:
+the joint pair (one item, one joint `Check:`) and the independent item (its own).
+
+A behavior-level `Check:` asserts an observable OUTPUT VALUE for a specified
+input, or an observable state change. Checks that only assert
+existence/importability/type/attribute-presence, a constant equality, an internal
+count or length, or echo back a hard-coded literal are NOT behavior-level — they
+pass with siblings reverted while proving no behavior.
+
+Anchor collapse on MUTUAL joint acceptance WITHIN A SINGLE DELIVERABLE, not on a
+one-directional prerequisite. A `Depends:` edge alone does not decide it — ask
+what the downstream check needs from the upstream. The prerequisite carve-out
+(keep separate) applies ONLY when the downstream check needs the upstream merely
+PRESENT/available at runtime (e.g., a DB migration behind a GET endpoint whose
+check exercises the endpoint's behavior); the upstream is a distinct DELIVERABLE.
+It does NOT apply when the downstream check's CORRECTNESS is co-produced by the
+upstream — round-trip, encode/decode, or any "two halves of one contract" shape;
+that pair is jointly acceptable and MUST be collapsed. The upstream's own check
+being weak is a SEPARATE concern. The deciding question is what the downstream
+check verifies: does it verify ONE deliverable's own behavior (the upstream is a
+separate deliverable it merely relies on being available → prerequisite, keep
+separate), or the CONJOINED behavior of both (neither's behavior is observable
+without the other → joint, collapse)?
+Likewise do NOT merge items merely because they share a file, share setup, or are
+individually small — items touching the same file that each carry an independent,
+behavior-level `Check:` stay separate. This is the guard against over-merging.
+
+In `file` mode a work item is a single Task; in `capability` mode a
+jointly-acceptable set is realized as a capability group (Tasks stay separate,
+the group carries the one joint `Check:`) — see Capability Groups below. "One
+work item" means one joint-acceptance unit, not necessarily one Task.
+
+The revert test IS the named check for this rule; it is a prose instrument the
+author applies by judgment — there is no mechanical backstop, consistent with the
+other rules in this skill.
 
 ## Capability Groups
 


### PR DESCRIPTION
## What does this PR do?

Three related changes to spellbook's planning + docs:

**1. Joint-acceptance work-item granularity rule** (stated once, enforced twice):
- `skills/writing-plans/SKILL.md` — a new "Work-Item Granularity (Revert Test)" rule: don't split below the joint-acceptance boundary. Each candidate work item's own meaningful, behavior-level `Check:` must pass with its siblings reverted; the maximal mutually-dependent subset is one work item. Un-gated across `task_granularity` modes, anchored strictly on joint acceptance (not shared files/setup/size), and distinguishes a joint deliverable from a layered `Depends:` prerequisite (what the downstream check verifies: one deliverable's behavior = keep separate; conjoined behavior = collapse).
- `commands/review-plan-completeness.md` — a mirrored "Cluster Collapse Check" backstop lint.

**2. AGENTS.md note** — regenerating the `docs/` mirror is required, normal work (not scope creep), since the `generate-docs` pre-commit hook enforces freshness.

**3. Research backing docs** — a `## Research backing` section in the README and an augmented `docs/reference/citations.md`, documenting where independent research supports spellbook's existing ceremonies (green-mirage/reward-hacking, mutation-as-check-strength, constrained orchestration, acceptance-boundary granularity, spec-before-code). All citations verified against primary sources; framed as external validation of an organically-developed process, not motivation.

Developed via spellbook's own develop fast path: Iron Law behavioral eval RED→GREEN (both scenarios, negative controls held); green-mirage audit 5 findings → CLEAN; code review APPROVE-WITH-NITS (addressed); `validate_schemas.py` 204/204; `pytest tests/test_skills/` 73 passed.

## Related issue

None. Stacked on `autonomous-stop-hook` (PR 494) — retarget to `main` after that merges.

## Checklist

- [x] Tests pass locally
- [x] Documentation updated
