### PR TITLE
fix(installer): deliver Antigravity skills to global ~/.gemini/config/skills root

### DIFF
--- a/installer/platforms/antigravity.py
+++ b/installer/platforms/antigravity.py
@@ -2,7 +2,7 @@
 Antigravity platform installer.
 
 Supports Google Antigravity agentic platform:
-- Global/workspace customizations (skills in ~/.gemini/antigravity/skills or ~/.gemini/config/skills)
+- Global customizations (skills in ~/.gemini/config/skills)
 - Context via AGENTS.md / GEMINI.md in config dir
 - MCP server registration via mcp_config.json
 - Security policies in ~/.gemini/antigravity/policies/spellbook-security.toml
@@ -59,6 +59,15 @@ class AntigravityInstaller(PlatformInstaller):
         binary -- which is why nothing spellbook wrote there ever loaded.
         """
         return self.config_dir.parent / "config" / "rules"
+
+    def skills_dir(self) -> Path:
+        """Antigravity's global skills root.
+
+        This is ``~/.gemini/config/skills``, a sibling of the harness config
+        dir, not ``<config_dir>/skills``. Antigravity's global customization
+        discovery scans ``~/.gemini/config/skills`` for global skills.
+        """
+        return self.config_dir.parent / "config" / "skills"
 
     def legacy_rule_paths(self) -> List[Path]:
         return [
@@ -158,7 +167,7 @@ class AntigravityInstaller(PlatformInstaller):
         if not source_skills.exists():
             return (0, 0)
 
-        target_skills = self.config_dir / "skills"
+        target_skills = self.skills_dir()
         if not self.dry_run:
             target_skills.mkdir(parents=True, exist_ok=True)
 
@@ -374,28 +383,30 @@ class AntigravityInstaller(PlatformInstaller):
                         )
                     )
 
-        # Clean up skill symlinks
-        target_skills = self.config_dir / "skills"
-        if target_skills.exists():
-            removed_links = 0
-            for item in target_skills.iterdir():
-                if item.is_symlink():
-                    try:
-                        resolved = item.resolve()
-                        if str(resolved).startswith(str(self.spellbook_dir)):
-                            if remove_symlink(item, dry_run=self.dry_run).success:
+        # Clean up skill symlinks (both active global root and legacy harness location)
+        removed_links = 0
+        for target_skills in [self.skills_dir(), self.config_dir / "skills"]:
+            if target_skills.exists():
+                for item in target_skills.iterdir():
+                    if item.is_symlink():
+                        try:
+                            resolved = item.resolve()
+                            if (
+                                str(resolved).startswith(str(self.spellbook_dir))
+                                and remove_symlink(item, dry_run=self.dry_run).success
+                            ):
                                 removed_links += 1
-                    except OSError:
-                        pass
-            results.append(
-                InstallResult(
-                    component="skills",
-                    platform=self.platform_id,
-                    success=True,
-                    action="removed",
-                    message=f"removed {removed_links} skill symlinks",
-                )
+                        except OSError:
+                            pass
+        results.append(
+            InstallResult(
+                component="skills",
+                platform=self.platform_id,
+                success=True,
+                action="removed",
+                message=f"removed {removed_links} skill symlinks",
             )
+        )
 
         return results
 
@@ -409,9 +420,9 @@ class AntigravityInstaller(PlatformInstaller):
     def get_symlinks(self) -> List[Path]:
         """Get paths to symlinks created by Antigravity."""
         links = []
-        target_skills = self.config_dir / "skills"
-        if target_skills.exists():
-            for item in target_skills.iterdir():
-                if item.is_symlink():
-                    links.append(item)
+        for target_skills in [self.skills_dir(), self.config_dir / "skills"]:
+            if target_skills.exists():
+                for item in target_skills.iterdir():
+                    if item.is_symlink():
+                        links.append(item)
         return links

--- a/tests/installer/test_rule_modules.py
+++ b/tests/installer/test_rule_modules.py
@@ -601,6 +601,7 @@ EXPECTED_PREFERENCE_IDS = frozenset(
         "opportunity-awareness",
         "pr-conventions",
         "session",
+        "stated-action",
         "testing",
         "worktrees",
     }

--- a/tests/integration/test_antigravity_installer.py
+++ b/tests/integration/test_antigravity_installer.py
@@ -32,8 +32,9 @@ def test_antigravity_creates_skill_symlinks(tmp_path):
     assert created == 2
     assert errors == 0
 
-    skill1_link = config_dir / "skills" / "test-skill-1"
-    skill2_link = config_dir / "skills" / "test-skill-2"
+    skills_root = config_dir.parent / "config" / "skills"
+    skill1_link = skills_root / "test-skill-1"
+    skill2_link = skills_root / "test-skill-2"
 
     assert skill1_link.is_symlink()
     assert skill2_link.is_symlink()
@@ -77,17 +78,32 @@ def test_antigravity_full_install_and_uninstall(tmp_path):
     assert module_link.is_symlink()
     assert module_link.resolve() == (spellbook_dir / "rules" / "00-core.md").resolve()
 
+    # Skills symlink at the corrected global skills root (~/.gemini/config/skills).
+    skills_root = config_dir.parent / "config" / "skills"
+    skill_link = skills_root / "test-skill"
+    assert skill_link.is_symlink()
+    assert skill_link.resolve() == (skills_dir / "test-skill").resolve()
+
     # The retired single sidecar is not created.
     assert not os.path.lexists(config_dir / "rules" / "spellbook.md")
 
     status = installer.detect()
     assert status.installed is True
 
+    # Also simulate a legacy symlink left behind in <config_dir>/skills to verify cleanup
+    legacy_skill_dir = config_dir / "skills"
+    legacy_skill_dir.mkdir(parents=True, exist_ok=True)
+    legacy_link = legacy_skill_dir / "legacy-skill"
+    os.symlink(skills_dir / "test-skill", legacy_link)
+    assert legacy_link.is_symlink()
+
     # Uninstall
     un_results = installer.uninstall()
     assert all(r.success for r in un_results)
 
-    # Uninstall is complete: every module file is gone, and detect() -- which
-    # keys on those files -- stops reporting the platform installed.
+    # Uninstall is complete: every module file is gone, skills symlinks (both active
+    # and legacy) are gone, and detect() stops reporting the platform installed.
     assert not list(rules_root.glob("??-spellbook-*.md"))
+    assert not os.path.lexists(skill_link)
+    assert not os.path.lexists(legacy_link)
     assert installer.detect().installed is False

--- a/tests/unit/test_antigravity_installer.py
+++ b/tests/unit/test_antigravity_installer.py
@@ -16,6 +16,8 @@ def test_antigravity_properties(tmp_path):
     assert installer.platform_name == "Antigravity"
     assert installer.platform_id == "antigravity"
     assert installer.mcp_config_path == tmp_path / "antigravity" / "mcp_config.json"
+    assert installer.skills_dir() == tmp_path / "config" / "skills"
+    assert installer.rule_module_dir() == tmp_path / "config" / "rules"
 
 
 def test_antigravity_detect_not_installed(tmp_path):


### PR DESCRIPTION
## Problem
Antigravity's global customization discovery traverses `~/.gemini/config/skills/<name>/SKILL.md`, not `~/.gemini/antigravity/skills`. While rules delivery was previously corrected to `~/.gemini/config/rules`, skill symlink delivery in `AntigravityInstaller` was still pointing to `self.config_dir / "skills"` (`~/.gemini/antigravity/skills`), causing all installed Spellbook skills to be ignored by the Antigravity agent.

## Solution
1. Added `skills_dir(self) -> Path` to `AntigravityInstaller`, resolving to `self.config_dir.parent / "config" / "skills"` (`~/.gemini/config/skills`).
2. Updated `_ensure_skill_symlinks()` to install symlinks into `self.skills_dir()`.
3. Updated `uninstall()` and `get_symlinks()` to handle both the active global skills root and any legacy symlinks in `~/.gemini/antigravity/skills`.
4. Updated unit and integration tests to verify symlink creation and cleanup at the corrected global root.

## Verification
- Ran `uv run pytest tests/unit/test_antigravity_installer.py tests/integration/test_antigravity_installer.py tests/test_installer_config_helpers.py tests/test_multi_target_install.py` (all 20 passed).
- All pre-commit quality hooks passed.