### PR TITLE
fix(tests): mark the pi settings mode assertions POSIX-only

### DIFF
--- a/tests/installer/test_pi_mcp_adapter.py
+++ b/tests/installer/test_pi_mcp_adapter.py
@@ -535,6 +535,7 @@ def test_reported_message_never_names_a_version_spellbook_did_not_write(
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.posix_only
 def test_install_preserves_an_owner_only_settings_mode(spellbook_dir, config_dir):
     """An owner-only settings.json must not come back world-readable.
 
@@ -556,6 +557,7 @@ def test_install_preserves_an_owner_only_settings_mode(spellbook_dir, config_dir
     assert PI_MCP_ADAPTER_SPEC in _read_pi_settings(settings_path)["packages"]
 
 
+@pytest.mark.posix_only
 def test_a_settings_file_the_installer_creates_is_owner_only(
     spellbook_dir, config_dir
 ):


### PR DESCRIPTION
## What does this PR do?

Marks the two `settings.json` file-mode tests in `tests/installer/test_pi_mcp_adapter.py` with the existing `posix_only` pytest marker. They assert on POSIX permission bits (`stat.S_IMODE(...) == 0o600`), which Windows does not implement, so they failed on `windows-latest` while passing on ubuntu and macOS and left `main` red.

`tests/conftest.py` already wires `posix_only` to a skip on Windows via `pytest_collection_modifyitems`, so the marker takes effect without further changes. The assertions themselves are untouched -- the POSIX behaviour they guard is the reason the underlying fix exists.

## Related issue

None.

## Checklist

- [x] Tests pass locally
- [ ] Documentation updated (if applicable)
