### PR TITLE
skills: add session-pull — portable session export across four coding agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`session-pull` skill.** Pulls chat history and hidden context out of
+  coding-agent sessions and re-emits them in a portable format another
+  assistant can pick up exactly where the session left off. Sources:
+  Claude Code CLI and Claude Code Desktop local sessions (the same
+  `~/.claude` JSONL store), OpenCode's current SQLite schema (legacy
+  `storage/` JSON deliberately unsupported), AionUi's conversation store,
+  and Antigravity conversations (protobuf payloads with no public schema,
+  reverse-engineered via a generic wire-format walk + string carving
+  calibrated against live dbs 2026-09-10, with a `debug-dump` subcommand for
+  archaeology). Stdlib-only bundled script (`skills/session-pull/session_pull.py`)
+  following the roundup.py precedent; strictly read-only (SQLite sources are
+  read through db+wal+shm snapshot copies, never opened in place). Output:
+  canonical JSON envelope normalizing events (`message`/`thinking`/
+  `tool_call`/`tool_result`/`compaction`/`file_state`/`meta`) across all
+  four sources, or a Markdown handoff document under a char budget in
+  `--mode handoff`. Default `compact` mode emits the latest compaction
+  summary verbatim plus everything after its boundary — the session's true
+  current position — falling back to the full transcript when no anchor
+  exists. `--redact` runs a best-effort secret pass; `--out` writes 0600 and
+  refuses overwrite without `--force`. AionUi installer-platform support is
+  a separate deferred workstream; Claude Desktop remote (claude.ai) chats
+  are out of scope by design.
 - Philosophy: a measurement taken on ONE member is not a measurement about the
   population. Name which one, every time. The failure is quiet because the
   figure is real -- measured, accurate, and false only in its scope -- so nothing

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@
   - [Parallelization](#parallelization)
   - [What it handles](#what-it-handles)
 - [What's Included](#whats-included)
-  - [Skills (62 total)](#skills-62-total)
+  - [Skills (63 total)](#skills-63-total)
   - [Commands (108 total)](#commands-108-total)
   - [Agents (16 total)](#agents-16-total)
 - [Platform Support](#platform-support)
@@ -181,7 +181,7 @@ Complete feature implementation, greenfield project creation, refactoring (with 
 
 ## What's Included
 
-### Skills (62 total)
+### Skills (63 total)
 
 Reusable workflows for structured development:
 
@@ -193,7 +193,7 @@ Reusable workflows for structured development:
 | **Autonomous Dev** | [autonomous-mode], [gathering-requirements], [dehallucination], [reflexion], [analyzing-domains], [assembling-context], [designing-workflows], [deep-research], [fractal-thinking] |
 | **Specialized** | [async-await-patterns], [using-lsp-tools], [managing-artifacts], [polish-repo], [generating-diagrams], [tooling-discovery], [dedupe], [estimating-tickets], [rounding-up-worktree-sessions] |
 | **Meta** | [using-skills]†, [writing-skills]†, [writing-commands], [instruction-engineering], [sharpening-prompts], [optimizing-instructions], [dispatching-parallel-agents]†, [smart-reading], [analyzing-skill-usage], [documenting-tools], [documenting-projects], [testing-strategy], [opportunity-awareness], [branch-context], [writing-copy] |
-| **Session** | [emotional-stakes], [agent2agent] |
+| **Session** | [emotional-stakes], [agent2agent], [session-pull] |
 
 *† Derived from [superpowers](https://github.com/obra/superpowers)*
 
@@ -247,6 +247,7 @@ Reusable workflows for structured development:
 [opportunity-awareness]: https://axiomantic.github.io/spellbook/latest/skills/opportunity-awareness/
 [branch-context]: https://axiomantic.github.io/spellbook/latest/skills/branch-context/
 [agent2agent]: https://axiomantic.github.io/spellbook/latest/skills/agent2agent/
+[session-pull]: https://axiomantic.github.io/spellbook/latest/skills/session-pull/
 [dedupe]: https://axiomantic.github.io/spellbook/latest/skills/dedupe/
 [distilling-prs]: https://axiomantic.github.io/spellbook/latest/skills/distilling-prs/
 [creating-issues-and-pull-requests]: https://axiomantic.github.io/spellbook/latest/skills/creating-issues-and-pull-requests/

--- a/docs/skills/session-pull.md
+++ b/docs/skills/session-pull.md
@@ -1,0 +1,156 @@
+# session-pull
+
+**Auto-invocation:** Your coding assistant will automatically invoke this skill when it detects a matching trigger.
+
+> Pull chat history and hidden context out of Claude Code / Claude Desktop (local), OpenCode, AionUi, and Antigravity sessions, and render a handoff document another coding assistant can pick up exactly where the session left off. Use when the user asks to export a session, hand off work between tools, resume a session in a different assistant, extract conversation history, or transfer context from one coding agent to another.
+## Skill Content
+
+````markdown
+# Session Pull
+
+Extract a coding-agent session — chat history, tool activity, todos, compaction
+summaries, file state — from its native store and re-emit it in a portable
+format the next assistant can consume directly.
+
+<ROLE>
+Context courier. Your job is lossless *enough*: the next agent must be able to
+continue the work without re-deriving what was already decided, tried, or
+broken. When in doubt, include more context and say what was truncated.
+</ROLE>
+
+## Invariant Principles
+
+1. **Read-only, always.** Never open a live store in place; the script
+   snapshot-copies SQLite databases and never writes to any source directory.
+2. **Honesty over completeness.** Unknown roles, unmappable records, and
+   reverse-engineered extractions are labeled as such (warnings, `role: null`)
+   rather than guessed.
+3. **Compaction-anchored reconstruction.** The default `compact` mode emits
+   the latest compaction summary verbatim plus every event after its boundary
+   — that is the true current position of the session, not the whole history.
+4. **The envelope is the contract.** Every mode except `handoff` emits exactly
+   one JSON object with `schema_version`, `source`, `session`, `summary`,
+   `events`, `warnings`. Never invent ad-hoc output shapes.
+5. **Privacy is the operator's call, not yours.** Transcripts contain
+   everything typed plus tool output. Suggest `--redact` for anything that
+   will leave the machine; never silently widen distribution.
+
+## CLI
+
+Single entry point, stdlib-only (no runtime deps), Python 3.11+:
+
+```
+skills/session-pull/session_pull.py <subcommand> [flags]
+```
+
+| Command | Purpose |
+|---------|---------|
+| `sources` | Which stores are present on this machine |
+| `list --source S [--cwd DIR] [--since ISO] [--lookback-hours N] [--limit N]` | Discover sessions (`--source all` for a union) |
+| `pull --source S --id ID [--mode compact\|full\|handoff] [--budget-chars N] [--out PATH] [--redact] [--include-thinking]` | Export one session |
+| `debug-dump --source antigravity --id ID` | Schema archaeology for the protobuf blobs |
+
+Modes:
+
+- `compact` (default): latest compaction summary verbatim + all post-boundary
+  events + todos + file state. Equals `full` when the session has no
+  compaction point.
+- `full`: every reconstructed event.
+- `handoff`: Markdown document for direct consumption by the next assistant
+  (Position → Pending work → Recent transcript, newest first, char-budgeted).
+
+`--out PATH` writes 0600 and refuses to overwrite without `--force`.
+
+## Workflow
+
+<analysis>
+Determine, before touching the script: which assistant produced the session
+(`sources`), which session (`list`, filtered to the repo with `--cwd`), and
+where the output must land (stdout pipe vs `--out` file). If the user did not
+name the session, show them the `list` candidates and let them pick — never
+guess between similarly-titled sessions.
+</analysis>
+
+<reflection>
+Before emitting, verify: did the source store actually exist (`sources`)? Are
+`warnings` empty enough to trust the output? In compact mode, is `summary`
+present or was there no compaction anchor (in which case the export is the
+whole transcript)? Did events survive at all for reverse-engineered sources?
+</reflection>
+
+<step number="1">
+Run `sources`. Report which of claude_code / opencode / aionui / antigravity
+are available. claude_code covers Claude Code CLI **and** Claude Code Desktop
+local sessions (same `~/.claude` store); Claude Desktop *remote* (claude.ai)
+chats are out of scope by design.
+</step>
+
+<step number="2">
+Run `list` for the relevant source, filtered with `--cwd` when the session
+belongs to a repo. Present candidates (title, last activity, source, whether
+it appears to be running right now) and confirm which one to pull.
+</step>
+
+<step number="3">
+Run `pull --mode compact`. Summarize for the user: how many events, whether a
+compaction anchor was used (and its boundary), todos found, truncation
+warnings. If the user needs the complete record, rerun with `--mode full`.
+</step>
+
+<step number="4">
+Deliver the context:
+- Piping into another assistant: feed the JSON envelope (or handoff markdown)
+  as context in the new conversation, then state the task to continue.
+- Claude Code target: if the session itself should be *resumed natively*,
+  `claude --resume <session-id>` is available; the handoff doc is for
+  cross-tool transfers.
+- Aion target: hand the handoff doc to the target conversation, optionally
+  via the agent2agent / session-message machinery for cross-session delivery.
+</step>
+
+<step number="5" optional="true">
+If the user asks for Antigravity detail the extractor missed, run `debug-dump`
+and inspect the carved strings; refine classifier constants only with that
+evidence, and record what you learned in the script's calibration docstrings.
+</step>
+
+## FORBIDDEN
+
+- NEVER write to any source store, config, or state directory. Export only.
+- NEVER pull and share a session the user did not ask about; transcripts are
+  sensitive by default.
+- NEVER claim an extraction is complete when `warnings` say otherwise — say
+  what was skipped and why.
+- NEVER pipe a session into another assistant without the user knowing where
+  its content will land.
+
+## Output Format
+
+The canonical JSON envelope (`compact`/`full`) normalizes across sources:
+
+| event type | meaning |
+|------------|---------|
+| `message` | chat text (`role`: user/assistant/unknown) |
+| `thinking` | model reasoning (only with `--include-thinking`) |
+| `tool_call` | tool name + input |
+| `tool_result` | tool output |
+| `compaction` | compaction summary record (`meta.anchor: true`) |
+| `file_state` | snapshot/file metadata |
+| `meta` | tips, agent notices, unmappable-but-kept records |
+
+`hidden: true` marks UI-hidden rows (AionUi `messages.hidden`); `sidechain:
+true` marks subagent traffic (Claude Code). Source quirks that survived
+verification are documented per-parser in the script docstrings — read them
+before changing extraction logic.
+
+## Known limits
+
+- **Antigravity**: payloads are protobuf with no public schema; extraction is
+  heuristic string carving calibrated on live dbs (2026-09-10). Roles, tool
+  names (`manage_task` fragments to `anag`/`task_description`), and tool
+  *results* are partially recoverable; unknown shapes degrade to meta events.
+- **AionUi**: text rows carry no user/assistant marker — roles are left unset.
+- **OpenCode**: current SQLite schema only; legacy `storage/` JSON is
+  deliberately unsupported.
+- **Claude Desktop remote** (claude.ai chats): out of scope by design.
+````

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -189,6 +189,7 @@ nav:
       - skills/requesting-code-review.md
       - skills/resolving-merge-conflicts.md
       - skills/rounding-up-worktree-sessions.md
+      - skills/session-pull.md
       - skills/reviewing-design-docs.md
       - skills/reviewing-impl-plans.md
       - skills/reviewing-prs.md

--- a/skills/session-pull/SKILL.md
+++ b/skills/session-pull/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: session-pull
+description: Pull chat history and hidden context out of Claude Code / Claude Desktop (local), OpenCode, AionUi, and Antigravity sessions, and render a handoff document another coding assistant can pick up exactly where the session left off. Use when the user asks to export a session, hand off work between tools, resume a session in a different assistant, extract conversation history, or transfer context from one coding agent to another.
+---
+
+# Session Pull
+
+Extract a coding-agent session — chat history, tool activity, todos, compaction
+summaries, file state — from its native store and re-emit it in a portable
+format the next assistant can consume directly.
+
+<ROLE>
+Context courier. Your job is lossless *enough*: the next agent must be able to
+continue the work without re-deriving what was already decided, tried, or
+broken. When in doubt, include more context and say what was truncated.
+</ROLE>
+
+## Invariant Principles
+
+1. **Read-only, always.** Never open a live store in place; the script
+   snapshot-copies SQLite databases and never writes to any source directory.
+2. **Honesty over completeness.** Unknown roles, unmappable records, and
+   reverse-engineered extractions are labeled as such (warnings, `role: null`)
+   rather than guessed.
+3. **Compaction-anchored reconstruction.** The default `compact` mode emits
+   the latest compaction summary verbatim plus every event after its boundary
+   — that is the true current position of the session, not the whole history.
+4. **The envelope is the contract.** Every mode except `handoff` emits exactly
+   one JSON object with `schema_version`, `source`, `session`, `summary`,
+   `events`, `warnings`. Never invent ad-hoc output shapes.
+5. **Privacy is the operator's call, not yours.** Transcripts contain
+   everything typed plus tool output. Suggest `--redact` for anything that
+   will leave the machine; never silently widen distribution.
+
+## CLI
+
+Single entry point, stdlib-only (no runtime deps), Python 3.11+:
+
+```
+skills/session-pull/session_pull.py <subcommand> [flags]
+```
+
+| Command | Purpose |
+|---------|---------|
+| `sources` | Which stores are present on this machine |
+| `list --source S [--cwd DIR] [--since ISO] [--lookback-hours N] [--limit N]` | Discover sessions (`--source all` for a union) |
+| `pull --source S --id ID [--mode compact\|full\|handoff] [--budget-chars N] [--out PATH] [--redact] [--include-thinking]` | Export one session |
+| `debug-dump --source antigravity --id ID` | Schema archaeology for the protobuf blobs |
+
+Modes:
+
+- `compact` (default): latest compaction summary verbatim + all post-boundary
+  events + todos + file state. Equals `full` when the session has no
+  compaction point.
+- `full`: every reconstructed event.
+- `handoff`: Markdown document for direct consumption by the next assistant
+  (Position → Pending work → Recent transcript, newest first, char-budgeted).
+
+`--out PATH` writes 0600 and refuses to overwrite without `--force`.
+
+## Workflow
+
+<analysis>
+Determine, before touching the script: which assistant produced the session
+(`sources`), which session (`list`, filtered to the repo with `--cwd`), and
+where the output must land (stdout pipe vs `--out` file). If the user did not
+name the session, show them the `list` candidates and let them pick — never
+guess between similarly-titled sessions.
+</analysis>
+
+<reflection>
+Before emitting, verify: did the source store actually exist (`sources`)? Are
+`warnings` empty enough to trust the output? In compact mode, is `summary`
+present or was there no compaction anchor (in which case the export is the
+whole transcript)? Did events survive at all for reverse-engineered sources?
+</reflection>
+
+<step number="1">
+Run `sources`. Report which of claude_code / opencode / aionui / antigravity
+are available. claude_code covers Claude Code CLI **and** Claude Code Desktop
+local sessions (same `~/.claude` store); Claude Desktop *remote* (claude.ai)
+chats are out of scope by design.
+</step>
+
+<step number="2">
+Run `list` for the relevant source, filtered with `--cwd` when the session
+belongs to a repo. Present candidates (title, last activity, source, whether
+it appears to be running right now) and confirm which one to pull.
+</step>
+
+<step number="3">
+Run `pull --mode compact`. Summarize for the user: how many events, whether a
+compaction anchor was used (and its boundary), todos found, truncation
+warnings. If the user needs the complete record, rerun with `--mode full`.
+</step>
+
+<step number="4">
+Deliver the context:
+- Piping into another assistant: feed the JSON envelope (or handoff markdown)
+  as context in the new conversation, then state the task to continue.
+- Claude Code target: if the session itself should be *resumed natively*,
+  `claude --resume <session-id>` is available; the handoff doc is for
+  cross-tool transfers.
+- Aion target: hand the handoff doc to the target conversation, optionally
+  via the agent2agent / session-message machinery for cross-session delivery.
+</step>
+
+<step number="5" optional="true">
+If the user asks for Antigravity detail the extractor missed, run `debug-dump`
+and inspect the carved strings; refine classifier constants only with that
+evidence, and record what you learned in the script's calibration docstrings.
+</step>
+
+## FORBIDDEN
+
+- NEVER write to any source store, config, or state directory. Export only.
+- NEVER pull and share a session the user did not ask about; transcripts are
+  sensitive by default.
+- NEVER claim an extraction is complete when `warnings` say otherwise — say
+  what was skipped and why.
+- NEVER pipe a session into another assistant without the user knowing where
+  its content will land.
+
+## Output Format
+
+The canonical JSON envelope (`compact`/`full`) normalizes across sources:
+
+| event type | meaning |
+|------------|---------|
+| `message` | chat text (`role`: user/assistant/unknown) |
+| `thinking` | model reasoning (only with `--include-thinking`) |
+| `tool_call` | tool name + input |
+| `tool_result` | tool output |
+| `compaction` | compaction summary record (`meta.anchor: true`) |
+| `file_state` | snapshot/file metadata |
+| `meta` | tips, agent notices, unmappable-but-kept records |
+
+`hidden: true` marks UI-hidden rows (AionUi `messages.hidden`); `sidechain:
+true` marks subagent traffic (Claude Code). Source quirks that survived
+verification are documented per-parser in the script docstrings — read them
+before changing extraction logic.
+
+## Known limits
+
+- **Antigravity**: payloads are protobuf with no public schema; extraction is
+  heuristic string carving calibrated on live dbs (2026-09-10). Roles, tool
+  names (`manage_task` fragments to `anag`/`task_description`), and tool
+  *results* are partially recoverable; unknown shapes degrade to meta events.
+- **AionUi**: text rows carry no user/assistant marker — roles are left unset.
+- **OpenCode**: current SQLite schema only; legacy `storage/` JSON is
+  deliberately unsupported.
+- **Claude Desktop remote** (claude.ai chats): out of scope by design.

--- a/skills/session-pull/session_pull.py
+++ b/skills/session-pull/session_pull.py
@@ -1,0 +1,2066 @@
+#!/usr/bin/env python3
+"""session_pull.py — pull coding-agent session history + hidden context into a
+portable format another assistant can pick up.
+
+Bundled with the ``session-pull`` skill. Stdlib-only (argparse, json, sqlite3,
+os, re, shutil, tempfile, datetime, pathlib) so it runs anywhere without a
+runtime dependency. Precedent: ``skills/rounding-up-worktree-sessions/roundup.py``.
+
+Supported sources (verified against live stores 2026-09-10):
+
+==================  ==========================================================
+source              storage
+==================  ==========================================================
+claude_code         ~/.claude/projects/<encoded-cwd>/<uuid>.jsonl plus
+                    ~/.claude-work/projects (same layout). JSONL, typed
+                    records. ALSO covers Claude Desktop *local* sessions,
+                    which persist to the same store (only the remote
+                    claude.ai cache in IndexedDB is out of scope).
+opencode            ~/.local/share/opencode/opencode.db — SQLite with
+                    session/message/part tables and JSON ``data`` columns.
+                    Current schema ONLY: the legacy ``storage/`` JSON tree
+                    is deliberately unsupported (operator decision).
+aionui              ~/Library/Application Support/AionUi/aionui/
+                    aionui-backend.db — conversations/messages/
+                    assistant_sessions tables; ``messages.content`` is a
+                    JSON blob and ``messages.hidden`` marks UI-hidden rows.
+antigravity         ~/.gemini/antigravity/conversations/<uuid>.db —
+                    per-conversation SQLite; ``steps.step_payload`` blobs
+                    are protobuf WITHOUT a public schema, so extraction is
+                    heuristic (generic wire-format walk + string carving).
+                    Degrades gracefully; use ``debug-dump`` for archaeology.
+==================  ==========================================================
+
+Output contract
+---------------
+* ``sources`` / ``list`` / ``pull`` (modes ``compact``/``full``) print exactly
+  one JSON object on stdout (``ensure_ascii=False``).
+* ``pull --mode handoff`` prints a Markdown handoff document (nothing else) —
+  that is the artifact to paste into / point the next assistant at.
+* ``--out PATH`` writes 0600, refuses to overwrite without ``--force``.
+
+Modes
+-----
+* ``full``    every reconstructed event, in source order.
+* ``compact`` default. Latest compaction summary VERBATIM + all events after
+              its boundary + todo/file-state snapshots + session metadata.
+              With no compaction point this equals ``full``.
+* ``handoff`` Markdown rendering of the compact view under a character
+              budget (--budget-chars, default 50000), newest-first.
+
+Safety
+------
+* Strictly read-only against every source store. SQLite sources are read
+  through snapshot copies (db + -wal + -shm copied to a temp dir, copy
+  removed afterwards); live WAL databases are never opened in place.
+* ``--redact`` runs a best-effort secret pattern pass over all extracted
+  text. It is a convenience, not a security boundary — review exports
+  before sharing.
+* Per-source parse failures degrade to ``warnings`` entries; a pull never
+  aborts because one record could not be decoded.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import sqlite3
+import sys
+import tempfile
+from collections.abc import Iterator
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = 1
+
+SOURCES = ("claude_code", "opencode", "aionui", "antigravity")
+
+RUNNING_WINDOW_SECONDS = 120
+
+DEFAULT_BUDGET_CHARS = 50_000
+
+# --------------------------------------------------------------------------
+# Root resolution. Everything is injectable: every parser takes explicit
+# root paths so tests can point them at tmp_path fixtures. The CLI resolves
+# defaults from $HOME, overridable per-source via env for operators whose
+# stores live elsewhere (dotfiles-synced machines, sandboxes).
+# --------------------------------------------------------------------------
+
+_ROOT_ENV = {
+    "claude_code": "SPELLBOOK_SESSION_PULL_CLAUDE_ROOT",
+    "opencode": "SPELLBOOK_SESSION_PULL_OPENCODE_ROOT",
+    "aionui": "SPELLBOOK_SESSION_PULL_AIONUI_ROOT",
+    "antigravity": "SPELLBOOK_SESSION_PULL_ANTIGRAVITY_ROOT",
+}
+
+
+def claude_root() -> Path:
+    env = os.environ.get(_ROOT_ENV["claude_code"])
+    if env:
+        return Path(env)
+    home = Path(os.environ.get("HOME", str(Path.home())))
+    return home / ".claude"
+
+
+def claude_work_root() -> Path:
+    home = Path(os.environ.get("HOME", str(Path.home())))
+    return home / ".claude-work"
+
+
+def opencode_root() -> Path:
+    env = os.environ.get(_ROOT_ENV["opencode"])
+    if env:
+        return Path(env)
+    xdg = os.environ.get("XDG_DATA_HOME")
+    if xdg:
+        return Path(xdg) / "opencode"
+    home = Path(os.environ.get("HOME", str(Path.home())))
+    return home / ".local" / "share" / "opencode"
+
+
+def aionui_root() -> Path:
+    env = os.environ.get(_ROOT_ENV["aionui"])
+    if env:
+        return Path(env)
+    home = Path(os.environ.get("HOME", str(Path.home())))
+    # macOS convention; Linux builds keep the same relative layout.
+    return home / "Library" / "Application Support" / "AionUi" / "aionui"
+
+
+def antigravity_root() -> Path:
+    env = os.environ.get(_ROOT_ENV["antigravity"])
+    if env:
+        return Path(env)
+    home = Path(os.environ.get("HOME", str(Path.home())))
+    return home / ".gemini" / "antigravity"
+
+
+# --------------------------------------------------------------------------
+# Small utilities
+# --------------------------------------------------------------------------
+
+
+def now_iso() -> str:
+    return datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def epoch_to_iso(ts: float | None) -> str | None:
+    """Epoch seconds or milliseconds -> ISO-8601 Z. None stays None."""
+    if ts is None:
+        return None
+    ts = float(ts)
+    if ts > 1e12:  # milliseconds
+        ts /= 1000.0
+    if ts <= 0:
+        return None
+    return datetime.fromtimestamp(ts, tz=UTC).strftime(
+        "%Y-%m-%dT%H:%M:%SZ"
+    )
+
+
+def iso_to_epoch_ms(value: str | None) -> int | None:
+    if not value:
+        return None
+    try:
+        dt = datetime.fromisoformat(value)
+    except ValueError:
+        return None
+    return int(dt.timestamp() * 1000)
+
+
+def tolerant_json(raw: str | bytes | None) -> Any:
+    """json.loads that returns the raw value instead of raising."""
+    if raw is None:
+        return None
+    try:
+        return json.loads(raw)
+    except (ValueError, TypeError):
+        return None
+
+
+def emit(payload: Any, out: Any = None) -> None:
+    """Print a JSON document. Always-JSON convention (see module docstring)."""
+    target = out if out is not None else sys.stdout
+    json.dump(payload, target, ensure_ascii=False, indent=2, default=str)
+    target.write("\n")
+
+
+def warn(envelope_warnings: list[str], message: str) -> None:
+    if message not in envelope_warnings:
+        envelope_warnings.append(message)
+
+
+def looks_running(epoch_seconds: float | None) -> bool:
+    if not epoch_seconds:
+        return False
+    now = datetime.now(UTC).timestamp()
+    return 0 < now - epoch_seconds < RUNNING_WINDOW_SECONDS
+
+
+# --------------------------------------------------------------------------
+# Secret redaction (best-effort convenience pass)
+# --------------------------------------------------------------------------
+
+REDACT_PATTERNS: tuple[tuple[str, str], ...] = (
+    ("aws_access_key", r"AKIA[0-9A-Z]{16}"),
+    ("anthropic_key", r"sk-ant-[A-Za-z0-9_\-]{20,}"),
+    ("openai_key", r"sk-[A-Za-z0-9_\-]{20,}"),
+    ("github_token", r"gh[pousr]_[A-Za-z0-9]{36,}"),
+    ("slack_token", r"xox[abprs]-[A-Za-z0-9\-]{10,}"),
+    ("bearer", r"(?i)bearer\s+[A-Za-z0-9._\-]{20,}"),
+    ("private_key_block", r"-----BEGIN [A-Z ]*PRIVATE KEY-----"),
+    ("password_uri", r"://[^/\s:]+:[^@\s/]+@"),
+)
+
+
+def redact_text(text: str) -> tuple[str, list[str]]:
+    """Replace secret-looking substrings. Returns (text, kinds_redacted)."""
+    kinds: list[str] = []
+    for kind, pattern in REDACT_PATTERNS:
+        new = re.sub(pattern, f"[REDACTED:{kind}]", text)
+        if new != text:
+            kinds.append(kind)
+            text = new
+    return text, kinds
+
+
+# --------------------------------------------------------------------------
+# Canonical event model
+# --------------------------------------------------------------------------
+
+
+def make_event(
+    seq: int,
+    kind: str,
+    *,
+    ts: str | None = None,
+    role: str | None = None,
+    text: str | None = None,
+    tool: str | None = None,
+    meta: dict[str, Any] | None = None,
+    hidden: bool = False,
+    sidechain: bool = False,
+) -> dict[str, Any]:
+    ev: dict[str, Any] = {"seq": seq, "type": kind}
+    if ts is not None:
+        ev["ts"] = ts
+    if role is not None:
+        ev["role"] = role
+    if text is not None:
+        ev["text"] = text
+    if tool is not None:
+        ev["tool"] = tool
+    if meta:
+        ev["meta"] = meta
+    if hidden:
+        ev["hidden"] = True
+    if sidechain:
+        ev["sidechain"] = True
+    return ev
+
+
+def build_envelope(
+    source: str,
+    mode: str,
+    session: dict[str, Any],
+    events: list[dict[str, Any]],
+    summary: dict[str, Any] | None,
+    extras: dict[str, Any] | None,
+    warnings: list[str],
+) -> dict[str, Any]:
+    envelope = {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": now_iso(),
+        "source": source,
+        "mode": mode,
+        "session": session,
+        "summary": summary,
+        "events": events,
+        "warnings": warnings,
+    }
+    if extras:
+        envelope.update(extras)
+    return envelope
+
+
+# --------------------------------------------------------------------------
+# SQLite snapshot reading
+# --------------------------------------------------------------------------
+
+
+class SqliteSnapshot:
+    """Copy a live WAL-mode database and read the copy read-only.
+
+    Source stores are held open by their apps in WAL mode. Opening them in
+    place risks torn reads and lock contention; ``immutable=1`` risks missing
+    recent committed frames. The safe pattern is copying db + -wal + -shm to
+    a temp dir and reading the copy. The copy is removed on close.
+    """
+
+    def __init__(self, db_path: Path) -> None:
+        self.db_path = db_path
+        self.tmpdir: str | None = None
+        self.conn: Any = None
+
+    def __enter__(self) -> Any:
+        if not self.db_path.exists():
+            raise FileNotFoundError(str(self.db_path))
+        self.tmpdir = tempfile.mkdtemp(prefix="session-pull-snapshot-")
+        dest = Path(self.tmpdir) / "snapshot.db"
+        for suffix in ("", "-wal", "-shm"):
+            src = Path(str(self.db_path) + suffix)
+            if src.exists():
+                shutil.copy2(src, Path(str(dest) + suffix))
+        self.conn = sqlite3.connect(str(dest))
+        self.conn.row_factory = sqlite3.Row
+        return self.conn
+
+    def __exit__(self, exc_type: object, exc: object, tb: object) -> None:
+        if self.conn is not None:
+            self.conn.close()
+            self.conn = None
+        if self.tmpdir:
+            shutil.rmtree(self.tmpdir, ignore_errors=True)
+            self.tmpdir = None
+
+
+# --------------------------------------------------------------------------
+# claude_code source
+# --------------------------------------------------------------------------
+
+
+def encode_cwd_literal(path: str) -> str:
+    """Claude Code encodes a project cwd by replacing every non-alphanumeric
+    character with '-'. Verified against ~/.claude/projects layout
+    (2026-09-10), matching roundup.py's rule."""
+    return re.sub(r"[^A-Za-z0-9]", "-", path)
+
+
+def claude_project_dirs(root: Path) -> list[Path]:
+    projects = root / "projects"
+    if not projects.is_dir():
+        return []
+    return sorted(p for p in projects.iterdir() if p.is_dir())
+
+
+def claude_session_files(root: Path) -> list[Path]:
+    """All conversation JSONL files across project dirs, newest first.
+
+    Only ``<uuid>.jsonl`` conversation files count. roundup.py documented
+    that sidecar per-session directories and ``agent-*.jsonl`` subagent
+    transcripts live beside them; those are deliberately excluded here.
+    """
+    files: list[Path] = []
+    for project_dir in claude_project_dirs(root):
+        for entry in project_dir.iterdir():
+            if entry.is_file() and entry.name.endswith(".jsonl") and not (
+                entry.name.startswith("agent-")
+            ):
+                files.append(entry)
+    files.sort(key=lambda p: p.stat().st_mtime, reverse=True)
+    return files
+
+
+def claude_title_scan(jsonl_path: Path) -> dict[str, Any]:
+    """Light scan: title + timestamps without a full parse.
+
+    Reads the first 64KiB and last 32KiB of the file. Title precedence
+    (verified in roundup.py): customTitle > agentName > aiTitle > first
+    user text. Compact detection from any scanned record.
+    """
+    info: dict[str, Any] = {"title": None, "first_ts": None, "last_ts": None,
+                            "compacted": False, "git_branch": None}
+    size = jsonl_path.stat().st_size
+    with jsonl_path.open("rb") as fh:
+        head = fh.read(65536)
+        if size > 65536:
+            fh.seek(max(0, size - 32768))
+            tail = fh.read()
+        else:
+            tail = b""
+    candidate: str | None = None
+    for chunk in (head, tail):
+        for line in chunk.splitlines():
+            if not line.strip():
+                continue
+            rec = tolerant_json(line)
+            if not isinstance(rec, dict):
+                continue
+            if rec.get("type") == "summary" and rec.get("summary"):
+                info["title"] = info["title"] or rec["summary"]
+            for key in ("customTitle", "agentName", "aiTitle"):
+                if rec.get(key):
+                    info["title"] = rec[key]
+                    break
+            if info["git_branch"] is None and rec.get("gitBranch"):
+                info["git_branch"] = rec["gitBranch"]
+            if rec.get("timestamp"):
+                if info["first_ts"] is None and chunk is head:
+                    info["first_ts"] = rec["timestamp"]
+                info["last_ts"] = rec["timestamp"]
+            if rec.get("isCompactSummary"):
+                info["compacted"] = True
+            if (
+                candidate is None
+                and rec.get("type") == "user"
+                and not rec.get("isMeta")
+                and not rec.get("isSidechain")
+            ):
+                content = (rec.get("message") or {}).get("content")
+                if isinstance(content, str) and content.strip():
+                    candidate = content.strip()
+                elif isinstance(content, list):
+                    for block in content:
+                        if isinstance(block, dict) and block.get("type") == "text":
+                            candidate = block.get("text")
+                            break
+            if info["title"] is None and candidate:
+                info["title"] = candidate.splitlines()[0][:120]
+    return info
+
+
+def claude_session_id(jsonl_path: Path) -> str:
+    return jsonl_path.stem
+
+
+def claude_todo_paths(root: Path, session_id: str) -> list[Path]:
+    """Todo snapshots live in ~/.claude/todos/<sessionId>*.json (verified:
+    2026-09-10; the directory may be absent entirely)."""
+    todo_dir = root / "todos"
+    if not todo_dir.is_dir():
+        return []
+    return sorted(todo_dir.glob(f"{session_id}*.json"))
+
+
+def claude_file_state(root: Path, session_id: str) -> list[dict[str, Any]]:
+    """file-history/<uuid>/ holds per-session file snapshots (verified:
+    2026-09-10). We list tracked file names; contents are NOT copied."""
+    hist = root / "file-history" / session_id
+    if not hist.is_dir():
+        return []
+    entries = []
+    for p in sorted(hist.rglob("*")):
+        if p.is_file():
+            entries.append({
+                "path": str(p.relative_to(hist)),
+                "bytes": p.stat().st_size,
+            })
+    return entries
+
+
+def claude_todo_items(root: Path, session_id: str) -> list[dict[str, Any]]:
+    items: list[dict[str, Any]] = []
+    for path in claude_todo_paths(root, session_id):
+        data = tolerant_json(path.read_text(encoding="utf-8", errors="replace"))
+        rows = data if isinstance(data, list) else (data or {}).get("todos", [])
+        if isinstance(rows, list):
+            for row in rows:
+                if isinstance(row, dict):
+                    items.append({
+                        "content": row.get("content") or row.get("subject") or "",
+                        "status": row.get("status") or "pending",
+                    })
+    return items
+
+
+def _claude_block_events(
+    blocks: Any,
+    seq: int,
+    ts: str | None,
+    role: str,
+    sidechain: bool,
+    warnings: list[str],
+) -> Iterator[dict[str, Any]]:
+    """Yield canonical events for one Claude message content payload."""
+    if isinstance(blocks, str):
+        if blocks.strip():
+            yield make_event(seq, "message", ts=ts, role=role, text=blocks,
+                             sidechain=sidechain)
+        return
+    if not isinstance(blocks, list):
+        warn(warnings, f"unrecognized message content type: {type(blocks).__name__}")
+        return
+    for block in blocks:
+        if not isinstance(block, dict):
+            continue
+        btype = block.get("type")
+        if btype == "text":
+            text = block.get("text")
+            if isinstance(text, str) and text.strip():
+                yield make_event(seq, "message", ts=ts, role=role, text=text,
+                                 sidechain=sidechain)
+        elif btype == "thinking":
+            text = block.get("thinking") or block.get("text")
+            if isinstance(text, str) and text.strip():
+                yield make_event(seq, "thinking", ts=ts, text=text,
+                                 sidechain=sidechain)
+        elif btype == "tool_use":
+            yield make_event(seq, "tool_call", ts=ts, tool=block.get("name"),
+                             meta={"input": block.get("input")},
+                             sidechain=sidechain)
+        elif btype == "tool_result":
+            content = block.get("content")
+            if isinstance(content, list):
+                parts = [
+                    b.get("text", "")
+                    for b in content
+                    if isinstance(b, dict) and b.get("type") == "text"
+                ]
+                text = "\n".join(parts)
+            elif isinstance(content, str):
+                text = content
+            else:
+                text = tolerant_json(json.dumps(block.get("content")))
+                text = text if isinstance(text, str) else json.dumps(
+                    block.get("content"), default=str
+                )
+            yield make_event(
+                seq, "tool_result", ts=ts, text=text or None,
+                meta={"tool_use_id": block.get("tool_use_id"),
+                      "is_error": bool(block.get("is_error"))},
+                sidechain=sidechain,
+            )
+        elif btype == "image":
+            yield make_event(seq, "meta", ts=ts,
+                             meta={"image_block": True}, sidechain=sidechain)
+        else:
+            warn(warnings, f"unknown claude content block type: {btype!r}")
+
+
+def parse_claude_session(
+    jsonl_path: Path,
+    mode: str,
+    root: Path,
+    warnings: list[str],
+    include_thinking: bool = False,
+) -> dict[str, Any]:
+    """Parse one Claude Code conversation JSONL into the canonical envelope.
+
+    Record kinds handled (verified against live files 2026-09-10):
+    * ``type=user`` / ``type=assistant`` — message envelope; ``message.content``
+      is a string or a block list (text / thinking / tool_use / tool_result).
+    * ``isCompactSummary: true`` — compaction boundary record (summary text).
+    * ``type=summary`` — title summary records (also used as compaction
+      anchors when no isCompactSummary exists in compact mode).
+    * ``isSidechain`` — subagent traffic, tagged, excluded in compact mode.
+    * ``isMeta`` — harness-inserted rows (e.g. queued commands), tagged meta.
+    """
+    session_id = claude_session_id(jsonl_path)
+    events: list[dict[str, Any]] = []
+    compaction_idx: int | None = None
+    compaction_text: str | None = None
+    compaction_ts: str | None = None
+    summary_records: list[str] = []
+    session_meta: dict[str, Any] = {}
+    seq = 0
+    raw_records: list[tuple[str | None, dict[str, Any] | None, str | None]] = []
+
+    with jsonl_path.open("r", encoding="utf-8", errors="replace") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            rec = tolerant_json(line)
+            if not isinstance(rec, dict):
+                warn(warnings, "claude_code: undecodable JSONL line skipped")
+                continue
+            rtype = rec.get("type")
+            ts = rec.get("timestamp")
+            if rtype == "summary" and rec.get("summary"):
+                summary_records.append(rec["summary"])
+                continue
+            if rec.get("isCompactSummary"):
+                text = None
+                content = (rec.get("message") or {}).get("content")
+                if isinstance(content, str):
+                    text = content
+                elif isinstance(content, list):
+                    parts = [
+                        b.get("text", "") for b in content
+                        if isinstance(b, dict) and b.get("type") == "text"
+                    ]
+                    text = "\n".join(parts)
+                if text:
+                    compaction_idx = len(raw_records)
+                    compaction_text = text
+                    compaction_ts = ts
+                continue
+            raw_records.append((rtype, rec, ts))
+
+    # Title precedence mirrors roundup.py.
+    title = None
+    for rtype, rec, _ts in raw_records:
+        for key in ("customTitle", "agentName", "aiTitle"):
+            if rec and rec.get(key):
+                title = rec[key]
+                break
+        if title:
+            break
+    if not title and summary_records:
+        title = summary_records[-1]
+    if not title:
+        for rtype, rec, _ts in raw_records:
+            if rtype == "user" and rec and not rec.get("isMeta"):
+                content = (rec.get("message") or {}).get("content")
+                text = None
+                if isinstance(content, str):
+                    text = content
+                elif isinstance(content, list):
+                    for block in content:
+                        if isinstance(block, dict) and block.get("type") == "text":
+                            text = block.get("text")
+                            break
+                if text and text.strip():
+                    title = text.strip().splitlines()[0][:120]
+                    break
+
+    # Compact mode drops everything strictly before the compaction anchor.
+    start = 0
+    if mode == "compact" and compaction_idx is not None:
+        start = compaction_idx
+
+    for idx in range(start, len(raw_records)):
+        rtype, rec, ts = raw_records[idx]
+        if rec is None:
+            continue
+        sidechain = bool(rec.get("isSidechain"))
+        if sidechain and mode == "compact":
+            continue
+        message = rec.get("message") or {}
+        role = message.get("role") or ("user" if rtype == "user" else rtype)
+        if rtype in ("user", "assistant"):
+            blocks = message.get("content")
+            for ev in _claude_block_events(
+                blocks, seq, ts, role or "", sidechain, warnings
+            ):
+                if ev["type"] == "thinking" and not include_thinking:
+                    continue
+                events.append(ev)
+                seq += 1
+        elif rtype == "system":
+            text = rec.get("content") or rec.get("text")
+            if isinstance(text, str) and text.strip():
+                events.append(make_event(seq, "meta", ts=ts, text=text))
+                seq += 1
+        if rec.get("cwd") and "cwd" not in session_meta:
+            session_meta["cwd"] = rec["cwd"]
+        if rec.get("gitBranch") and "git_branch" not in session_meta:
+            session_meta["git_branch"] = rec["gitBranch"]
+        if rec.get("version") and "app_version" not in session_meta:
+            session_meta["app_version"] = rec["version"]
+        if rec.get("slug"):
+            session_meta["slug"] = rec["slug"]
+
+    if compaction_idx is not None and mode != "full":
+        events.insert(
+            0,
+            make_event(-1, "compaction", ts=compaction_ts, text=compaction_text,
+                        meta={"anchor": True, "source_record": "isCompactSummary"}),
+        )
+
+    info = claude_title_scan(jsonl_path)
+    stat = jsonl_path.stat()
+    session = {
+        "id": session_id,
+        "title": title or info["title"],
+        "cwd": session_meta.get("cwd"),
+        "git_branch": session_meta.get("git_branch") or info["git_branch"],
+        "created_at": info["first_ts"],
+        "last_activity": info["last_ts"],
+        "compacted": compaction_idx is not None or info["compacted"],
+        "appears_running": looks_running(stat.st_mtime),
+        "size_bytes": stat.st_size,
+    }
+    todos = claude_todo_items(root, session_id)
+    file_state = claude_file_state(root, session_id)
+    summary = None
+    if compaction_text:
+        summary = {
+            "text": compaction_text,
+            "timestamp": compaction_ts,
+            "boundary_seq": compaction_idx,
+        }
+    elif summary_records and mode == "compact":
+        # Older-style /title-only summaries still give the next agent a hook.
+        summary = {"text": summary_records[-1], "timestamp": None,
+                   "boundary_seq": None}
+    extras = {"todos": todos, "file_state": file_state}
+    if session_meta.get("slug"):
+        session["slug"] = session_meta["slug"]
+    return build_envelope("claude_code", mode, session, events, summary,
+                          extras, warnings)
+
+
+def list_claude_sessions(
+    root: Path, cwd: str | None, warnings: list[str]
+) -> list[dict[str, Any]]:
+    sessions = []
+    for path in claude_session_files(root):
+        project_dir = path.parent
+        if cwd is not None:
+            encoded = encode_cwd_literal(cwd)
+            if project_dir.name != encoded and not project_dir.name.startswith(
+                encoded + "-"
+            ):
+                # Worktrees encode as <repo-path>-<worktree-name>.
+                continue
+        info = claude_title_scan(path)
+        stat = path.stat()
+        sessions.append({
+            "id": path.stem,
+            "source": "claude_code",
+            "title": info["title"],
+            "cwd": None,  # full parse resolves cwd; dir name is the hint
+            "project_dir": project_dir.name,
+            "git_branch": info["git_branch"],
+            "last_activity": info["last_ts"],
+            "compacted": info["compacted"],
+            "appears_running": looks_running(stat.st_mtime),
+            "size_bytes": stat.st_size,
+            "mtime": epoch_to_iso(stat.st_mtime),
+        })
+    return sessions
+
+
+# --------------------------------------------------------------------------
+# opencode source (current SQLite schema only)
+# --------------------------------------------------------------------------
+
+
+def opencode_db_path(root: Path) -> Path:
+    return root / "opencode.db"
+
+
+def list_opencode_sessions(
+    root: Path, cwd: str | None, warnings: list[str]
+) -> list[dict[str, Any]]:
+    db = opencode_db_path(root)
+    if not db.exists():
+        warn(warnings, f"opencode: no db at {db} (legacy storage/ layout is "
+                       "deliberately unsupported)")
+        return []
+    rows: list[dict[str, Any]] = []
+    with SqliteSnapshot(db) as conn:
+        query = (
+            "SELECT s.id, s.slug, s.directory, s.title, s.model, s.agent, "
+            "s.time_created, s.time_updated, s.time_compacting, "
+            "s.time_archived, p.worktree "
+            "FROM session s LEFT JOIN project p ON p.id = s.project_id"
+        )
+        try:
+            cursor = conn.execute(query)
+        except sqlite3.Error as exc:
+            warn(warnings, f"opencode: session query failed: {exc}")
+            return []
+        for row in cursor:
+            directory = row["directory"] or row["worktree"]
+            if cwd is not None and directory and directory != cwd:
+                continue
+            counts = {"messages": 0}
+            try:
+                counts["messages"] = conn.execute(
+                    "SELECT count(*) FROM message WHERE session_id = ?",
+                    (row["id"],),
+                ).fetchone()[0]
+            except sqlite3.Error:
+                pass
+            updated = epoch_to_iso(row["time_updated"])
+            running = False
+            if row["time_updated"]:
+                running = looks_running(float(row["time_updated"]) / 1000.0)
+            rows.append({
+                "id": row["id"],
+                "source": "opencode",
+                "title": row["title"] or row["slug"],
+                "cwd": directory,
+                "git_branch": None,
+                "last_activity": updated,
+                "compacted": row["time_compacting"] is not None,
+                "appears_running": running,
+                "message_count": counts["messages"],
+                "model": row["model"],
+                "archived": row["time_archived"] is not None,
+            })
+    return rows
+
+
+def _oc_part_events(
+    part_data: dict[str, Any],
+    seq: int,
+    ts: str | None,
+    include_thinking: bool,
+    warnings: list[str],
+) -> Iterator[dict[str, Any]]:
+    ptype = part_data.get("type")
+    if ptype == "text":
+        text = part_data.get("text")
+        if isinstance(text, str) and text.strip():
+            yield make_event(seq, "message", ts=ts, text=text)
+    elif ptype == "tool":
+        state = part_data.get("state") or {}
+        status = state.get("status")
+        output = state.get("output")
+        if isinstance(output, dict):
+            out_text = output.get("output")
+            out_title = output.get("title")
+        else:
+            out_text = output
+            out_title = None
+        if isinstance(out_text, (dict, list)):
+            out_text = json.dumps(out_text, default=str)
+        if status == "pending":
+            yield make_event(seq, "tool_call", ts=ts, tool=part_data.get("tool"),
+                             meta={"input": state.get("input"),
+                                   "call_id": part_data.get("callID")})
+        else:
+            yield make_event(
+                seq, "tool_result", ts=ts, tool=part_data.get("tool"),
+                text=out_text if isinstance(out_text, str) else None,
+                meta={"status": status, "title": out_title,
+                      "call_id": part_data.get("callID")},
+            )
+    elif ptype == "reasoning":
+        if include_thinking:
+            text = part_data.get("text")
+            if isinstance(text, str) and text.strip():
+                yield make_event(seq, "thinking", ts=ts, text=text)
+    elif ptype in ("step-start", "step-finish"):
+        pass  # harness scaffolding, not content
+    elif ptype == "compaction":
+        text = part_data.get("text") or ""
+        meta = {k: v for k, v in part_data.items() if k not in ("type", "text")}
+        yield make_event(seq, "compaction", ts=ts,
+                         text=text if isinstance(text, str) and text else None,
+                         meta={"anchor": True, **meta})
+    elif ptype == "snapshot":
+        yield make_event(seq, "file_state", ts=ts,
+                         meta={"snapshot": part_data.get("snapshot")})
+    elif ptype == "agent":
+        yield make_event(seq, "meta", ts=ts, meta={"agent": part_data.get("name")})
+    elif ptype == "file":
+        yield make_event(seq, "file_state", ts=ts, meta={"file": part_data.get("mime")})
+    else:
+        warn(warnings, f"opencode: unknown part type {ptype!r} (kept as meta)")
+        yield make_event(seq, "meta", ts=ts,
+                         meta={"part_type": ptype,
+                               "data": {k: v for k, v in part_data.items()
+                                        if k != "type"}})
+
+
+def parse_opencode_session(
+    root: Path,
+    session_id: str,
+    mode: str,
+    warnings: list[str],
+    include_thinking: bool = False,
+) -> dict[str, Any]:
+    db = opencode_db_path(root)
+    session_row: dict[str, Any] = {}
+    events: list[dict[str, Any]] = []
+    compaction_event_idx: int | None = None
+    seq = 0
+    with SqliteSnapshot(db) as conn:
+        row = conn.execute(
+            "SELECT * FROM session WHERE id = ?", (session_id,)
+        ).fetchone()
+        if row is None:
+            warn(warnings, f"opencode: session {session_id!r} not found")
+            return build_envelope("opencode", mode, {"id": session_id}, events,
+                                  None, None, warnings)
+        session_row = dict(row)
+        rows = conn.execute(
+            "SELECT m.time_created AS m_time, m.data AS m_data, "
+            "p.data AS p_data, p.time_created AS p_time "
+            "FROM message m LEFT JOIN part p ON p.message_id = m.id "
+            "WHERE m.session_id = ? ORDER BY m.time_created, p.time_created",
+            (session_id,),
+        ).fetchall()
+        message_roles: dict[str, str] = {}
+        for mrow in rows:
+            mdata = tolerant_json(mrow["m_data"]) or {}
+            message_roles[mdata.get("id", "")] = mdata.get("role") or ""
+        compaction_epoch = session_row.get("time_compacting")
+        for mrow in rows:
+            mdata = tolerant_json(mrow["m_data"]) or {}
+            role = mdata.get("role")
+            # Part time beats message time: parts carry their own clocks
+            # and the compaction boundary is per-part (verified 2026-09-10).
+            ts = epoch_to_iso(mrow["p_time"] or mrow["m_time"])
+            pdata = tolerant_json(mrow["p_data"])
+            if pdata is None:
+                continue
+            if pdata.get("type") == "compaction":
+                compaction_event_idx = seq
+            for ev in _oc_part_events(pdata, seq, ts, include_thinking, warnings):
+                if role:
+                    ev["role"] = ev.get("role", role)
+                events.append(ev)
+                seq += 1
+
+    if mode == "compact" and compaction_event_idx is not None:
+        anchor = next(
+            (e for e in events if e.get("seq") == compaction_event_idx), None
+        )
+        if anchor is not None:
+            anchor_ts = anchor.get("ts")
+            kept = [e for e in events
+                    if e.get("type") == "compaction" or
+                    (anchor_ts and e.get("ts") and e["ts"] >= anchor_ts)]
+            events = kept
+
+    if mode == "compact" and compaction_epoch and compaction_event_idx is None:
+        warn(warnings, "opencode: session has time_compacting but no "
+                       "compaction part survived; falling back to full order")
+
+    session = {
+        "id": session_id,
+        "title": session_row.get("title") or session_row.get("slug"),
+        "cwd": session_row.get("directory") or session_row.get("worktree"),
+        "git_branch": None,
+        "created_at": epoch_to_iso(session_row.get("time_created")),
+        "last_activity": epoch_to_iso(session_row.get("time_updated")),
+        "compacted": compaction_epoch is not None,
+        "appears_running": (
+            looks_running(float(session_row["time_updated"]) / 1000.0)
+            if session_row.get("time_updated") else False
+        ),
+        "model": session_row.get("model"),
+        "agent": session_row.get("agent"),
+        "tokens_input": session_row.get("tokens_input"),
+        "tokens_output": session_row.get("tokens_output"),
+    }
+    summary = None
+    compactions = [e for e in events if e["type"] == "compaction"]
+    if compactions:
+        last = compactions[-1]
+        summary = {"text": last.get("text"),
+                   "timestamp": last.get("ts"),
+                   "boundary_seq": last["seq"]}
+    return build_envelope("opencode", mode, session, events, summary, None,
+                          warnings)
+
+
+# --------------------------------------------------------------------------
+# aionui source
+# --------------------------------------------------------------------------
+
+
+def aionui_db_path(root: Path) -> Path:
+    return root / "aionui-backend.db"
+
+
+def _aionui_project_paths(conn: Any, conversation_id: str) -> list[str]:
+    """Best-effort workspace paths for a conversation.
+
+    Sources tried in order (verified 2026-09-10):
+    * assistant_sessions.workspace (agent-backed conversations)
+    * conversations.extra JSON (path-shaped values)
+    """
+    paths: list[str] = []
+    try:
+        for row in conn.execute(
+            "SELECT workspace FROM assistant_sessions WHERE conversation_id = ?",
+            (conversation_id,),
+        ):
+            if row["workspace"]:
+                paths.append(row["workspace"])
+    except sqlite3.Error:
+        pass
+    try:
+        row = conn.execute(
+            "SELECT extra FROM conversations WHERE id = ?", (conversation_id,)
+        ).fetchone()
+        extra = tolerant_json(row["extra"]) if row and row["extra"] else None
+        if isinstance(extra, dict):
+            for value in extra.values():
+                if isinstance(value, str) and value.startswith(os.sep):
+                    paths.append(value)
+                elif isinstance(value, dict):
+                    for inner in value.values():
+                        if isinstance(inner, str) and inner.startswith(os.sep):
+                            paths.append(inner)
+    except sqlite3.Error:
+        pass
+    # Deduplicate preserving order.
+    seen: set[str] = set()
+    unique = []
+    for p in paths:
+        if p not in seen:
+            seen.add(p)
+            unique.append(p)
+    return unique
+
+
+def list_aionui_sessions(
+    root: Path, cwd: str | None, warnings: list[str]
+) -> list[dict[str, Any]]:
+    db = aionui_db_path(root)
+    if not db.exists():
+        warn(warnings, f"aionui: no db at {db}")
+        return []
+    rows: list[dict[str, Any]] = []
+    with SqliteSnapshot(db) as conn:
+        try:
+            cursor = conn.execute(
+                "SELECT c.id, c.name, c.type, c.model, c.status, c.created_at, "
+                "c.updated_at, c.archived_at "
+                "FROM conversations c ORDER BY c.updated_at DESC"
+            )
+        except sqlite3.Error as exc:
+            warn(warnings, f"aionui: conversations query failed: {exc}")
+            return []
+        for row in cursor:
+            paths = _aionui_project_paths(conn, row["id"])
+            if cwd is not None and not any(
+                    p == cwd or p.startswith(cwd + os.sep) or
+                    cwd.startswith(p + os.sep)
+                    for p in paths
+            ):
+                continue
+            try:
+                msg_count = conn.execute(
+                    "SELECT count(*) FROM messages WHERE conversation_id = ?",
+                    (row["id"],),
+                ).fetchone()[0]
+            except sqlite3.Error:
+                msg_count = 0
+            agent_types: list[str] = []
+            try:
+                agent_types = [
+                    r[0] for r in conn.execute(
+                        "SELECT DISTINCT agent_type FROM assistant_sessions "
+                        "WHERE conversation_id = ?",
+                        (row["id"],),
+                    )
+                ]
+            except sqlite3.Error:
+                pass
+            last_iso = epoch_to_iso(row["updated_at"])
+            running = False
+            if row["updated_at"]:
+                running = looks_running(float(row["updated_at"]) / 1000.0)
+            rows.append({
+                "id": row["id"],
+                "source": "aionui",
+                "title": (row["name"] or "").splitlines()[0][:120] or None,
+                "cwd": paths[0] if paths else None,
+                "workspaces": paths,
+                "agent_types": agent_types,
+                "last_activity": last_iso,
+                "appears_running": running,
+                "message_count": msg_count,
+                "model": row["model"],
+                "conversation_type": row["type"],
+                "archived": row["archived_at"] is not None,
+            })
+    return rows
+
+
+def _aionui_content_events(
+    msg_type: str,
+    content: dict[str, Any],
+    seq: int,
+    ts: str | None,
+    hidden: bool,
+    warnings: list[str],
+) -> Iterator[dict[str, Any]]:
+    """Map one aionui ``messages`` row to canonical events.
+
+    Row ``type`` column is the discriminator (verified 2026-09-10):
+    * ``text``      -> {content} — chat message. NOTE: the store carries NO
+                       user/assistant marker on text rows, so role is
+                       unknown and left unset; position order is the flow.
+    * ``thinking``  -> {content, status, duration_ms} — model reasoning.
+    * ``tool_call`` -> {call_id, name, args, status, input, output} — one row
+                       holds both the call and (once finished) its output.
+    * ``tips``      -> {content, type, code, params, supersedes_key, error} —
+                       harness status notes (success/error), mapped to meta.
+    """
+    text = content.get("content")
+    if msg_type == "thinking" and isinstance(text, str) and text.strip():
+        yield make_event(seq, "thinking", ts=ts, text=text, hidden=hidden)
+        return
+    if msg_type == "tips":
+        tip = {"content": text} if isinstance(text, str) else {}
+        tip.update({k: content.get(k) for k in ("type", "code", "params",
+                                                "supersedes_key", "error")
+                    if content.get(k) is not None})
+        if tip:
+            yield make_event(seq, "meta", ts=ts,
+                             text=tip.get("content"),
+                             meta={"kind": "aionui_tip", **{
+                                 k: v for k, v in tip.items()
+                                 if k != "content"}}, hidden=hidden)
+            return
+    if msg_type == "tool_call" or content.get("name"):
+        name = content.get("name")
+        call_input = (content.get("args")
+                      if content.get("args") is not None
+                      else content.get("input"))
+        meta: dict[str, Any] = {"call_id": content.get("call_id"),
+                                "status": content.get("status")}
+        if isinstance(call_input, (dict, list)):
+            meta["input"] = call_input
+        elif isinstance(call_input, str):
+            meta["input_raw"] = call_input
+        if name:
+            yield make_event(seq, "tool_call", ts=ts, tool=name, meta=meta,
+                             hidden=hidden)
+        output = content.get("output")
+        if output is not None:
+            if isinstance(output, dict):
+                output_text = output.get("output") or json.dumps(
+                    output, default=str)
+            elif isinstance(output, str):
+                output_text = output
+            else:
+                output_text = json.dumps(output, default=str)
+            yield make_event(
+                seq, "tool_result", ts=ts, tool=name,
+                text=output_text if isinstance(output_text, str) else None,
+                meta={"call_id": content.get("call_id"),
+                      "error": content.get("error")}, hidden=hidden,
+            )
+        error = content.get("error")
+        if error and not name:
+            yield make_event(seq, "meta", ts=ts, text=str(error),
+                             meta={"kind": "error"}, hidden=hidden)
+        return
+    # text (and anything unknown): chat message; no role marker exists.
+    if isinstance(text, str) and text.strip():
+        yield make_event(seq, "message", ts=ts, text=text, hidden=hidden)
+    elif not content:
+        # Unknown content shape — keep it visible rather than dropping data.
+        warn(warnings,
+             f"aionui: message row type {msg_type!r} has empty content")
+
+
+def parse_aionui_session(
+    root: Path,
+    session_id: str,
+    mode: str,
+    warnings: list[str],
+    include_thinking: bool = False,
+) -> dict[str, Any]:
+    db = aionui_db_path(root)
+    events: list[dict[str, Any]] = []
+    seq = 0
+    conv_row: dict[str, Any] = {}
+    with SqliteSnapshot(db) as conn:
+        row = conn.execute(
+            "SELECT * FROM conversations WHERE id = ?", (session_id,)
+        ).fetchone()
+        if row is None:
+            warn(warnings, f"aionui: conversation {session_id!r} not found")
+            return build_envelope("aionui", mode, {"id": session_id}, events,
+                                  None, None, warnings)
+        conv_row = dict(row)
+        try:
+            rows = conn.execute(
+                "SELECT type, content, hidden, created_at, position, status "
+                "FROM messages WHERE conversation_id = ? "
+                "ORDER BY position, created_at",
+                (session_id,),
+            ).fetchall()
+        except sqlite3.Error as exc:
+            warn(warnings, f"aionui: messages query failed: {exc}")
+            rows = []
+        for mrow in rows:
+            content = tolerant_json(mrow["content"])
+            if not isinstance(content, dict):
+                content = {}
+            ts = epoch_to_iso(mrow["created_at"])
+            hidden = bool(mrow["hidden"])
+            for ev in _aionui_content_events(
+                mrow["type"], content, seq, ts, hidden, warnings
+            ):
+                events.append(ev)
+                seq += 1
+        agent_types: list[str] = []
+        try:
+            agent_types = [
+                r[0] for r in conn.execute(
+                    "SELECT DISTINCT agent_type FROM assistant_sessions "
+                    "WHERE conversation_id = ?",
+                    (session_id,),
+                )
+            ]
+        except sqlite3.Error:
+            pass
+        artifacts: list[dict[str, Any]] = []
+        try:
+            for arow in conn.execute(
+                "SELECT * FROM conversation_artifacts WHERE conversation_id = ?",
+                (session_id,),
+            ):
+                artifacts.append({
+                    k: arow[idx] for idx, k in enumerate(arow.keys())
+                })
+        except sqlite3.Error:
+            pass
+
+    compaction = None  # aionui has no first-class compaction records
+    if mode == "compact":
+        warn(warnings, "aionui: no compaction records in store; compact mode "
+                       "equals full mode")
+    workspaces = _aionui_workspaces(db, session_id)
+    session = {
+        "id": session_id,
+        "title": (conv_row.get("name") or "").splitlines()[0][:120] or None,
+        "cwd": None,
+        "workspaces": workspaces,
+        "created_at": epoch_to_iso(conv_row.get("created_at")),
+        "last_activity": epoch_to_iso(conv_row.get("updated_at")),
+        "compacted": False,
+        "appears_running": (
+            looks_running(float(conv_row["updated_at"]) / 1000.0)
+            if conv_row.get("updated_at") else False
+        ),
+        "model": conv_row.get("model"),
+        "agent_types": agent_types,
+        "conversation_type": conv_row.get("type"),
+    }
+    extras = None
+    if artifacts:
+        extras = {"artifacts": artifacts}
+    return build_envelope("aionui", mode, session, events, compaction, extras,
+                          warnings)
+
+
+def _aionui_workspaces(db_path: Path, session_id: str) -> list[str]:
+    try:
+        with SqliteSnapshot(db_path) as conn:
+            return _aionui_project_paths(conn, session_id)
+    except (FileNotFoundError, sqlite3.Error):
+        return []
+
+
+# --------------------------------------------------------------------------
+# antigravity source (reverse-engineered)
+# --------------------------------------------------------------------------
+
+
+def antigravity_conversation_dbs(root: Path) -> list[Path]:
+    conv_dir = root / "conversations"
+    if not conv_dir.is_dir():
+        return []
+    return sorted(conv_dir.glob("*.db"), key=lambda p: p.stat().st_mtime,
+                  reverse=True)
+
+
+def _pb_read_varint(blob: bytes, pos: int) -> tuple[int, int] | None:
+    """Read a varint; returns (value, new_pos) or None on malformed input."""
+    result = 0
+    shift = 0
+    start = pos
+    while pos < len(blob):
+        byte = blob[pos]
+        result |= (byte & 0x7F) << shift
+        pos += 1
+        if not byte & 0x80:
+            return result, pos
+        shift += 7
+        if shift > 63 or pos - start > 10:
+            return None
+    return None
+
+
+def pb_walk(blob: bytes, depth: int = 0) -> list[tuple[int, int, Any]]:
+    """Generic protobuf wire-format walk (tolerant, schema-less).
+
+    Returns (field_number, wire_type, value) triples; length-delimited
+    values are raw bytes. Stops cleanly on malformed tails — Antigravity
+    blobs are protobuf without a public schema (verified 2026-09-10), so
+    this walk plus string carving is the extraction strategy.
+    """
+    fields: list[tuple[int, int, Any]] = []
+    pos = 0
+    n = len(blob)
+    while pos < n:
+        header = _pb_read_varint(blob, pos)
+        if header is None:
+            break
+        key, pos = header
+        field_no = key >> 3
+        wire = key & 0x07
+        if field_no == 0 or field_no > 100_000:
+            break
+        if wire == 0:  # varint
+            val = _pb_read_varint(blob, pos)
+            if val is None:
+                break
+            value, pos = val
+            fields.append((field_no, wire, value))
+        elif wire == 1:  # 64-bit
+            if pos + 8 > n:
+                break
+            fields.append((field_no, wire, blob[pos:pos + 8]))
+            pos += 8
+        elif wire == 2:  # length-delimited
+            ln = _pb_read_varint(blob, pos)
+            if ln is None:
+                break
+            length, pos = ln
+            if length > n - pos:
+                break
+            fields.append((field_no, wire, blob[pos:pos + length]))
+            pos += length
+        elif wire == 5:  # 32-bit
+            if pos + 4 > n:
+                break
+            fields.append((field_no, wire, blob[pos:pos + 4]))
+            pos += 4
+        else:
+            break  # groups (3/4) are deprecated; stop rather than guess
+    return fields
+
+
+def _pb_collect_strings(blob: bytes, depth: int = 0,
+                        max_depth: int = 6) -> list[str]:
+    """Recursively collect UTF-8-decodable strings from a protobuf blob.
+
+    Nested length-delimited fields that are NOT printable text are walked as
+    nested messages (bounded depth). Critically, a decoded string that ITSELF
+    parses as a nested protobuf message with high byte coverage is recursed
+    into rather than emitted — Antigravity nests text one wire level below a
+    wrapper, and the wrapper's length byte is otherwise glued onto the text
+    as a stray leading character (verified: 2026-09-10).
+    """
+    out: list[str] = []
+    fields = pb_walk(blob)
+    if not fields:
+        return out
+    # How much of the blob did the wire walk explain? High coverage on a
+    # printable-decoding blob means it is actually a nested message.
+    covered = 0
+    for field_no, wire, value in fields:
+        if wire == 0:
+            covered += 1
+        elif wire == 1:
+            covered += 10
+        elif wire == 5:
+            covered += 5
+        elif isinstance(value, bytes):
+            covered += len(value) + 1
+    if covered / max(len(blob), 1) < 0.5:
+        # Not protobuf-shaped: harvest printable runs directly.
+        for run in re.findall(rb"[\x20-\x7e]{10,}", blob):
+            out.append(run.decode("ascii", "replace"))
+        return out
+    for _field, _wire, value in fields:
+        if not isinstance(value, bytes):
+            continue
+        try:
+            text = value.decode("utf-8")
+        except UnicodeDecodeError:
+            if depth < max_depth:
+                out.extend(_pb_collect_strings(value, depth + 1, max_depth))
+            continue
+        if not text:
+            continue
+        printable = sum(1 for c in text if c.isprintable())
+        if printable / len(text) < 0.95:
+            if depth < max_depth and len(value) >= 8:
+                out.extend(_pb_collect_strings(value, depth + 1, max_depth))
+            continue
+        # Printable, but is it a nested message in disguise?
+        if depth < max_depth and len(value) >= 8:
+            nested = pb_walk(value)
+            if nested:
+                nested_covered = 0
+                for _n, w, v in nested:
+                    if w == 0:
+                        nested_covered += 1
+                    elif w == 1:
+                        nested_covered += 10
+                    elif w == 5:
+                        nested_covered += 5
+                    elif isinstance(v, bytes):
+                        nested_covered += len(v) + 1
+                if nested_covered / len(value) >= 0.5:
+                    out.extend(
+                        _pb_collect_strings(value, depth + 1, max_depth)
+                    )
+                    continue
+        out.append(text)
+    return out
+
+
+_MESSAGE_TS_RE = re.compile(r"\[Message\] timestamp=([\dT:.\-]+Z?) sender=(\S+)")
+_CALL_ID_RE = re.compile(r"^call_[0-9A-Za-z_\-]+$")
+_UUID_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+    re.IGNORECASE,
+)
+_TOOL_NAME_RE = re.compile(r"^[a-z][a-z_]{2,40}$")
+
+# Calibration (debug-dump against live dbs, 2026-09-10). Antigravity writes
+# each trajectory step with a ``step_type`` code; observed meanings:
+AGY_STEP_TYPE_USER = 14       # user prompt row
+AGY_STEP_TYPE_TASK_NOTE = 101  # task notifications ([Message] records)
+
+
+def _looks_like_natural_text(text: str) -> bool:
+    if len(text) < 12:
+        return False
+    letters = sum(1 for c in text if c.isalpha())
+    spaces = sum(1 for c in text if c.isspace())
+    return (letters + spaces) / len(text) >= 0.55
+
+
+def _agy_clean_message(text: str) -> str:
+    """Strip carving noise from a message body.
+
+    A message body is one string among carved runs; binary header bytes
+    sometimes survive as short junk lines (e.g. a lone 'H') or as stray
+    leading whitespace. Drop lines that are trivially short and re-join.
+    """
+    lines = [ln.strip() for ln in text.splitlines()]
+    kept = [ln for ln in lines if len(ln) > 2]
+    return "\n".join(kept).strip()
+
+
+def _agy_extract_step(
+    step_type: int,
+    strings: list[str],
+    seq: int,
+    warnings: list[str],
+    vocab: set[str] | None = None,
+) -> Iterator[dict[str, Any]]:
+    """Turn the carved strings of one Antigravity step into canonical events.
+
+    Calibration (2026-09-10, live dbs):
+    * Tool steps carry ``call_<id>``, a snake_case tool name and a JSON args
+      dict — across several step_type codes (5/7/8/21/132), so detection is
+      per-string, not per-step-type.
+    * Task notifications use ``[Message] timestamp=... sender=...`` records.
+    * step_type 14 rows hold the user prompt.
+    * State-marker rows (sessionID + UUIDs + opaque keys) are skipped.
+    """
+    # Filter carving noise: UUIDs, call ids, lone field labels.
+    texts = [
+        s for s in strings
+        if not _UUID_RE.match(s.strip())
+        and not _CALL_ID_RE.match(s.strip())
+        and s.strip() not in ("sessionID", "session_id")
+        and not re.fullmatch(r"-?\d+", s.strip())
+    ]
+    call_ids = [s for s in strings if _CALL_ID_RE.match(s.strip())]
+
+    # Task notifications ([Message] records) outrank tool detection: their
+    # blobs also embed call ids.
+    note_records = [s for s in texts if "[Message]" in s]
+    if note_records:
+        for record in note_records:
+            ts_match = _MESSAGE_TS_RE.search(record)
+            # Body: everything after the priority token, or after the
+            # sender when no priority token is present.
+            body = record.split("priority=", 1)[-1]
+            if "priority=" in record:
+                body = body.split(" ", 1)[-1]
+            yield make_event(
+                seq, "message",
+                ts=ts_match.group(1) if ts_match else None,
+                text=_agy_clean_message(body),
+                meta={"record": "task_notification"},
+            )
+        return
+
+    if call_ids:
+        tool = max(
+            (s.strip() for s in texts
+             if _TOOL_NAME_RE.match(s.strip()) and not s.strip().startswith("call_")),
+            key=len,
+            default=None,
+        )
+        args_json = next(
+            (s for s in texts if s.strip().startswith("{")
+             or s.strip().startswith("[")),
+            None,
+        )
+        args = tolerant_json(args_json) if args_json else None
+        if tool:
+            tool = _agy_repair_tool_name(tool, vocab)
+            meta: dict[str, Any] = {"call_id": call_ids[0]}
+            if isinstance(args, dict):
+                meta["input"] = args
+            elif args_json:
+                meta["input_raw"] = args_json
+            yield make_event(seq, "tool_call", tool=tool.strip(), meta=meta)
+            return
+
+    messages = [s for s in texts if _looks_like_natural_text(s)]
+    if not messages:
+        return
+
+    if step_type == AGY_STEP_TYPE_USER:
+        body = max(messages, key=len)
+        yield make_event(seq, "message", role="user",
+                         text=_agy_clean_message(body))
+        return
+
+    # Assistant/other natural text: role unknown (no reliable marker in the
+    # blobs) — emitted honestly as unattributed messages.
+    body = max(messages, key=len)
+    yield make_event(seq, "message", text=_agy_clean_message(body))
+
+
+def _agy_repair_tool_name(name: str, vocab: set[str] | None) -> str:
+    """Repair a fragmentary carved tool name against known names.
+
+    E.g. 'anag' is a fragment of 'manage_task' seen complete in sibling
+    rows. Single-fragment, substring-superstring only; never invents names.
+    """
+    if not vocab:
+        return name
+    for candidate in vocab:
+        if candidate != name and name in candidate:
+            return candidate
+    return name
+
+
+def _agy_emit_events(
+    step_rows: list[tuple[int, list[str]]],
+    vocab: set[str],
+    seq: int,
+    warnings: list[str],
+) -> tuple[list[dict[str, Any]], int]:
+    events: list[dict[str, Any]] = []
+    for step_type, strings in step_rows:
+        for ev in _agy_extract_step(step_type, strings, seq, warnings, vocab):
+            events.append(ev)
+            seq += 1
+    return events, seq
+
+
+def parse_antigravity_session(
+    root: Path,
+    session_id: str,
+    mode: str,
+    warnings: list[str],
+    include_thinking: bool = False,
+) -> dict[str, Any]:
+    db = root / "conversations" / f"{session_id}.db"
+    if not db.exists():
+        warn(warnings, f"antigravity: no conversation db at {db}")
+        return build_envelope("antigravity", mode, {"id": session_id}, [],
+                              None, None, warnings)
+    events: list[dict[str, Any]] = []
+    seq = 0
+    step_rows: list[tuple[int, list[str]]] = []
+    with SqliteSnapshot(db) as conn:
+        try:
+            rows = conn.execute(
+                "SELECT idx, step_type, step_format, step_payload "
+                "FROM steps ORDER BY idx"
+            ).fetchall()
+        except sqlite3.Error as exc:
+            warn(warnings, f"antigravity: steps query failed: {exc}")
+            rows = []
+        step_formats: dict[int, int] = {}
+        for row in rows:
+            sf = row["step_format"]
+            step_formats[sf] = step_formats.get(sf, 0) + 1
+            blob = row["step_payload"]
+            if not blob:
+                continue
+            strings = _pb_collect_strings(blob)
+            if not strings:
+                continue
+            step_rows.append((row["step_type"], strings))
+        # Conversation-local tool-name vocabulary: fragments carved from
+        # nested payloads get repaired against complete names seen in other
+        # rows (best-effort; verified 2026-09-10).
+        vocab: set[str] = set()
+        for _stype, strings in step_rows:
+            for s in strings:
+                if _TOOL_NAME_RE.match(s.strip()) and "_" in s:
+                    vocab.add(s.strip())
+        events, seq = _agy_emit_events(step_rows, vocab, seq, warnings)
+    session = {
+        "id": session_id,
+        "title": None,
+        "cwd": None,
+        "created_at": None,
+        "last_activity": epoch_to_iso(db.stat().st_mtime),
+        "compacted": False,
+        "appears_running": looks_running(db.stat().st_mtime),
+        "step_formats": step_formats,
+    }
+    if mode == "compact":
+        warn(warnings, "antigravity: no compaction markers are recoverable "
+                       "from protobuf blobs; compact mode equals full mode")
+    return build_envelope("antigravity", mode, session, events, None, None,
+                          warnings)
+
+
+def debug_dump_antigravity(
+    root: Path, session_id: str, warnings: list[str]
+) -> dict[str, Any]:
+    """Schema archaeology for one conversation db.
+
+    Emits per-step-type/step-format histograms and sample carved strings so
+    field meanings can be pinned and the classifier constants updated with
+    evidence. Read-only.
+    """
+    db = root / "conversations" / f"{session_id}.db"
+    if not db.exists():
+        warn(warnings, f"antigravity: no conversation db at {db}")
+        return {"warnings": warnings, "session_id": session_id}
+    dump: dict[str, Any] = {"session_id": session_id, "tables": {},
+                            "steps": []}
+    with SqliteSnapshot(db) as conn:
+        tables = [
+            r[0] for r in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            )
+        ]
+        for table in tables:
+            try:
+                count = conn.execute(
+                    f"SELECT count(*) FROM \"{table}\""
+                ).fetchone()[0]
+                cols = [
+                    r[1] for r in conn.execute(
+                        f'PRAGMA table_info("{table}")'
+                    )
+                ]
+                dump["tables"][table] = {"rows": count, "columns": cols}
+            except sqlite3.Error:
+                continue
+        try:
+            rows = conn.execute(
+                "SELECT idx, step_type, status, step_format, "
+                "length(step_payload) AS payload_len, step_payload "
+                "FROM steps ORDER BY idx LIMIT 200"
+            ).fetchall()
+        except sqlite3.Error as exc:
+            warn(warnings, f"antigravity: steps query failed: {exc}")
+            rows = []
+        for row in rows:
+            blob = row["step_payload"] or b""
+            strings = _pb_collect_strings(blob)[:8]
+            dump["steps"].append({
+                "idx": row["idx"],
+                "step_type": row["step_type"],
+                "status": row["status"],
+                "step_format": row["step_format"],
+                "payload_len": row["payload_len"],
+                "carved_strings": [s[:160] for s in strings],
+            })
+    dump["warnings"] = warnings
+    return dump
+
+
+# --------------------------------------------------------------------------
+# Handoff renderer (Markdown)
+# --------------------------------------------------------------------------
+
+
+HANDOFF_HEADER = """# Session handoff — {title}
+
+- **Source**: {source} (`{session_id}`)
+- **Workspace**: {cwd}
+- **Branch**: {branch}
+- **Exported**: {generated_at}
+- **Mode**: {mode}
+
+{stats_line}
+"""
+
+
+def render_handoff(envelope: dict[str, Any], budget_chars: int) -> str:
+    """Render the canonical envelope as a Markdown handoff document.
+
+    Structure follows the assembling-context convention (Position →
+    Pending work → Active decisions → Key learnings → Verification
+    commands → Recent transcript). Inclusion is newest-first under the
+    budget; elided content is marked, never silently dropped.
+    """
+    session = envelope.get("session") or {}
+    summary = envelope.get("summary") or {}
+    todos = envelope.get("todos") or []
+    events = envelope.get("events") or []
+    lines: list[str] = []
+    title = session.get("title") or session.get("id") or "exported session"
+    lines.append(HANDOFF_HEADER.format(
+        title=(title or "untitled session").replace("\n", " ")[:120],
+        source=envelope.get("source", "?"),
+        session_id=session.get("id", "?"),
+        cwd=session.get("cwd") or session.get("workspaces") or "unknown",
+        branch=session.get("git_branch") or "n/a",
+        generated_at=envelope.get("generated_at", "?"),
+        mode=envelope.get("mode", "?"),
+        stats_line=(
+            f"{len(events)} events included; "
+            f"compaction anchor: {'yes' if summary else 'none'}"
+        ),
+    ).rstrip())
+
+    if summary and summary.get("text"):
+        lines.append("## Position (latest compaction summary)\n")
+        lines.append(str(summary.get("text")).strip())
+        lines.append("")
+
+    if todos:
+        lines.append("## Pending work (todos)\n")
+        for todo in todos:
+            status = todo.get("status", "pending")
+            mark = {"completed": "x", "in_progress": "~"}.get(status, " ")
+            lines.append(f"- [{mark}] {todo.get('content', '')}")
+        lines.append("")
+
+    if summary and summary.get("boundary_seq") is not None:
+        lines.append(
+            "> Note: transcript below starts at the latest compaction "
+            "boundary; earlier turns are summarized in Position above.\n"
+        )
+
+    lines.append("## Recent transcript (newest first)\n")
+    used = 0
+    included = 0
+    elided = 0
+    rendered: list[str] = []
+    for ev in reversed(events):
+        if ev.get("type") == "compaction":
+            continue
+        text = ev.get("text")
+        tool = ev.get("tool")
+        meta = ev.get("meta") or {}
+        if ev["type"] == "tool_call":
+            chunk = f"**tool_call** `{tool}`\n```json\n{json.dumps(meta.get('input') or {}, indent=2, default=str)[:1500]}\n```"
+        elif ev["type"] == "tool_result":
+            body = (text or "")[:3000]
+            chunk = f"**tool_result** `{tool}`\n```\n{body}\n```"
+        elif ev["type"] in ("message", "thinking", "meta"):
+            chunk = f"**{ev['type']}**{(' [' + str(ev['role']) + ']') if ev.get('role') else ''}\n{(text or '')}"
+        else:
+            chunk = f"**{ev['type']}**\n{(text or json.dumps(meta, default=str)[:1500])}"
+        chunk = chunk.strip()
+        if used + len(chunk) > budget_chars:
+            elided += 1
+            continue
+        used += len(chunk)
+        rendered.append(f"### seq {ev.get('seq')}\n\n{chunk}")
+        included += 1
+    if elided:
+        rendered.append(
+            f"_(… {elided} older event(s) elided by the "
+            f"{budget_chars}-char budget; rerun with --mode full for "
+            "everything)_"
+        )
+    if rendered:
+        lines.extend(rendered)
+    else:
+        lines.append("_(no events recovered)_")
+    lines.append("")
+    return "\n".join(lines)
+
+
+# --------------------------------------------------------------------------
+# Source registry / CLI plumbing
+# --------------------------------------------------------------------------
+
+
+def source_status(root_override: dict[str, Path] | None = None) -> list[dict[str, Any]]:
+    def root_for(source: str) -> Path:
+        if root_override and source in root_override:
+            return root_override[source]
+        return {
+            "claude_code": claude_root(),
+            "opencode": opencode_root(),
+            "aionui": aionui_root(),
+            "antigravity": antigravity_root(),
+        }[source]
+
+    statuses = []
+    cc = root_for("claude_code")
+    sessions = cc / "projects"
+    oc = root_for("opencode")
+    aion = root_for("aionui")
+    agy = root_for("antigravity")
+    statuses.append({
+        "source": "claude_code",
+        "store": str(cc),
+        "available": sessions.is_dir() and any(sessions.iterdir()) if sessions.is_dir() else False,
+        "covers": "Claude Code CLI + Claude Code Desktop (local sessions)",
+        "notes": [
+            "Claude Desktop remote (claude.ai) chats are out of scope by design",
+        ],
+    })
+    legacy = oc / "storage"
+    statuses.append({
+        "source": "opencode",
+        "store": str(opencode_db_path(oc)),
+        "available": opencode_db_path(oc).exists(),
+        "covers": "OpenCode (current SQLite schema)",
+        "notes": (["Legacy storage/ JSON tree unsupported (by decision)"]
+                  if legacy.exists() else []),
+    })
+    statuses.append({
+        "source": "aionui",
+        "store": str(aionui_db_path(aion)),
+        "available": aionui_db_path(aion).exists(),
+        "covers": "AionUi conversations + agent sessions (assistant_sessions)",
+        "notes": [
+            "Installer-platform support for AionUi is a separate, deferred workstream",
+        ],
+    })
+    statuses.append({
+        "source": "antigravity",
+        "store": str(agy / "conversations"),
+        "available": bool(antigravity_conversation_dbs(agy)),
+        "covers": "Antigravity conversations (reverse-engineered protobuf "
+                  "blobs — best effort)",
+        "notes": [
+            ("Payloads are protobuf without a public schema; extraction degrades "
+             "to carved strings. debug-dump for archaeology"),
+        ],
+    })
+    return statuses
+
+
+def write_out(path: Path, content: str, force: bool) -> None:
+    if path.exists() and not force:
+        raise SystemExit(f"refusing to overwrite {path} (use --force)")
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "w", encoding="utf-8") as fh:
+        fh.write(content)
+
+
+def apply_redaction(
+    envelope: dict[str, Any],
+) -> tuple[dict[str, Any], list[str]]:
+    """Run the best-effort secret pass over all text-bearing fields.
+
+    Returns a NEW envelope plus the redaction kinds hit; the original is
+    left untouched.
+    """
+    kinds: set[str] = set()
+
+    def scrub(value: Any) -> Any:
+        if isinstance(value, str):
+            new, hit = redact_text(value)
+            kinds.update(hit)
+            return new
+        if isinstance(value, dict):
+            return {k: scrub(v) for k, v in value.items()}
+        if isinstance(value, list):
+            return [scrub(v) for v in value]
+        return value
+
+    cleaned = scrub(envelope)
+    return cleaned, sorted(kinds)
+
+
+def dispatch_pull(args: argparse.Namespace) -> int:
+    warnings: list[str] = []
+    mode = args.mode
+    if args.source == "claude_code":
+        envelope = parse_claude_session(
+            _find_claude_file(args.id, warnings),
+            mode, claude_root(), warnings,
+            include_thinking=args.include_thinking,
+        )
+    elif args.source == "opencode":
+        envelope = parse_opencode_session(
+            opencode_root(), args.id, mode, warnings,
+            include_thinking=args.include_thinking,
+        )
+    elif args.source == "aionui":
+        envelope = parse_aionui_session(
+            aionui_root(), args.id, mode, warnings,
+            include_thinking=args.include_thinking,
+        )
+    elif args.source == "antigravity":
+        envelope = parse_antigravity_session(
+            antigravity_root(), args.id, mode, warnings,
+            include_thinking=args.include_thinking,
+        )
+    else:
+        raise SystemExit(f"unknown source: {args.source}")
+
+    if getattr(args, "redact", False):
+        envelope, kinds = apply_redaction(envelope)
+        envelope["redacted"] = True
+        if kinds:
+            envelope["redaction_kinds"] = kinds
+    envelope["warnings"] = warnings
+
+    if mode == "handoff":
+        content = render_handoff(envelope, args.budget_chars)
+        envelope["handoff_md"] = content
+        if args.out:
+            write_out(Path(args.out), content, args.force)
+            emit({"written": str(args.out),
+                  "bytes": len(content.encode("utf-8")),
+                  "warnings": warnings})
+        else:
+            sys.stdout.write(content)
+        return 0
+
+    payload = json.dumps(envelope, indent=2, ensure_ascii=False, default=str)
+    if args.out:
+        write_out(Path(args.out), payload, args.force)
+        emit({"written": str(args.out),
+              "bytes": len(payload.encode("utf-8")),
+              "warnings": warnings})
+    else:
+        emit(envelope)
+    return 0
+
+
+def _find_claude_file(session_id: str, warnings: list[str]) -> Path:
+    matches = [
+        p for p in claude_session_files(claude_root())
+        if p.stem == session_id
+    ]
+    if not matches:
+        work = claude_work_root()
+        if work.is_dir():
+            matches = [p for p in claude_session_files(work)
+                       if p.stem == session_id]
+    if not matches:
+        raise SystemExit(
+            f"claude_code: no session file for id {session_id!r}"
+        )
+    return matches[0]
+
+
+def dispatch_list(args: argparse.Namespace) -> int:
+    warnings: list[str] = []
+    since_ms: int | None = None
+    if args.since:
+        since_ms = iso_to_epoch_ms(args.since)
+        if since_ms is None:
+            raise SystemExit(f"unparseable --since: {args.since}")
+    elif args.lookback_hours:
+        since_ms = int(
+            (datetime.now(UTC).timestamp() - args.lookback_hours * 3600)
+            * 1000
+        )
+    wanted = (
+        SOURCES if args.source == "all" else (args.source,)
+    )
+    collected: dict[str, list[dict[str, Any]]] = {}
+    for source in wanted:
+        if source == "claude_code":
+            sessions = list_claude_sessions(claude_root(), args.cwd, warnings)
+            for s in sessions:
+                s["_sort_ms"] = iso_to_epoch_ms(s.get("last_activity")) or 0
+        elif source == "opencode":
+            sessions = list_opencode_sessions(opencode_root(), args.cwd, warnings)
+            for s in sessions:
+                s["_sort_ms"] = iso_to_epoch_ms(s.get("last_activity")) or 0
+        elif source == "aionui":
+            sessions = list_aionui_sessions(aionui_root(), args.cwd, warnings)
+            for s in sessions:
+                s["_sort_ms"] = iso_to_epoch_ms(s.get("last_activity")) or 0
+        elif source == "antigravity":
+            sessions = []
+            warn(warnings, "antigravity: listing is best-effort; sessions are "
+                           "identified by db file id only. Use pull --source "
+                           "antigravity --id <file stem>.")
+            for db_path in antigravity_conversation_dbs(antigravity_root()):
+                sessions.append({
+                    "id": db_path.stem,
+                    "source": "antigravity",
+                    "title": None,
+                    "cwd": None,
+                    "last_activity": epoch_to_iso(db_path.stat().st_mtime),
+                    "appears_running": looks_running(db_path.stat().st_mtime),
+                    "size_bytes": db_path.stat().st_size,
+                })
+            for s in sessions:
+                s["_sort_ms"] = iso_to_epoch_ms(s.get("last_activity")) or 0
+        else:
+            raise SystemExit(f"unknown source: {source}")
+        if since_ms is not None:
+            sessions = [s for s in sessions if s["_sort_ms"] >= since_ms]
+        sessions.sort(key=lambda s: s["_sort_ms"], reverse=True)
+        collected[source] = [
+            {k: v for k, v in s.items() if k != "_sort_ms"}
+            for s in sessions[: args.limit]
+        ]
+
+    emit({
+        "generated_at": now_iso(),
+        "cwd": args.cwd,
+        "sources": {k: v for k, v in collected.items() if v or args.source != "all"},
+        "warnings": warnings,
+    })
+    return 0
+
+
+def dispatch_sources(_args: argparse.Namespace) -> int:
+    emit({
+        "generated_at": now_iso(),
+        "sources": source_status(),
+    })
+    return 0
+
+
+def dispatch_debug_dump(args: argparse.Namespace) -> int:
+    warnings: list[str] = []
+    if args.source != "antigravity":
+        raise SystemExit("debug-dump currently supports --source antigravity only")
+    dump = debug_dump_antigravity(antigravity_root(), args.id, warnings)
+    emit(dump)
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="session_pull.py",
+        description="Pull coding-agent session history + hidden context "
+                    "into a portable format for another assistant.",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_sources = sub.add_parser("sources", help="detect available sources")
+    p_sources.set_defaults(func=dispatch_sources)
+
+    p_list = sub.add_parser("list", help="discover sessions per source")
+    p_list.add_argument("--source", default="all",
+                        help=f"one of {SOURCES} or 'all'")
+    p_list.add_argument("--cwd", default=None,
+                        help="filter to sessions whose workspace matches")
+    p_list.add_argument("--since", default=None,
+                        help="ISO-8601 lower bound on last activity")
+    p_list.add_argument("--lookback-hours", type=float, default=None)
+    p_list.add_argument("--limit", type=int, default=20)
+    p_list.set_defaults(func=dispatch_list)
+
+    p_pull = sub.add_parser("pull", help="export one session")
+    p_pull.add_argument("--source", required=True, choices=SOURCES)
+    p_pull.add_argument("--id", required=True)
+    p_pull.add_argument("--mode", default="compact",
+                        choices=("compact", "full", "handoff"))
+    p_pull.add_argument("--budget-chars", type=int, default=DEFAULT_BUDGET_CHARS)
+    p_pull.add_argument("--out", default=None)
+    p_pull.add_argument("--force", action="store_true")
+    p_pull.add_argument("--redact", action="store_true")
+    p_pull.add_argument("--include-thinking", action="store_true")
+    p_pull.set_defaults(func=dispatch_pull)
+
+    p_dump = sub.add_parser("debug-dump",
+                            help="antigravity schema archaeology")
+    p_dump.add_argument("--source", default="antigravity")
+    p_dump.add_argument("--id", required=True)
+    p_dump.set_defaults(func=dispatch_debug_dump)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/session-pull/session_pull.py
+++ b/skills/session-pull/session_pull.py
@@ -37,8 +37,9 @@ Output contract
 ---------------
 * ``sources`` / ``list`` / ``pull`` (modes ``compact``/``full``) print exactly
   one JSON object on stdout (``ensure_ascii=False``).
-* ``pull --mode handoff`` prints a Markdown handoff document (nothing else) —
+* ``pull --mode handoff`` prints a Markdown handoff document to stdout —
   that is the artifact to paste into / point the next assistant at.
+  With ``--out PATH`` it prints the usual JSON status receipt instead.
 * ``--out PATH`` writes 0600, refuses to overwrite without ``--force``.
 
 Modes
@@ -1218,6 +1219,10 @@ def parse_aionui_session(
             for ev in _aionui_content_events(
                 mrow["type"], content, seq, ts, hidden, warnings
             ):
+                # Same default-drop rule as the claude parser: thinking rows
+                # are omitted unless the caller asked for them.
+                if ev["type"] == "thinking" and not include_thinking:
+                    continue
                 events.append(ev)
                 seq += 1
         agent_types: list[str] = []
@@ -1580,6 +1585,8 @@ def parse_antigravity_session(
     mode: str,
     warnings: list[str],
     include_thinking: bool = False,
+    # (accepted for parser-signature parity: antigravity's heuristically
+    # decoded steps never yield thinking events, so the flag is a no-op here)
 ) -> dict[str, Any]:
     db = root / "conversations" / f"{session_id}.db"
     if not db.exists():
@@ -1828,7 +1835,7 @@ def source_status(root_override: dict[str, Path] | None = None) -> list[dict[str
     statuses.append({
         "source": "claude_code",
         "store": str(cc),
-        "available": sessions.is_dir() and any(sessions.iterdir()) if sessions.is_dir() else False,
+        "available": sessions.is_dir() and any(sessions.iterdir()),
         "covers": "Claude Code CLI + Claude Code Desktop (local sessions)",
         "notes": [
             "Claude Desktop remote (claude.ai) chats are out of scope by design",

--- a/skills/session-pull/session_pull.py
+++ b/skills/session-pull/session_pull.py
@@ -127,8 +127,21 @@ def aionui_root() -> Path:
     if env:
         return Path(env)
     home = Path(os.environ.get("HOME", str(Path.home())))
-    # macOS convention; Linux builds keep the same relative layout.
-    return home / "Library" / "Application Support" / "AionUi" / "aionui"
+    # Electron userData dir, mirroring installer/config.py:
+    # darwin -> ~/Library/Application Support/AionUi, win32 -> %APPDATA%/AionUi,
+    # else XDG ~/.config/AionUi. ``~/.aionui`` is a symlink INTO the
+    # ``aionui`` subdir, which is where the app stores its SQLite db.
+    if sys.platform == "darwin":
+        base = home / "Library" / "Application Support" / "AionUi"
+    elif sys.platform == "win32":
+        base = Path(
+            os.environ.get("APPDATA", str(home / "AppData" / "Roaming"))
+        ) / "AionUi"
+    else:
+        xdg = os.environ.get("XDG_CONFIG_HOME")
+        base = Path(xdg) if xdg else home / ".config"
+        base = base / "AionUi"
+    return base / "aionui"
 
 
 def antigravity_root() -> Path:
@@ -298,7 +311,12 @@ class SqliteSnapshot:
     Source stores are held open by their apps in WAL mode. Opening them in
     place risks torn reads and lock contention; ``immutable=1`` risks missing
     recent committed frames. The safe pattern is copying db + -wal + -shm to
-    a temp dir and reading the copy. The copy is removed on close.
+    a temp dir and reading the copy; the copy is removed on close.
+
+    The snapshot is best-effort: a commit landing mid-copy can leave it
+    slightly stale (or, rarely, unrecoverable) relative to the source. That
+    is accepted over mutating or locking the source store, and reads happen
+    between chat turns in practice.
     """
 
     def __init__(self, db_path: Path) -> None:
@@ -365,15 +383,25 @@ def claude_session_files(root: Path) -> list[Path]:
     return files
 
 
+# Title precedence, verified in roundup.py (2026-09-10): a user-pinned
+# customTitle beats agentName and the AI-generated aiTitle regardless of
+# which JSONL record appears first, so precedence is enforced by KEY rank,
+# never by record order. Ties (same key seen twice) keep the latest value.
+_CLAUDE_TITLE_KEYS = ("customTitle", "agentName", "aiTitle")
+_CLAUDE_TITLE_RANK = {"aiTitle": 1, "agentName": 2, "customTitle": 3}
+
+
 def claude_title_scan(jsonl_path: Path) -> dict[str, Any]:
     """Light scan: title + timestamps without a full parse.
 
     Reads the first 64KiB and last 32KiB of the file. Title precedence
     (verified in roundup.py): customTitle > agentName > aiTitle > first
-    user text. Compact detection from any scanned record.
+    user text, enforced by key rank rather than record order. Compact
+    detection from any scanned record.
     """
     info: dict[str, Any] = {"title": None, "first_ts": None, "last_ts": None,
                             "compacted": False, "git_branch": None}
+    best_rank = 0
     size = jsonl_path.stat().st_size
     with jsonl_path.open("rb") as fh:
         head = fh.read(65536)
@@ -392,9 +420,13 @@ def claude_title_scan(jsonl_path: Path) -> dict[str, Any]:
                 continue
             if rec.get("type") == "summary" and rec.get("summary"):
                 info["title"] = info["title"] or rec["summary"]
-            for key in ("customTitle", "agentName", "aiTitle"):
-                if rec.get(key):
-                    info["title"] = rec[key]
+            for key in _CLAUDE_TITLE_KEYS:
+                value = rec.get(key)
+                if value:
+                    rank = _CLAUDE_TITLE_RANK[key]
+                    if rank >= best_rank:
+                        best_rank = rank
+                        info["title"] = value
                     break
             if info["git_branch"] is None and rec.get("gitBranch"):
                 info["git_branch"] = rec["gitBranch"]
@@ -591,15 +623,19 @@ def parse_claude_session(
                 continue
             raw_records.append((rtype, rec, ts))
 
-    # Title precedence mirrors roundup.py.
+    # Title precedence mirrors roundup.py: rank by KEY, not by which record
+    # happens to appear first; same-rank ties keep the latest occurrence.
     title = None
+    best_rank = 0
     for rtype, rec, _ts in raw_records:
-        for key in ("customTitle", "agentName", "aiTitle"):
-            if rec and rec.get(key):
-                title = rec[key]
+        for key in _CLAUDE_TITLE_KEYS:
+            value = rec.get(key) if rec else None
+            if value:
+                rank = _CLAUDE_TITLE_RANK[key]
+                if rank >= best_rank:
+                    best_rank = rank
+                    title = value
                 break
-        if title:
-            break
     if not title and summary_records:
         title = summary_records[-1]
     if not title:
@@ -1204,12 +1240,17 @@ def parse_aionui_session(
                 })
         except sqlite3.Error:
             pass
+        # Resolve workspaces inside the same snapshot — a second snapshot
+        # here would re-copy the whole db for one query.
+        try:
+            workspaces = _aionui_project_paths(conn, session_id)
+        except (sqlite3.Error, OSError):
+            workspaces = []
 
     compaction = None  # aionui has no first-class compaction records
     if mode == "compact":
         warn(warnings, "aionui: no compaction records in store; compact mode "
                        "equals full mode")
-    workspaces = _aionui_workspaces(db, session_id)
     session = {
         "id": session_id,
         "title": (conv_row.get("name") or "").splitlines()[0][:120] or None,
@@ -1231,14 +1272,6 @@ def parse_aionui_session(
         extras = {"artifacts": artifacts}
     return build_envelope("aionui", mode, session, events, compaction, extras,
                           warnings)
-
-
-def _aionui_workspaces(db_path: Path, session_id: str) -> list[str]:
-    try:
-        with SqliteSnapshot(db_path) as conn:
-            return _aionui_project_paths(conn, session_id)
-    except (FileNotFoundError, sqlite3.Error):
-        return []
 
 
 # --------------------------------------------------------------------------
@@ -1734,7 +1767,12 @@ def render_handoff(envelope: dict[str, Any], budget_chars: int) -> str:
         tool = ev.get("tool")
         meta = ev.get("meta") or {}
         if ev["type"] == "tool_call":
-            chunk = f"**tool_call** `{tool}`\n```json\n{json.dumps(meta.get('input') or {}, indent=2, default=str)[:1500]}\n```"
+            # Antigravity emits input_raw when the JSON args could not be
+            # parsed — surface the raw string rather than an empty object.
+            payload = meta.get("input")
+            if payload is None:
+                payload = meta.get("input_raw") or {}
+            chunk = f"**tool_call** `{tool}`\n```json\n{json.dumps(payload, indent=2, default=str)[:1500]}\n```"
         elif ev["type"] == "tool_result":
             body = (text or "")[:3000]
             chunk = f"**tool_result** `{tool}`\n```\n{body}\n```"
@@ -1892,7 +1930,8 @@ def dispatch_pull(args: argparse.Namespace) -> int:
         envelope["redacted"] = True
         if kinds:
             envelope["redaction_kinds"] = kinds
-    envelope["warnings"] = warnings
+    # NOTE: warnings stay as apply_redaction left them — re-assigning the
+    # raw list here would resurrect unredacted strings after --redact.
 
     if mode == "handoff":
         content = render_handoff(envelope, args.budget_chars)

--- a/skills/session-pull/session_pull.py
+++ b/skills/session-pull/session_pull.py
@@ -20,10 +20,12 @@ opencode            ~/.local/share/opencode/opencode.db — SQLite with
                     session/message/part tables and JSON ``data`` columns.
                     Current schema ONLY: the legacy ``storage/`` JSON tree
                     is deliberately unsupported (operator decision).
-aionui              ~/Library/Application Support/AionUi/aionui/
-                    aionui-backend.db — conversations/messages/
-                    assistant_sessions tables; ``messages.content`` is a
-                    JSON blob and ``messages.hidden`` marks UI-hidden rows.
+aionui              <Electron userData>/aionui/aionui-backend.db — macOS
+                    ~/Library/Application Support/AionUi, Linux
+                    ~/.config/AionUi, Windows %APPDATA%/AionUi — with
+                    conversations/messages/assistant_sessions tables;
+                    ``messages.content`` is a JSON blob and
+                    ``messages.hidden`` marks UI-hidden rows.
 antigravity         ~/.gemini/antigravity/conversations/<uuid>.db —
                     per-conversation SQLite; ``steps.step_payload`` blobs
                     are protobuf WITHOUT a public schema, so extraction is

--- a/skills/session-pull/session_pull.py
+++ b/skills/session-pull/session_pull.py
@@ -655,7 +655,7 @@ def parse_claude_session(
         if rec.get("slug"):
             session_meta["slug"] = rec["slug"]
 
-    if compaction_idx is not None and mode != "full":
+    if compaction_idx is not None:
         events.insert(
             0,
             make_event(-1, "compaction", ts=compaction_ts, text=compaction_text,
@@ -703,10 +703,13 @@ def list_claude_sessions(
         project_dir = path.parent
         if cwd is not None:
             encoded = encode_cwd_literal(cwd)
+            # Worktrees encode as <repo-path>-<worktree-name>. Because '-'
+            # is also the replacement character, the prefix match is
+            # ambiguous ("/repository" also matches cwd "/repo") — this
+            # filter deliberately over-matches for list; pull is by id.
             if project_dir.name != encoded and not project_dir.name.startswith(
                 encoded + "-"
             ):
-                # Worktrees encode as <repo-path>-<worktree-name>.
                 continue
         info = claude_title_scan(path)
         stat = path.stat()
@@ -879,10 +882,6 @@ def parse_opencode_session(
             "WHERE m.session_id = ? ORDER BY m.time_created, p.time_created",
             (session_id,),
         ).fetchall()
-        message_roles: dict[str, str] = {}
-        for mrow in rows:
-            mdata = tolerant_json(mrow["m_data"]) or {}
-            message_roles[mdata.get("id", "")] = mdata.get("role") or ""
         compaction_epoch = session_row.get("time_compacting")
         for mrow in rows:
             mdata = tolerant_json(mrow["m_data"]) or {}
@@ -907,9 +906,12 @@ def parse_opencode_session(
         )
         if anchor is not None:
             anchor_ts = anchor.get("ts")
-            kept = [e for e in events
-                    if e.get("type") == "compaction" or
-                    (anchor_ts and e.get("ts") and e["ts"] >= anchor_ts)]
+            kept = [
+                e for e in events
+                if e.get("type") == "compaction"
+                or e.get("ts") is None  # never silently drop untimed events
+                or (anchor_ts and e.get("ts") and e["ts"] >= anchor_ts)
+            ]
             events = kept
 
     if mode == "compact" and compaction_epoch and compaction_event_idx is None:
@@ -1749,7 +1751,7 @@ def render_handoff(envelope: dict[str, Any], budget_chars: int) -> str:
         included += 1
     if elided:
         rendered.append(
-            f"_(… {elided} older event(s) elided by the "
+            f"_(… {elided} event(s) elided by the "
             f"{budget_chars}-char budget; rerun with --mode full for "
             "everything)_"
         )
@@ -1861,9 +1863,10 @@ def dispatch_pull(args: argparse.Namespace) -> int:
     warnings: list[str] = []
     mode = args.mode
     if args.source == "claude_code":
+        claude_file = _find_claude_file(args.id, warnings)
         envelope = parse_claude_session(
-            _find_claude_file(args.id, warnings),
-            mode, claude_root(), warnings,
+            claude_file,
+            mode, _claude_root_for(claude_file), warnings,
             include_thinking=args.include_thinking,
         )
     elif args.source == "opencode":
@@ -1929,6 +1932,16 @@ def _find_claude_file(session_id: str, warnings: list[str]) -> Path:
             f"claude_code: no session file for id {session_id!r}"
         )
     return matches[0]
+
+
+def _claude_root_for(path: Path) -> Path:
+    """Derive the store root (todos/, file-history/) a session file lives in.
+
+    Session files sit in <root>/projects/<encoded-cwd>/<id>.jsonl; the root
+    may be ~/.claude or ~/.claude-work, and sidecar state must be resolved
+    from the SAME root the transcript came from.
+    """
+    return path.parent.parent.parent
 
 
 def dispatch_list(args: argparse.Namespace) -> int:

--- a/tests/test_skills/test_session_pull.py
+++ b/tests/test_skills/test_session_pull.py
@@ -1,0 +1,715 @@
+"""Tests for the session-pull bundled script.
+
+Fixtures are synthetic stores built in tmp_path (JSONL for claude_code,
+SQLite for opencode/aionui/antigravity). No real user stores are touched;
+roots are injected via env overrides (monkeypatch.setenv — the sanctioned
+use) or direct root arguments.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+_SKILL_SCRIPT = (
+    Path(__file__).resolve().parents[2]
+    / "skills"
+    / "session-pull"
+    / "session_pull.py"
+)
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("session_pull", _SKILL_SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+# ---------------------------------------------------------------------------
+# Fixture builders
+# ---------------------------------------------------------------------------
+
+
+def _claude_record(
+    rtype: str,
+    content: Any,
+    *,
+    ts: str = "2026-09-10T10:00:00.000Z",
+    **extra: Any,
+) -> dict[str, Any]:
+    rec: dict[str, Any] = {
+        "type": rtype,
+        "timestamp": ts,
+        "sessionId": "11111111-2222-3333-4444-555555555555",
+        "cwd": "/repo",
+        "gitBranch": "main",
+        "version": "2.0.0",
+    }
+    if rtype in ("user", "assistant"):
+        rec["message"] = {"role": rtype, "content": content}
+    rec.update(extra)
+    return rec
+
+
+def _write_claude_session(
+    root: Path, cwd: str, session_id: str, records: list[dict[str, Any]]
+) -> Path:
+    project = root / "projects" / _load_module().encode_cwd_literal(cwd)
+    project.mkdir(parents=True, exist_ok=True)
+    path = project / f"{session_id}.jsonl"
+    lines = [json.dumps(r) for r in records]
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return path
+
+
+def _make_opencode_db(root: Path) -> None:
+    """Create an opencode-shaped db with the verified schema."""
+    root.mkdir(parents=True, exist_ok=True)
+    db = root / "opencode.db"
+    conn = sqlite3.connect(db)
+    conn.executescript(
+        """
+        CREATE TABLE project (id TEXT PRIMARY KEY, worktree TEXT);
+        CREATE TABLE session (
+            id TEXT PRIMARY KEY, project_id TEXT, workspace_id TEXT,
+            parent_id TEXT, slug TEXT, directory TEXT, path TEXT,
+            title TEXT, version TEXT, share_url TEXT,
+            summary_additions TEXT, summary_deletions TEXT, summary_files TEXT,
+            metadata TEXT, cost TEXT, tokens_input INTEGER, tokens_output INTEGER,
+            tokens_reasoning INTEGER, tokens_cache INTEGER,
+            revert TEXT, permission TEXT, agent TEXT, model TEXT,
+            time_created INTEGER, time_updated INTEGER,
+            time_compacting INTEGER, time_archived INTEGER
+        );
+        CREATE TABLE message (
+            id TEXT, session_id TEXT, time_created INTEGER,
+            time_updated INTEGER, data TEXT
+        );
+        CREATE TABLE part (
+            id TEXT, message_id TEXT, session_id TEXT, data TEXT,
+            time_created INTEGER, time_updated INTEGER
+        );
+        """
+    )
+    conn.execute("INSERT INTO project VALUES ('proj1', '/repo')")
+    conn.commit()
+    conn.close()
+    return {}
+
+
+def _insert_opencode_session(
+    root: Path,
+    session_id: str,
+    title: str,
+    parts: list[tuple[str, int, dict[str, Any]]],
+    *,
+    time_compacting: int | None = None,
+    directory: str = "/repo",
+) -> None:
+    """parts: (message_id, epoch_ms, part_data)."""
+    conn = sqlite3.connect(root / "opencode.db")
+    conn.execute(
+        "INSERT INTO session (id, project_id, slug, directory, path, title, "
+        "model, agent, time_created, time_updated, time_compacting) "
+        "VALUES (?,?,?,?,?,?,?,?,?,?,?)",
+        (
+            session_id, "proj1", title, directory, title, title,
+            "test/model", "build",
+            parts[0][1] if parts else 0, parts[-1][1] if parts else 0,
+            time_compacting,
+        ),
+    )
+    for i, (mid, ts, pdata) in enumerate(parts):
+        msg_key = f"{session_id}:{mid}"
+        if not conn.execute(
+            "SELECT 1 FROM message WHERE id = ?", (msg_key,)
+        ).fetchone():
+            conn.execute(
+                "INSERT INTO message VALUES (?,?,?,?,?)",
+                (msg_key, session_id, ts, ts,
+                 json.dumps({"id": mid, "role": "user"})),
+            )
+        conn.execute(
+            "INSERT INTO part VALUES (?,?,?,?,?,?)",
+            (f"p{i}", f"{session_id}:{mid}", session_id, json.dumps(pdata),
+             ts, ts),
+        )
+    conn.commit()
+    conn.close()
+
+
+def _make_aionui_db(root: Path) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(root / "aionui-backend.db")
+    conn.executescript(
+        """
+        CREATE TABLE conversations (
+            id TEXT PRIMARY KEY, user_id TEXT, name TEXT, type TEXT,
+            extra TEXT, model TEXT, status TEXT, source TEXT,
+            channel_chat_id TEXT, pinned INTEGER, pinned_at INTEGER,
+            created_at INTEGER, updated_at INTEGER, project_id TEXT,
+            folder_id TEXT, name_source TEXT, archived_at INTEGER
+        );
+        CREATE TABLE messages (
+            id TEXT PRIMARY KEY, conversation_id TEXT, msg_id TEXT,
+            type TEXT, content TEXT, position INTEGER, status TEXT,
+            hidden INTEGER, created_at INTEGER, backend_turn_id TEXT
+        );
+        CREATE TABLE assistant_sessions (
+            id TEXT PRIMARY KEY, user_id TEXT, agent_type TEXT,
+            conversation_id TEXT, workspace TEXT, chat_id TEXT,
+            created_at INTEGER, last_activity INTEGER
+        );
+        CREATE TABLE conversation_artifacts (
+            id TEXT PRIMARY KEY, conversation_id TEXT, kind TEXT, path TEXT
+        );
+        """
+    )
+    conn.execute(
+        "INSERT INTO conversations (id, user_id, name, type, extra, model, "
+        "status, source, created_at, updated_at) VALUES "
+        "('conv1','u1','Test conversation','agent','{}','m1','ok',"
+        "'local',1757400000000,1757401000000)"
+    )
+    conn.commit()
+    conn.close()
+
+
+def _aionui_msg(
+    conversation_id: str,
+    mtype: str,
+    content: dict[str, Any],
+    position: int,
+    *,
+    hidden: int = 0,
+    created_at: int = 1757400000000,
+) -> tuple[str, str, int, str, int, int]:
+    return (
+        f"m{position}", conversation_id, f"msg{position}", mtype,
+        json.dumps(content), position, "finish", hidden, created_at, None,
+    )
+
+
+def _make_antigravity_db(root: Path, conversation_id: str) -> None:
+    (root / "conversations").mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(root / "conversations" / f"{conversation_id}.db")
+    conn.executescript(
+        """
+        CREATE TABLE steps (
+            idx INTEGER PRIMARY KEY, step_type INTEGER, status INTEGER,
+            has_subtrajectory INTEGER, metadata BLOB, error_details BLOB,
+            permissions BLOB, task_details BLOB, render_info BLOB,
+            step_payload BLOB, step_format INTEGER
+        );
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
+def _pb_len_field(field_no: int, payload: bytes) -> bytes:
+    """Encode one length-delimited protobuf field."""
+    key = (field_no << 3) | 2
+    return bytes([key, len(payload)]) + payload
+
+
+# ---------------------------------------------------------------------------
+# claude_code
+# ---------------------------------------------------------------------------
+
+
+def test_claude_compact_mode_uses_latest_boundary(tmp_path: Path) -> None:
+    sp = _load_module()
+    root = tmp_path / "claude"
+    records = [
+        _claude_record("user", "first request", ts="2026-09-10T10:00:00Z"),
+        _claude_record("assistant", "working", ts="2026-09-10T10:00:05Z"),
+        _claude_record(
+            "user", "summary of earlier work",
+            ts="2026-09-10T10:01:00Z", isCompactSummary=True,
+            isMeta=True,
+        ),
+        _claude_record("assistant", "post-compact work",
+                       ts="2026-09-10T10:02:00Z"),
+        _claude_record(
+            "assistant",
+            [{"type": "tool_use", "name": "Bash",
+              "input": {"command": "pytest"}}],
+            ts="2026-09-10T10:02:10Z",
+        ),
+        _claude_record("user", "subagent traffic", isSidechain=True),
+    ]
+    _write_claude_session(root, "/repo", "sid-1", records)
+
+    warnings: list[str] = []
+    envelope = sp.parse_claude_session(
+        root / "projects" / sp.encode_cwd_literal("/repo") / "sid-1.jsonl",
+        "compact", root, warnings,
+    )
+    assert envelope["source"] == "claude_code"
+    assert envelope["session"]["compacted"] is True
+    assert envelope["summary"] is not None
+    assert envelope["summary"]["text"] == "summary of earlier work"
+    texts = [e.get("text", "") for e in envelope["events"]]
+    assert "working" not in texts, "pre-compact events must be dropped"
+    assert "post-compact work" in texts
+    kinds = [e["type"] for e in envelope["events"]]
+    assert "compaction" in kinds, "anchor must be re-injected first"
+    assert envelope["events"][0]["type"] == "compaction"
+    tool_calls = [e for e in envelope["events"] if e["type"] == "tool_call"]
+    assert len(tool_calls) == 1
+    assert tool_calls[0]["tool"] == "Bash"
+    assert "subagent traffic excluded" not in " ".join(texts)
+    assert warnings == []
+
+
+def test_claude_full_mode_keeps_everything(tmp_path: Path) -> None:
+    sp = _load_module()
+    root = tmp_path / "claude"
+    records = [
+        _claude_record("user", "early", ts="2026-09-10T10:00:00Z"),
+        _claude_record(
+            "user", "summary text", ts="2026-09-10T10:01:00Z",
+            isCompactSummary=True, isMeta=True,
+        ),
+        _claude_record("user", "subagent", isSidechain=True),
+    ]
+    _write_claude_session(root, "/repo", "sid-2", records)
+    warnings: list[str] = []
+    envelope = sp.parse_claude_session(
+        root / "projects" / sp.encode_cwd_literal("/repo") / "sid-2.jsonl",
+        "full", root, warnings,
+    )
+    texts = [e.get("text", "") for e in envelope["events"]]
+    assert "early" in texts
+    assert "subagent" in texts
+
+
+def test_claude_list_filters_by_cwd(tmp_path: Path) -> None:
+    sp = _load_module()
+    root = tmp_path / "claude"
+    _write_claude_session(root, "/repo", "s-a", [_claude_record("user", "a")])
+    _write_claude_session(root, "/other", "s-b", [_claude_record("user", "b")])
+    warnings: list[str] = []
+    sessions = sp.list_claude_sessions(root, "/repo", warnings)
+    assert [s["id"] for s in sessions] == ["s-a"]
+    assert sessions[0]["title"] == "a"
+
+
+def test_claude_todo_and_title_precedence(tmp_path: Path) -> None:
+    sp = _load_module()
+    root = tmp_path / "claude"
+    records = [
+        {"type": "summary", "summary": "older title",
+         "timestamp": "2026-09-10T10:00:00Z"},
+        _claude_record("user", "first user message"),
+        _claude_record("assistant", "reply", customTitle="Custom Name"),
+    ]
+    _write_claude_session(root, "/repo", "sid-3", records)
+    todos_dir = root / "todos"
+    todos_dir.mkdir()
+    (todos_dir / "sid-3-agent-todo.json").write_text(
+        json.dumps([{"content": "ship it", "status": "in_progress"}]),
+        encoding="utf-8",
+    )
+    warnings: list[str] = []
+    envelope = sp.parse_claude_session(
+        root / "projects" / sp.encode_cwd_literal("/repo") / "sid-3.jsonl",
+        "compact", root, warnings,
+    )
+    assert envelope["session"]["title"] == "Custom Name"
+    assert envelope["todos"] == [{"content": "ship it",
+                                  "status": "in_progress"}]
+
+
+# ---------------------------------------------------------------------------
+# opencode
+# ---------------------------------------------------------------------------
+
+
+def test_opencode_compact_boundary(tmp_path: Path) -> None:
+    sp = _load_module()
+    root = tmp_path / "opencode"
+    _make_opencode_db(root)
+    sid = "ses_test1"
+    compact_ms = 1757400100000
+    _insert_opencode_session(
+        root, sid, "My session",
+        [
+            ("m1", 1757400000000,
+             {"type": "text", "text": "pre-compact question"}),
+            ("m1", 1757400000001, {"type": "step-start"}),
+            ("m1", 1757400000002,
+             {"type": "tool", "tool": "bash", "callID": "c1",
+              "state": {"status": "completed",
+                        "output": {"title": "ran", "output": "ok"}}}),
+            ("m1", compact_ms,
+             {"type": "compaction", "text": "everything before is summarized"}),
+            ("m2", compact_ms + 1000, {"type": "text", "text": "after"}),
+        ],
+        time_compacting=compact_ms,
+        directory="/repo",
+    )
+    warnings: list[str] = []
+    envelope = sp.parse_opencode_session(root, sid, "compact", warnings)
+    assert envelope["session"]["title"] == "My session"
+    assert envelope["summary"]["text"] == "everything before is summarized"
+    texts = [e.get("text", "") for e in envelope["events"]]
+    assert "pre-compact question" not in texts
+    assert "after" in texts
+    assert envelope["warnings"] == []
+
+
+def test_opencode_tool_string_output(tmp_path: Path) -> None:
+    sp = _load_module()
+    root = tmp_path / "opencode"
+    _make_opencode_db(root)
+    _insert_opencode_session(
+        root, "ses_s", "t",
+        [
+            ("m1", 1757400000000,
+             {"type": "tool", "tool": "read", "callID": "c9",
+              "state": {"status": "completed", "output": "plain string"}}),
+        ],
+        directory="/repo",
+    )
+    warnings: list[str] = []
+    envelope = sp.parse_opencode_session(root, "ses_s", "full", warnings)
+    results = [e for e in envelope["events"] if e["type"] == "tool_result"]
+    assert results and results[0]["text"] == "plain string"
+
+
+def test_opencode_thinking_excluded_by_default(tmp_path: Path) -> None:
+    sp = _load_module()
+    root = tmp_path / "opencode"
+    _make_opencode_db(root)
+    _insert_opencode_session(
+        root, "ses_th", "t",
+        [
+            ("m1", 1757400000000,
+             {"type": "reasoning", "text": "deep thought"}),
+            ("m1", 1757400000001, {"type": "text", "text": "answer"}),
+        ],
+    )
+    envelope = sp.parse_opencode_session(root, "ses_th", "full", [], False)
+    assert [e["type"] for e in envelope["events"]] == ["message"]
+    envelope = sp.parse_opencode_session(root, "ses_th", "full", [], True)
+    kinds = [e["type"] for e in envelope["events"]]
+    assert kinds == ["thinking", "message"]
+
+
+# ---------------------------------------------------------------------------
+# aionui
+# ---------------------------------------------------------------------------
+
+
+def test_aionui_event_mapping(tmp_path: Path) -> None:
+    sp = _load_module()
+    root = tmp_path / "aionui"
+    _make_aionui_db(root)
+    conn = sqlite3.connect(root / "aionui-backend.db")
+    rows = [
+        _aionui_msg("conv1", "text", {"content": "hello"}, 0),
+        _aionui_msg("conv1", "thinking", {"content": "hmm"}, 1),
+        _aionui_msg("conv1", "tool_call",
+                    {"call_id": "c1", "name": "run", "args": {"x": 1},
+                     "output": "done"}, 2),
+        _aionui_msg("conv1", "tips",
+                    {"content": "success", "type": "info"}, 3),
+        _aionui_msg("conv1", "text", {"content": "hidden note"}, 4, hidden=1),
+    ]
+    conn.executemany("INSERT INTO messages VALUES (?,?,?,?,?,?,?,?,?,?)", rows)
+    conn.commit()
+    conn.close()
+
+    warnings: list[str] = []
+    envelope = sp.parse_aionui_session(root, "conv1", "compact", warnings)
+    events = envelope["events"]
+    kinds = [e["type"] for e in events]
+    assert kinds == ["message", "thinking", "tool_call", "tool_result",
+                     "meta", "message"]
+    assert events[0].get("role") is None, "aionui text rows carry no role"
+    assert events[1]["type"] == "thinking"
+    assert events[2]["tool"] == "run"
+    assert events[2]["meta"]["input"] == {"x": 1}
+    assert events[3]["text"] == "done"
+    assert events[4]["meta"]["kind"] == "aionui_tip"
+    assert events[5].get("hidden") is True
+
+
+def test_aionui_workspace_and_listing(tmp_path: Path) -> None:
+    sp = _load_module()
+    root = tmp_path / "aionui"
+    _make_aionui_db(root)
+    conn = sqlite3.connect(root / "aionui-backend.db")
+    conn.execute(
+        "INSERT INTO assistant_sessions VALUES "
+        "('as1','u1','aionrs','conv1','/repo','chat',NULL,NULL)"
+    )
+    conn.commit()
+    conn.close()
+    warnings: list[str] = []
+    sessions = sp.list_aionui_sessions(root, "/repo", warnings)
+    assert len(sessions) == 1
+    assert sessions[0]["workspaces"] == ["/repo"]
+    miss = sp.list_aionui_sessions(root, "/elsewhere", warnings)
+    assert miss == []
+
+
+# ---------------------------------------------------------------------------
+# antigravity
+# ---------------------------------------------------------------------------
+
+
+def test_pb_walk_roundtrip_and_malformed_tail() -> None:
+    sp = _load_module()
+    payload = _pb_len_field(1, b"hello world") + _pb_len_field(2, b"x" * 5)
+    fields = sp.pb_walk(payload)
+    assert [(f, w) for f, w, _v in fields] == [(1, 2), (2, 2)]
+    assert fields[0][2] == b"hello world"
+    # Truncated varint tail must stop cleanly, not raise.
+    fields = sp.pb_walk(b"\x0a\x80")
+    assert fields == []
+
+
+def test_pb_collect_strings_unwraps_nested_message() -> None:
+    sp = _load_module()
+    # field 3 wraps a nested message whose field 1 wraps the text — the
+    # length byte (0x48='H') must NOT survive glued onto the text.
+    inner = _pb_len_field(1, b"code review the changes pls")
+    wrapper = _pb_len_field(3, inner)
+    blob = bytes([0x0A, len(wrapper)]) + wrapper
+    strings = sp._pb_collect_strings(blob)
+    assert "code review the changes pls" in strings
+    assert not any(s.startswith("H") for s in strings)
+
+
+def test_antigravity_extraction(tmp_path: Path) -> None:
+    sp = _load_module()
+    root = tmp_path / "antigravity"
+    _make_antigravity_db(root, "agy1")
+    conn = sqlite3.connect(root / "conversations" / "agy1.db")
+    steps = [
+        # user prompt (step_type 14)
+        (0, 14, 0, _agy_user_prompt_step("run the tests and fix failures")),
+        # state marker row: skipped
+        (1, 15, 0, _pb_len_field(1, b"sessionID") ),
+        # tool call row (call id + tool name + JSON args)
+        (2, 21, 0,
+         bytes([0x0A, 0x09]) + b"call_1145"
+         + bytes([0x12, 11]) + b"run_command"
+         + bytes([0x1A, len(b'{"Cwd":"/repo","Cmd":"pytest"}')])
+         + b'{"Cwd":"/repo","Cmd":"pytest"}'),
+        # task notification row
+        (3, 101, 0,
+         _pb_len_field(
+             1,
+             b"[Message] timestamp=2026-09-10T12:00:00Z sender=agy "
+             b"priority=MESSAGE_PRIORITY_NORMAL Run pytest finished",
+         )),
+    ]
+    for idx, stype, sfmt, payload in steps:
+        conn.execute(
+            "INSERT INTO steps VALUES (?,?,?,?,?,?,?,?,?,?,?)",
+            (idx, stype, 3, 0, None, None, None, None, None, payload, sfmt),
+        )
+    conn.commit()
+    conn.close()
+
+    warnings: list[str] = []
+    envelope = sp.parse_antigravity_session(root, "agy1", "compact", warnings)
+    events = envelope["events"]
+    kinds = [e["type"] for e in events]
+    assert kinds == ["message", "tool_call", "message"]
+    assert events[0]["role"] == "user"
+    assert events[0]["text"] == "run the tests and fix failures"
+    tool = events[1]
+    assert tool["meta"]["call_id"] == "call_1145"
+    assert tool["meta"]["input"] == {"Cwd": "/repo", "Cmd": "pytest"}
+    assert events[2]["meta"]["record"] == "task_notification"
+    assert events[2]["text"] == "Run pytest finished"
+    assert envelope["warnings"], "antigravity must warn about best-effort"
+
+
+def _agy_user_prompt_step(text: str) -> bytes:
+    return _pb_len_field(1, _pb_len_field(1, text.encode()))
+
+
+# ---------------------------------------------------------------------------
+# envelope / output contract
+# ---------------------------------------------------------------------------
+
+
+def test_redaction_patterns() -> None:
+    sp = _load_module()
+    envelope = {
+        "events": [
+            {"type": "message", "text": "key AKIAIOSFODNN7EXAMPLE and "
+                                        "sk-ant-abc123def456ghi789jkl"},
+        ],
+        "warnings": [],
+    }
+    cleaned, kinds = sp.apply_redaction(envelope)
+    text = cleaned["events"][0]["text"]
+    assert "AKIAIOSFODNN7EXAMPLE" not in text
+    assert "[REDACTED:aws_access_key]" in text
+    assert "sk-ant-abc123def456ghi789jkl" not in text
+    assert "aws_access_key" in kinds
+
+
+def test_write_out_permissions_and_overwrite_guard(tmp_path: Path) -> None:
+    sp = _load_module()
+    out = tmp_path / "export.json"
+    sp.write_out(out, "one", force=False)
+    mode = out.stat().st_mode & 0o777
+    assert mode == 0o600, "exports must not be group/world readable"
+    try:
+        sp.write_out(out, "two", force=False)
+    except SystemExit as exc:
+        assert "refusing to overwrite" in str(exc)
+    else:
+        raise AssertionError("overwrite must be refused without --force")
+    sp.write_out(out, "two", force=True)
+    assert out.read_text(encoding="utf-8") == "two"
+
+
+def test_handoff_budget_elides_and_marks(tmp_path: Path) -> None:
+    sp = _load_module()
+    events = [
+        {"seq": i, "type": "message", "text": f"turn {i} " + "x" * 500}
+        for i in range(10)
+    ]
+    envelope = {
+        "source": "claude_code", "mode": "compact",
+        "generated_at": "2026-09-10T00:00:00Z",
+        "session": {"id": "s", "title": "T", "cwd": "/repo",
+                    "git_branch": "main"},
+        "summary": None, "events": events, "todos": [],
+        "warnings": [],
+    }
+    md = sp.render_handoff(envelope, budget_chars=2000)
+    assert "## Recent transcript" in md
+    assert "elided by the" in md, "truncation must be explicit"
+    assert "turn 9" in md, "newest events are included first"
+
+
+def test_handoff_includes_summary_and_todos() -> None:
+    sp = _load_module()
+    envelope = {
+        "source": "opencode", "mode": "compact",
+        "generated_at": "2026-09-10T00:00:00Z",
+        "session": {"id": "s", "title": "T", "cwd": "/repo",
+                    "git_branch": "feat"},
+        "summary": {"text": "We migrated the parser.",
+                    "boundary_seq": 3},
+        "events": [{"seq": 4, "type": "message", "text": "next steps"}],
+        "todos": [{"content": "ship it", "status": "in_progress"}],
+        "warnings": [],
+    }
+    md = sp.render_handoff(envelope, budget_chars=10000)
+    assert "## Position (latest compaction summary)" in md
+    assert "We migrated the parser." in md
+    assert "- [~] ship it" in md
+    assert "latest compaction boundary" in md
+
+
+# ---------------------------------------------------------------------------
+# CLI dispatch (in-process; env-rooted fixtures)
+# ---------------------------------------------------------------------------
+
+
+def test_cli_sources_and_list_via_env_roots(
+    tmp_path: Path, monkeypatch: Any, capsys: Any
+) -> None:
+    sp = _load_module()
+    monkeypatch.setenv("SPELLBOOK_SESSION_PULL_CLAUDE_ROOT", str(tmp_path / "c"))
+    monkeypatch.setenv(
+        "SPELLBOOK_SESSION_PULL_OPENCODE_ROOT", str(tmp_path / "o")
+    )
+    monkeypatch.setenv(
+        "SPELLBOOK_SESSION_PULL_AIONUI_ROOT", str(tmp_path / "a")
+    )
+    monkeypatch.setenv(
+        "SPELLBOOK_SESSION_PULL_ANTIGRAVITY_ROOT", str(tmp_path / "g")
+    )
+    assert sp.main(["sources"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["sources"][0]["source"] == "claude_code"
+    assert payload["sources"][0]["available"] is False
+
+    # claude session in the fixture root
+    root = tmp_path / "c"
+    _write_claude_session(root, "/repo", "cli-1", [_claude_record("user", "hi")])
+    assert sp.main(["list", "--source", "claude_code", "--cwd", "/repo"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["sources"]["claude_code"][0]["id"] == "cli-1"
+
+    assert sp.main(["pull", "--source", "claude_code", "--id", "cli-1",
+                    "--mode", "compact"]) == 0
+    envelope = json.loads(capsys.readouterr().out)
+    assert envelope["session"]["id"] == "cli-1"
+    assert envelope["events"][0]["text"] == "hi"
+
+
+def test_cli_out_flag_routes_to_file(
+    tmp_path: Path, monkeypatch: Any, capsys: Any
+) -> None:
+    sp = _load_module()
+    monkeypatch.setenv("SPELLBOOK_SESSION_PULL_CLAUDE_ROOT", str(tmp_path / "c"))
+    root = tmp_path / "c"
+    _write_claude_session(root, "/repo", "out-1", [_claude_record("user", "hi")])
+    out_path = tmp_path / "export.json"
+    assert sp.main(["pull", "--source", "claude_code", "--id", "out-1",
+                    "--mode", "compact", "--out", str(out_path)]) == 0
+    summary = json.loads(capsys.readouterr().out)
+    assert summary["written"] == str(out_path)
+    assert (out_path.stat().st_mode & 0o777) == 0o600
+    envelope = json.loads(out_path.read_text(encoding="utf-8"))
+    assert envelope["source"] == "claude_code"
+
+    assert sp.main(["pull", "--source", "claude_code", "--id", "out-1",
+                    "--mode", "handoff", "--out", str(tmp_path / "h.md")]) == 0
+    handoff_summary = json.loads(capsys.readouterr().out)
+    assert handoff_summary["bytes"] > 0
+    assert "# Session handoff" in (tmp_path / "h.md").read_text(
+        encoding="utf-8"
+    )
+
+
+def test_cli_unknown_source_fails(tmp_path: Path) -> None:
+    sp = _load_module()
+    try:
+        sp.main(["pull", "--source", "nope", "--id", "x"])
+    except SystemExit as exc:
+        assert exc.code == 2
+    else:
+        raise AssertionError("argparse must reject unknown sources")
+
+
+def test_sqlite_snapshot_is_read_only_and_cleans_up(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    sp = _load_module()
+    monkeypatch.setenv("TMPDIR", str(tmp_path))
+    db = tmp_path / "live.db"
+    conn = sqlite3.connect(db)
+    conn.execute("CREATE TABLE t (x INTEGER)")
+    conn.execute("INSERT INTO t VALUES (1)")
+    conn.commit()
+    conn.close()
+    before = db.read_bytes()
+    with sp.SqliteSnapshot(db) as snap:
+        rows = snap.execute("SELECT x FROM t").fetchall()
+        assert rows[0][0] == 1
+        # Writes must not reach the original.
+        snap.execute("INSERT INTO t VALUES (2)")
+        snap.commit()
+    after = db.read_bytes()
+    assert before == after
+    leftovers = list(tmp_path.glob("session-pull-snapshot-*"))
+    assert leftovers == [], "snapshot temp dirs must be removed"

--- a/tests/test_skills/test_session_pull.py
+++ b/tests/test_skills/test_session_pull.py
@@ -598,8 +598,10 @@ def test_write_out_permissions_and_overwrite_guard(tmp_path: Path) -> None:
     sp = _load_module()
     out = tmp_path / "export.json"
     sp.write_out(out, "one", force=False)
-    mode = out.stat().st_mode & 0o777
-    assert mode == 0o600, "exports must not be group/world readable"
+    if os.name != "nt":
+        # Windows does not honor POSIX file modes; st_mode is always 0o666.
+        mode = out.stat().st_mode & 0o777
+        assert mode == 0o600, "exports must not be group/world readable"
     try:
         sp.write_out(out, "two", force=False)
     except SystemExit as exc:

--- a/tests/test_skills/test_session_pull.py
+++ b/tests/test_skills/test_session_pull.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import os
 import sqlite3
 from pathlib import Path
 from typing import Any
@@ -288,6 +289,37 @@ def test_claude_full_mode_keeps_everything(tmp_path: Path) -> None:
     texts = [e.get("text", "") for e in envelope["events"]]
     assert "early" in texts
     assert "subagent" in texts
+    # The compaction record itself must survive in full mode too — the
+    # envelope claims every reconstructed event.
+    kinds = [e["type"] for e in envelope["events"]]
+    assert "compaction" in kinds
+
+
+def test_claude_work_root_resolves_sidecar_state(
+    tmp_path: Path, monkeypatch: Any, capsys: Any
+) -> None:
+    """A session under ~/.claude-work must resolve todos from the SAME root,
+    not from ~/.claude (regression: dispatch_pull used to hard-code the
+    default root regardless of where the transcript came from)."""
+    sp = _load_module()
+    work_root = tmp_path / "home" / ".claude-work"
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    project = work_root / "projects" / sp.encode_cwd_literal("/repo")
+    project.mkdir(parents=True)
+    (project / "wk-1.jsonl").write_text(
+        json.dumps(_claude_record("user", "worktree session")) + "\n",
+        encoding="utf-8",
+    )
+    todos = work_root / "todos"
+    todos.mkdir(parents=True)
+    (todos / "wk-1-agent-todo.json").write_text(
+        json.dumps([{"content": "wt todo", "status": "pending"}]),
+        encoding="utf-8",
+    )
+    assert sp.main(["pull", "--source", "claude_code", "--id", "wk-1"]) == 0
+    envelope = json.loads(capsys.readouterr().out)
+    assert envelope["todos"] == [{"content": "wt todo", "status": "pending"}]
+    assert envelope["session"]["id"] == "wk-1"
 
 
 def test_claude_list_filters_by_cwd(tmp_path: Path) -> None:
@@ -668,7 +700,8 @@ def test_cli_out_flag_routes_to_file(
                     "--mode", "compact", "--out", str(out_path)]) == 0
     summary = json.loads(capsys.readouterr().out)
     assert summary["written"] == str(out_path)
-    assert (out_path.stat().st_mode & 0o777) == 0o600
+    if os.name != "nt":
+        assert (out_path.stat().st_mode & 0o777) == 0o600
     envelope = json.loads(out_path.read_text(encoding="utf-8"))
     assert envelope["source"] == "claude_code"
 

--- a/tests/test_skills/test_session_pull.py
+++ b/tests/test_skills/test_session_pull.py
@@ -498,7 +498,13 @@ def test_aionui_event_mapping(tmp_path: Path) -> None:
     conn.close()
 
     warnings: list[str] = []
-    envelope = sp.parse_aionui_session(root, "conv1", "compact", warnings)
+    # Default drops thinking rows, matching the claude/opencode parsers.
+    events = sp.parse_aionui_session(root, "conv1", "compact", warnings)["events"]
+    assert [e["type"] for e in events] == [
+        "message", "tool_call", "tool_result", "meta", "message"]
+
+    envelope = sp.parse_aionui_session(root, "conv1", "compact", warnings,
+                                       include_thinking=True)
     events = envelope["events"]
     kinds = [e["type"] for e in events]
     assert kinds == ["message", "thinking", "tool_call", "tool_result",

--- a/tests/test_skills/test_session_pull.py
+++ b/tests/test_skills/test_session_pull.py
@@ -359,6 +359,44 @@ def test_claude_todo_and_title_precedence(tmp_path: Path) -> None:
                                   "status": "in_progress"}]
 
 
+def test_claude_title_custom_beats_ai_regardless_of_order(tmp_path: Path) -> None:
+    """customTitle outranks aiTitle even when the aiTitle record comes first.
+
+    Precedence is enforced by key rank, not record order (roundup.py
+    verification); before the rank fix the first title-bearing record won.
+    """
+    sp = _load_module()
+    root = tmp_path / "claude"
+    records = [
+        _claude_record("assistant", "reply", aiTitle="AI Generated"),
+        _claude_record("user", "later", customTitle="Pinned Name"),
+    ]
+    _write_claude_session(root, "/repo", "sid-a", records)
+    warnings: list[str] = []
+    path = root / "projects" / sp.encode_cwd_literal("/repo") / "sid-a.jsonl"
+    envelope = sp.parse_claude_session(path, "compact", root, warnings)
+    assert envelope["session"]["title"] == "Pinned Name"
+    # The lightweight list scan must agree with the full parse.
+    sessions = sp.list_claude_sessions(root, "/repo", warnings)
+    assert sessions[0]["title"] == "Pinned Name"
+
+
+def test_claude_title_custom_first_beats_later_ai(tmp_path: Path) -> None:
+    sp = _load_module()
+    root = tmp_path / "claude"
+    records = [
+        _claude_record("user", "hi", customTitle="Pinned Name"),
+        _claude_record("assistant", "reply", aiTitle="AI Generated"),
+    ]
+    _write_claude_session(root, "/repo", "sid-b", records)
+    warnings: list[str] = []
+    path = root / "projects" / sp.encode_cwd_literal("/repo") / "sid-b.jsonl"
+    envelope = sp.parse_claude_session(path, "compact", root, warnings)
+    assert envelope["session"]["title"] == "Pinned Name"
+    sessions = sp.list_claude_sessions(root, "/repo", warnings)
+    assert sessions[0]["title"] == "Pinned Name"
+
+
 # ---------------------------------------------------------------------------
 # opencode
 # ---------------------------------------------------------------------------
@@ -491,6 +529,33 @@ def test_aionui_workspace_and_listing(tmp_path: Path) -> None:
     assert sessions[0]["workspaces"] == ["/repo"]
     miss = sp.list_aionui_sessions(root, "/elsewhere", warnings)
     assert miss == []
+
+
+def test_aionui_root_env_override(tmp_path: Path, monkeypatch) -> None:
+    sp = _load_module()
+    monkeypatch.setenv("SPELLBOOK_SESSION_PULL_AIONUI_ROOT",
+                       str(tmp_path / "custom"))
+    assert sp.aionui_root() == tmp_path / "custom"
+
+
+def test_aionui_root_os_aware_default(tmp_path: Path, monkeypatch) -> None:
+    """Default root mirrors installer/config.py per-OS Electron layout."""
+    sp = _load_module()
+    monkeypatch.delenv("SPELLBOOK_SESSION_PULL_AIONUI_ROOT", raising=False)
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+    if sp.sys.platform == "darwin":
+        monkeypatch.delenv("APPDATA", raising=False)
+        expected = (home / "Library" / "Application Support" / "AionUi"
+                    / "aionui")
+    elif sp.sys.platform == "win32":
+        monkeypatch.setenv("APPDATA", str(home / "AppData" / "Roaming"))
+        expected = home / "AppData" / "Roaming" / "AionUi" / "aionui"
+    else:
+        expected = home / ".config" / "AionUi" / "aionui"
+    assert sp.aionui_root() == expected
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

New `session-pull` skill: pulls chat history + hidden context out of coding-agent session stores and re-emits a canonical JSON envelope (or a budgeted Markdown handoff) another assistant can resume from exactly where the session left off.

Stdlib-only bundled script following the `roundup.py` precedent. Compaction-anchored reconstruction: the default `compact` mode emits the latest compaction summary verbatim plus every event after its boundary — the session's true current position — falling back to the full transcript when no anchor exists.

## Sources

| source | storage | notes |
|---|---|---|
| `claude_code` | `~/.claude` JSONL (+ `~/.claude-work`) | covers Claude Code CLI **and** Claude Code Desktop local sessions (same store); remote claude.ai chats out of scope by design |
| `opencode` | current SQLite schema (`session`/`message`/`part`) | legacy `storage/` JSON deliberately unsupported; per-part timestamps govern the compaction boundary (found while testing) |
| `aionui` | AionUi conversation store | row `type` discriminates `text`/`thinking`/`tool_call`/`tips`; text rows carry no role marker and are left unattributed; `messages.hidden` tagged |
| `antigravity` | per-conversation SQLite, protobuf blobs with **no public schema** | generic wire-format walk + string carving, calibrated via `debug-dump` on live dbs; nested messages detected by byte coverage so length bytes never glue onto carved text |

## CLI

```
sources                              # detect stores
list --source all --cwd <repo>       # discover sessions
pull --source S --id ID --mode compact|full|handoff [--out] [--redact]
debug-dump --source antigravity --id ID
```

Safety: strictly read-only; SQLite sources read through `db+wal+shm` snapshot copies (never opened in place); `--out` writes `0600` and refuses overwrite without `--force`; `--redact` = best-effort secret pass; per-source failures degrade to `warnings`.

## Test plan

- [x] 20 new tests: synthetic JSONL + hand-built SQLite/protobuf fixtures, no mocks, no real user stores
- [x] Compaction boundary correctness per source; `--out` perms/overwrite guard; redaction patterns; handoff budget elision; snapshot-copy read-only proof + temp cleanup
- [x] Full suite green (2111 passed); `install.py --dry-run` passes
- [x] Live smoke against all four real stores on the author's machine
- [x] Docs mirror + mkdocs nav + README regenerated/updated

## Deferred (follow-ups, not in this PR)

- AionUi as an installer platform (separate branch)
- Optional MCP tool wrapper around the script