### PR TITLE
Convert test_update_config to tripwire

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `tests/unit/test_update_config.py` replaced functions and module attributes
+  through monkeypatch, which `AGENTS.md` restricts to environment, cwd, and
+  sys.path. The file mattered beyond the rule: a correct `tripwire.spy.object`
+  call sat a few lines below the violations, so anyone reading it for an example
+  met the wrong pattern first, and the same violation was then introduced twice
+  independently elsewhere. One of the patched targets already had a purpose-built
+  seam whose docstring says it exists so tests can redirect through tripwire
+  rather than patch the module constant -- the seam was built and then ignored.
+  Every converted test was proven to still fail: each went red under a mutation
+  of the code it covers. Two assertions grew stronger in the process, because
+  tripwire pins a call count and a return value that a hand-rolled recorder had
+  to assert separately or not at all, and one hand-rolled stub was hiding a
+  double close of a file descriptor that the replacement cannot reproduce.
+
+
 ### Changed
 
 - `develop` is now a thin entry gate. Its triggers fire on almost any "let's

--- a/tests/unit/test_update_config.py
+++ b/tests/unit/test_update_config.py
@@ -5,7 +5,7 @@ import os
 import threading
 import tripwire
 import pytest
-from dirty_equals import IsInstance
+from dirty_equals import IsBytes, IsInstance, IsStr
 
 try:
     import fcntl
@@ -16,14 +16,16 @@ except ImportError:
 class TestConfigFileLocking:
     """Tests for file-level locking in config_get/config_set."""
 
-    def test_config_set_creates_lock_file(self, tmp_path, monkeypatch):
+    def test_config_set_creates_lock_file(self, tmp_path):
         """config_set should use CrossPlatformLock during writes."""
         from spellbook.core.config import config_set
 
         config_path = tmp_path / "spellbook.json"
         lock_path = tmp_path / "config.lock"
-        monkeypatch.setattr("spellbook.core.config.get_config_path", lambda: config_path)
-        monkeypatch.setattr("spellbook.core.config.CONFIG_LOCK_PATH", lock_path)
+        path_mock = tripwire.mock("spellbook.core.config:get_config_path")
+        path_mock.returns(config_path)
+        lock_mock = tripwire.mock("spellbook.core.config:_config_lock_path")
+        lock_mock.returns(lock_path)
 
         # Spy on CrossPlatformLock.__enter__ to verify it's used as a context manager
         from spellbook.core.compat import CrossPlatformLock
@@ -33,6 +35,8 @@ class TestConfigFileLocking:
         with tripwire:
             config_set("test_key", "test_value")
 
+        path_mock.assert_call(args=(), kwargs={})
+        lock_mock.assert_call(args=(), kwargs={})
         enter_spy.assert_call(
             args=(IsInstance(CrossPlatformLock),),
             kwargs={},
@@ -43,18 +47,21 @@ class TestConfigFileLocking:
         config = json.loads(config_path.read_text())
         assert config["test_key"] == "test_value"
 
-    def test_concurrent_config_writes_no_data_loss(self, tmp_path, monkeypatch):
+    def test_concurrent_config_writes_no_data_loss(self, tmp_path):
         """Concurrent writes should not lose data due to locking."""
         from spellbook.core.config import config_set
 
         config_path = tmp_path / "spellbook.json"
         lock_path = tmp_path / "config.lock"
-        monkeypatch.setattr("spellbook.core.config.get_config_path", lambda: config_path)
-        monkeypatch.setattr("spellbook.core.config.CONFIG_LOCK_PATH", lock_path)
+        path_mock = tripwire.mock("spellbook.core.config:get_config_path")
+        path_mock.always_returns(config_path)
+        lock_mock = tripwire.mock("spellbook.core.config:_config_lock_path")
+        lock_mock.always_returns(lock_path)
 
         # Write initial config
         config_path.write_text(json.dumps({"initial": True}) + "\n")
 
+        writer_count = 10
         errors = []
 
         def write_key(key, value):
@@ -65,37 +72,56 @@ class TestConfigFileLocking:
 
         # Concurrent writes
         threads = []
-        for i in range(10):
+        for i in range(writer_count):
             t = threading.Thread(target=write_key, args=(f"key_{i}", f"value_{i}"))
             threads.append(t)
 
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join()
+        with tripwire:
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
 
         assert len(errors) == 0
+
+        # Every writer resolved the config path and the lock path exactly once.
+        # Thread interleaving makes the recorded order arbitrary, so the
+        # per-writer counts are what carries the meaning here.
+        with tripwire.in_any_order():
+            for _ in range(writer_count):
+                path_mock.assert_call(args=(), kwargs={})
+                lock_mock.assert_call(args=(), kwargs={})
 
         # All keys should be present (no lost updates)
         final_config = json.loads(config_path.read_text())
         assert final_config["initial"] is True
-        for i in range(10):
+        for i in range(writer_count):
             assert final_config[f"key_{i}"] == f"value_{i}"
 
-    def test_config_get_reads_with_shared_lock(self, tmp_path, monkeypatch):
+    def test_config_get_reads_with_shared_lock(self, tmp_path):
         """config_get should work correctly with locking."""
         from spellbook.core.config import config_get, config_set
 
         config_path = tmp_path / "spellbook.json"
         lock_path = tmp_path / "config.lock"
-        monkeypatch.setattr("spellbook.core.config.get_config_path", lambda: config_path)
-        monkeypatch.setattr("spellbook.core.config.CONFIG_LOCK_PATH", lock_path)
+        path_mock = tripwire.mock("spellbook.core.config:get_config_path")
+        path_mock.always_returns(config_path)
+        lock_mock = tripwire.mock("spellbook.core.config:_config_lock_path")
+        lock_mock.always_returns(lock_path)
 
-        config_set("locked_key", 42)
-        result = config_get("locked_key")
+        with tripwire:
+            config_set("locked_key", 42)
+            result = config_get("locked_key")
+
         assert result == 42
 
-    def test_config_write_is_atomic(self, tmp_path, monkeypatch):
+        # Write then read: each resolves the config path and takes the lock once.
+        path_mock.assert_call(args=(), kwargs={})
+        lock_mock.assert_call(args=(), kwargs={})
+        path_mock.assert_call(args=(), kwargs={})
+        lock_mock.assert_call(args=(), kwargs={})
+
+    def test_config_write_is_atomic(self, tmp_path):
         """Config write uses atomic replace pattern.
 
         Verifies that config_set writes to a temp file then replaces,
@@ -105,58 +131,85 @@ class TestConfigFileLocking:
 
         config_path = tmp_path / "spellbook.json"
         lock_path = tmp_path / "config.lock"
-        monkeypatch.setattr("spellbook.core.config.get_config_path", lambda: config_path)
-        monkeypatch.setattr("spellbook.core.config.CONFIG_LOCK_PATH", lock_path)
+        path_mock = tripwire.mock("spellbook.core.config:get_config_path")
+        path_mock.returns(config_path)
+        lock_mock = tripwire.mock("spellbook.core.config:_config_lock_path")
+        lock_mock.returns(lock_path)
 
         # Write initial valid config
         config_path.write_text(json.dumps({"existing": "data"}) + "\n")
 
-        # Track os.replace calls to verify atomic pattern
-        replace_calls = []
-        original_replace = os.replace
+        # Spy rather than mock: the real rename must happen for the
+        # post-conditions on the config file below to mean anything.
+        replace_spy = tripwire.spy("os:replace")
 
-        def tracking_replace(src, dst):
-            replace_calls.append((src, dst))
-            return original_replace(src, dst)
+        with tripwire:
+            config_set("new_key", "new_value")
 
-        monkeypatch.setattr("os.replace", tracking_replace)
-
-        config_set("new_key", "new_value")
-
-        # Verify os.replace was called (atomic rename)
-        assert len(replace_calls) == 1, "os.replace should be called exactly once"
-        src, dst = replace_calls[0]
-        assert dst == str(config_path), "os.replace target should be the config path"
-        assert src.endswith(".tmp"), "os.replace source should be a .tmp file"
+        path_mock.assert_call(args=(), kwargs={})
+        lock_mock.assert_call(args=(), kwargs={})
+        # Exactly one rename, from a .tmp sibling onto the config path.
+        # Tripwire fails the test on any unasserted interaction, so this
+        # single assertion also pins the call count. mkstemp picks the
+        # basename, so only its .tmp suffix is knowable here.
+        replace_spy.assert_call(
+            args=(IsStr(regex=r".*\.tmp"), str(config_path)),
+            kwargs={},
+            returned=None,
+        )
 
         # Verify final config is valid and contains both keys
         config = json.loads(config_path.read_text())
         assert config["existing"] == "data"
         assert config["new_key"] == "new_value"
 
-    def test_config_write_atomic_cleanup_on_failure(self, tmp_path, monkeypatch):
+    def test_config_write_atomic_cleanup_on_failure(self, tmp_path):
         """If write fails before os.replace, original config is untouched."""
         from spellbook.core.config import config_set
 
         config_path = tmp_path / "spellbook.json"
         lock_path = tmp_path / "config.lock"
-        monkeypatch.setattr("spellbook.core.config.get_config_path", lambda: config_path)
-        monkeypatch.setattr("spellbook.core.config.CONFIG_LOCK_PATH", lock_path)
+        path_mock = tripwire.mock("spellbook.core.config:get_config_path")
+        path_mock.returns(config_path)
+        lock_mock = tripwire.mock("spellbook.core.config:_config_lock_path")
+        lock_mock.returns(lock_path)
 
         # Write initial valid config
         original_content = json.dumps({"precious": "data"}) + "\n"
         config_path.write_text(original_content)
 
-        # Make os.write fail to simulate interrupted write
+        # CrossPlatformLock writes its own metadata through os.write before
+        # config_set writes the payload, so the first call is delegated to the
+        # real syscall and only the second one fails.
+        real_write = os.write
+        failure = OSError("simulated write failure")
+        write_mock = tripwire.mock("os:write")
+        write_mock.calls(real_write).raises(failure)
 
-        def failing_write(fd, data):
-            os.close(fd)  # Close fd so cleanup doesn't double-close
-            raise OSError("simulated write failure")
+        with tripwire:
+            with pytest.raises(OSError, match="simulated write failure"):
+                config_set("bad_key", "bad_value")
 
-        monkeypatch.setattr("os.write", failing_write)
-
-        with pytest.raises(OSError, match="simulated write failure"):
-            config_set("bad_key", "bad_value")
+        path_mock.assert_call(args=(), kwargs={})
+        lock_mock.assert_call(args=(), kwargs={})
+        # Lock metadata: the pid is knowable, the wall-clock timestamp is not.
+        write_mock.assert_call(
+            args=(
+                IsInstance(int),
+                IsBytes(regex=rb'\{"pid": %d, "timestamp": [0-9.]+\}' % os.getpid()),
+            ),
+            kwargs={},
+        )
+        # The merged config is written in one os.write of the full payload.
+        # The descriptor comes from mkstemp, so only its type is knowable.
+        expected_payload = (
+            json.dumps({"precious": "data", "bad_key": "bad_value"}, indent=2) + "\n"
+        ).encode("utf-8")
+        write_mock.assert_call(
+            args=(IsInstance(int), expected_payload),
+            kwargs={},
+            raised=failure,
+        )
 
         # Original config must be untouched
         assert config_path.read_text() == original_content


### PR DESCRIPTION
## What does this PR do?

Converts `tests/unit/test_update_config.py` from monkeypatch function replacement to tripwire, per the `AGENTS.md` mocking policy, and proves every converted test can still fail.

## Related issue

<!-- none -->

## Checklist

- [x] Tests pass locally
- [x] Documentation updated (if applicable)

---

### Why this file specifically

The policy is that monkeypatch covers environment, cwd, and sys.path only; everything else goes through tripwire, which enforces that a mock's interactions are actually asserted.

This file mattered beyond the rule. A correct `tripwire.spy.object` call sat a few lines below the violations, so anyone opening it for an example met the wrong pattern first — and the same violation was then introduced twice independently on another branch. Fixing the file removes the bad example, not just the instance.

One patched target already had a purpose-built seam. `_config_lock_path()`'s docstring says, verbatim, that it exists so tests can redirect through tripwire instead of patching the module-level constant. The seam was built and then ignored.

### Each test proven to still fail

Six mutations of the code under test — lock skipped, merge dropped, read stubbed, atomic rename replaced with write-then-unlink, cleanup re-raise removed, serialization altered. **None survived.** A conversion that keeps tests green without proving they can go red is not verified.

Worth recording: the first mutation attempt reported `1 passed` — against *unmutated* code, because a shell-quoting problem meant the patch never applied. A mutation run that comes back green has to be checked for having actually mutated anything.

### Two assertions came out stronger

Tripwire pins the call count and return value that a hand-rolled recorder had to assert separately, and the payload check now covers exact bytes rather than shape.

The hand-rolled stub was also hiding a real defect: its comment said it closed the fd "so cleanup doesn't double-close", but production closes the same descriptor again, so the test double-closed. With a reused fd number that is a genuine bug. The replacement never closes, so production closes exactly once.

No wildcard matcher appears in the file — incidental values are constrained by type or pattern. The one spy-only detail that cannot be asserted on a plain mock is omitted rather than written as a comparison against `None`, which would pass vacuously.

### Found, not fixed

**A production test-isolation escape.** `spellbook/core/config.py:142` binds `CONFIG_LOCK_PATH` at *import* time while `get_config_path()` resolves at *call* time. The sanctioned isolation is redirecting `HOME`, but that cannot move a constant bound before the redirect — so a test following the documented advice writes its config under `tmp_path` while taking its lock in the developer's real `~/.config/spellbook/config.lock`. The conftest guard fingerprints `spellbook.json` only and does not notice. Making `_config_lock_path()` call `get_config_dir()` itself would fix it and retire the seam.

**54 further violations across 11 files**, plus `unittest.mock` in two more. Several need a production-side seam that does not exist yet, and one is a different conversion shape entirely. Converting them blind would be the mechanical translation this PR avoided, so they are reported rather than swept in.

2161 passed, 36 skipped.
