### PR TITLE
installer: add AionUi platform support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,6 +99,7 @@ Claude Code is the **primary** supported platform with full support. The others 
 | OpenCode | Basic | [anomalyco/opencode](https://github.com/anomalyco/opencode) | `~/.config/opencode/` | HTTP daemon |
 | Codex | Basic | [openai/codex](https://github.com/openai/codex) | `~/.codex/` | HTTP daemon |
 | Gemini CLI | Basic | [google/gemini-cli](https://github.com/google/gemini-cli) | `~/.gemini/` | HTTP daemon |
+| AionUi | Basic | [iOfficerCN/AionUi](https://github.com/iOfficerCN/AionUi) | `~/Library/Application Support/AionUi/` (macOS; `AIONUI_CONFIG_DIR` to override) | Manual — MCP servers are app-database-managed |
 
 ## Invariant Principles
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **AionUi platform installer.** AionUi (Electron desktop app hosting multiple
+  agent engines) is now an installable platform. Skills are symlinked one
+  module per link into `<userData>/config/skills/` — the directory the app
+  watches for user skills (verified against a live install: the `skills`
+  table inventories `source='user'` rows with paths; siblings
+  `config/cron-skills` and `aionui/builtin-skills` confirm the per-source
+  dir convention). Two surfaces are deliberately NOT automated, because they
+  live inside the app's SQLite database and an installer must never write a
+  live app-owned store: MCP servers (`mcp_servers` table) and assistant
+  rules (`assistant_definitions` rows pointing at per-user files). Install
+  reports both as manual steps with exact instructions; the spellbook MCP
+  entry (type: http) is added via AionUi settings instead. Config dir
+  resolves per OS (macOS `~/Library/Application Support/AionUi`, Linux
+  `~/.config/AionUi`, Windows `%APPDATA%/AionUi`) with `AIONUI_CONFIG_DIR`
+  override. Detection is existence-based with no side effects; user skills
+  that collide with a spellbook name are preserved, never clobbered; the
+  app database is proven untouched by test. 12 integration tests.
 - Philosophy: a measurement taken on ONE member is not a measurement about the
   population. Name which one, every time. The failure is quiet because the
   figure is real -- measured, accurate, and false only in its scope -- so nothing

--- a/README.md
+++ b/README.md
@@ -538,6 +538,7 @@ Reusable workflows for structured development:
 | **Gemini CLI** | Basic support | Skills via MCP, native extension. No subagent Task tool. |
 | **ForgeCode** | Basic support | Skills via MCP, AGENTS.md context. Built-in agents (Forge, Sage, Muse) detected; custom agents fall through. |
 | **Goose** (AAIF) | Basic support | Skills via `~/.agents/skills/` (Agent Skills standard), MCP server in `~/.config/goose/config.yaml` (streamable_http), global hints at `~/.agents/AGENTS.md`, project `.goosehints` template. Requires goose v1.18.0+ for skills, v1.41.0+ for global hints. |
+| **AionUi** | Basic support | Skills symlinked into `<userData>/config/skills/` (rescanned on app restart). MCP servers and assistant rules are app-database-managed; add the spellbook MCP entry via AionUi settings (type: http). Config dir override: `AIONUI_CONFIG_DIR`. |
 
 Some MCP tools, hooks, and skills depend on Claude Code APIs that other platforms do not expose. These features are noted in their documentation. Contributions to extend coverage for other platforms are welcome -- see [Contributing](#contributing).
 

--- a/install.py
+++ b/install.py
@@ -1262,6 +1262,8 @@ def run_installation(spellbook_dir: Path, args: argparse.Namespace) -> int:
                     _post_notes.append("Pi: Restart to reload skills and prompts. Verify: /reload")
                 elif p == "goose":
                     _post_notes.append("Goose: Skills in ~/.agents/skills/. Restart goose to load the spellbook MCP server")
+                elif p == "aionui":
+                    _post_notes.append("AionUi: Skills symlinked into the app's config/skills directory; restart AionUi to rescan. MCP server and assistant rules are app-database-managed — add the spellbook MCP entry via AionUi settings (type: http, url: http://127.0.0.1:8765/mcp); attach rule modules to assistants in the UI if desired.")
             renderer.render_post_install(_post_notes)
         elif is_interactive():
             try:

--- a/installer/config.py
+++ b/installer/config.py
@@ -4,6 +4,7 @@ Configuration constants and platform settings for spellbook installer.
 
 import logging
 import os
+import sys
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -43,9 +44,26 @@ def get_spellbook_config_dir() -> Path:
 
 
 # Supported platforms (AI coding assistants that can consume spellbook)
-SUPPORTED_PLATFORMS = ['claude_code', 'antigravity', 'opencode', 'codex', 'gemini', 'forgecode', 'pi', 'prime_agent', 'goose']
+SUPPORTED_PLATFORMS = ['claude_code', 'antigravity', 'opencode', 'codex', 'gemini', 'forgecode', 'pi', 'prime_agent', 'goose', 'aionui']
 
 # Platform configuration
+
+def aionui_default_config_dir() -> Path:
+    """AionUi's Electron ``userData`` root, per OS (app need not exist).
+
+    Lives here rather than in the platform module so PLATFORM_CONFIG can
+    call it without an import cycle (platform modules import config, never
+    the reverse).
+    """
+    if sys.platform == "darwin":
+        return Path.home() / "Library" / "Application Support" / "AionUi"
+    if sys.platform == "win32":
+        appdata = os.environ.get("APPDATA")
+        base = Path(appdata) if appdata else Path.home() / "AppData" / "Roaming"
+        return base / "AionUi"
+    return Path.home() / ".config" / "AionUi"
+
+
 # NOTE: These are the AI assistant platforms that consume spellbook.
 # Spellbook's own config (SPELLBOOK_CONFIG_DIR) is separate from these.
 PLATFORM_CONFIG: Dict[str, Dict[str, Any]] = {
@@ -158,6 +176,19 @@ PLATFORM_CONFIG: Dict[str, Dict[str, Any]] = {
         # Honors $GOOSE_PATH_ROOT at runtime for non-default config dirs.
         "mcp_supported": True,
         "mcp_server_name": "spellbook",
+    },
+    "aionui": {
+        "name": "AionUi",
+        "config_dir_env": "AIONUI_CONFIG_DIR",
+        "default_config_dir": aionui_default_config_dir(),
+        "cli_flag_name": "aionui-config-dir",
+        # AionUi has no global instruction file; assistants carry their own
+        # rules via the app database (assistant_definitions), and MCP servers
+        # live in the mcp_servers db table -- both are app-database-managed
+        # surfaces the installer deliberately does not write.
+        "context_file": None,
+        "skills_subdir": "config/skills",
+        "mcp_supported": False,  # db-managed; reported as a manual step
     },
 }
 

--- a/installer/core.py
+++ b/installer/core.py
@@ -108,6 +108,7 @@ def get_platform_installer(
             (e.g., claude_config_dirs consumed by the Claude Code installer).
     """
     from .platforms.antigravity import AntigravityInstaller
+    from .platforms.aionui import AionUiInstaller
     from .platforms.claude_code import ClaudeCodeInstaller
     from .platforms.codex import CodexInstaller
     from .platforms.forgecode import ForgeCodeInstaller
@@ -129,6 +130,7 @@ def get_platform_installer(
         "pi": PiInstaller,
         "prime_agent": PrimeAgentInstaller,
         "goose": GooseInstaller,
+        "aionui": AionUiInstaller,
     }
 
     installer_class = installers.get(platform)

--- a/installer/platforms/aionui.py
+++ b/installer/platforms/aionui.py
@@ -1,0 +1,256 @@
+"""AionUi platform installer.
+
+AionUi (https://github.com/iOfficerCN/AionUi) is an Electron desktop app
+hosting multiple agent engines. Storage audit (2026-09-10, live app with
+aionrs backend):
+
+* ``<userData>/config/skills/<name>/SKILL.md`` is the user-skills directory
+  the app watches (observed as an existing empty dir). The ``skills`` table
+  in ``aionui-backend.db`` inventories skills with ``source='user'`` rows
+  and a ``path`` column; siblings ``config/cron-skills`` (source='cron') and
+  ``aionui/builtin-skills`` (source='builtin') confirm the per-source dir
+  convention.
+* ``<userData>/aionui/assistant-rules/users/<uid>/custom-*.md`` — assistant
+  rules are bound to assistants through db rows
+  (``assistant_definitions.rule_resource_ref``). Dropping files there
+  without a db binding orphans them, so rule delivery is NONE: no global
+  rule surface exists that an installer can write safely.
+* MCP servers live ONLY in the ``mcp_servers`` SQLite table
+  (``UNIQUE(user_id, name)``, UI-managed, with an ``original_json`` import
+  column). An installer must never write a live app-owned database, so MCP
+  registration is reported as a manual step, never automated.
+
+``~/.aionui`` is a macOS symlink to ``<userData>/aionui``; paths here use
+the canonical ``<userData>`` form.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING, List
+
+from ..components.symlinks import create_symlink, remove_symlink
+from .base import (
+    PlatformInstaller,
+    PlatformStatus,
+)
+
+if TYPE_CHECKING:
+    from ..core import InstallResult
+
+logger = logging.getLogger(__name__)
+
+
+class AionUiInstaller(PlatformInstaller):
+    """Installer for the AionUi desktop app.
+
+    Skill delivery mirrors the Antigravity installer: one symlink per skill
+    module into the app's watched skills directory. MCP and assistant rules
+    are app-database-managed surfaces and are deliberately NOT written;
+    install reports them as manual steps instead.
+    """
+
+    @property
+    def platform_name(self) -> str:
+        return "AionUi"
+
+    @property
+    def platform_id(self) -> str:
+        return "aionui"
+
+    def skills_dir(self) -> Path:
+        """AionUi's user-skills directory."""
+        return self.config_dir / "config" / "skills"
+
+    def get_context_files(self) -> List[Path]:
+        # AionUi has no global instruction file equivalent to CLAUDE.md /
+        # AGENTS.md that is read automatically; assistants carry their own
+        # rules through the app database.
+        return []
+
+    def get_symlinks(self) -> List[Path]:
+        skills_dir = self.skills_dir()
+        if not skills_dir.is_dir():
+            return []
+        return [
+            item for item in sorted(skills_dir.iterdir()) if item.is_symlink()
+        ]
+
+    def detect(self) -> PlatformStatus:
+        """Detect AionUi status.
+
+        Existence-based (like goose), no side effects: detect() must not
+        create the config dir as a byproduct of asking whether it exists.
+        """
+        available = self.config_dir.exists()
+        installed = False
+        installed_version = None
+
+        skills_dir = self.skills_dir()
+        if skills_dir.is_dir():
+            for link in skills_dir.glob("*"):
+                if not link.is_symlink():
+                    continue
+                try:
+                    resolved = link.resolve()
+                except OSError:
+                    continue
+                if str(resolved).startswith(str(self.spellbook_dir)):
+                    installed = True
+                    installed_version = self.version
+                    break
+
+        return PlatformStatus(
+            platform=self.platform_id,
+            available=available,
+            installed=installed,
+            version=installed_version,
+            details={"config_dir": str(self.config_dir)},
+        )
+
+    def _ensure_skill_symlinks(self) -> "tuple[int, int]":
+        """Create symlinks for spellbook skills in AionUi's skills dir.
+
+        Returns (created, errors). create_symlink is idempotent for existing
+        correct links; a real file/dir occupying a skill name is reported as
+        an error rather than clobbered.
+        """
+        source_skills = self.spellbook_dir / "skills"
+        if not source_skills.exists():
+            return (0, 0)
+
+        target_skills = self.skills_dir()
+        if not self.dry_run:
+            target_skills.mkdir(parents=True, exist_ok=True)
+
+        created = 0
+        errors = 0
+
+        for skill_dir in source_skills.iterdir():
+            if not skill_dir.is_dir():
+                continue
+            if not (skill_dir / "SKILL.md").exists():
+                continue
+
+            target_link = target_skills / skill_dir.name
+            if target_link.exists() and not target_link.is_symlink():
+                logger.warning(
+                    "aionui: %s exists and is not a spellbook symlink; "
+                    "left untouched",
+                    target_link,
+                )
+                errors += 1
+                continue
+            if create_symlink(
+                skill_dir, target_link, dry_run=self.dry_run
+            ).success:
+                created += 1
+            else:
+                errors += 1
+
+        return (created, errors)
+
+    def install(
+        self, force: bool = False, skip_global_steps: bool = False
+    ) -> List["InstallResult"]:
+        """Install spellbook components for AionUi."""
+        from ..core import InstallResult
+
+        results: List[InstallResult] = []
+
+        if not self.ensure_config_dir():
+            return [
+                InstallResult(
+                    component="config_dir",
+                    platform=self.platform_id,
+                    success=False,
+                    action="failed",
+                    message=(
+                        f"failed to create config directory {self.config_dir}"
+                    ),
+                )
+            ]
+
+        # Skill symlinks (the only automated surface in v1)
+        created, errors = self._ensure_skill_symlinks()
+        results.append(
+            InstallResult(
+                component="skills",
+                platform=self.platform_id,
+                success=errors == 0,
+                action="installed" if errors == 0 else "failed",
+                message=f"created {created} skill symlinks ({errors} errors)",
+            )
+        )
+
+        # MCP is db-managed by the app; never written from the installer.
+        results.append(
+            InstallResult(
+                component="mcp",
+                platform=self.platform_id,
+                success=True,
+                action="skipped",
+                message=(
+                    "AionUi manages MCP servers in its app database; add the "
+                    "spellbook server via AionUi settings (type: http, "
+                    "url: http://127.0.0.1:8765/mcp) rather than the "
+                    "installer writing the database"
+                ),
+            )
+        )
+
+        # Assistant rules are per-assistant db rows; no global surface.
+        results.append(
+            InstallResult(
+                component="rules",
+                platform=self.platform_id,
+                success=True,
+                action="skipped",
+                message=(
+                    "AionUi assistant rules are attached to assistants in "
+                    "the app UI; no global rules directory exists to write"
+                ),
+            )
+        )
+
+        return results
+
+    def uninstall(
+        self, skip_global_steps: bool = False
+    ) -> List["InstallResult"]:
+        """Uninstall spellbook components from AionUi."""
+        from ..core import InstallResult
+
+        results: List[InstallResult] = []
+
+        removed_links = 0
+        errors = 0
+        for link in self.get_symlinks():
+            try:
+                resolved = link.resolve()
+            except OSError:
+                resolved = None
+            if resolved is None or not str(resolved).startswith(
+                str(self.spellbook_dir)
+            ):
+                continue
+            if remove_symlink(link, dry_run=self.dry_run).success:
+                removed_links += 1
+            else:
+                errors += 1
+        results.append(
+            InstallResult(
+                component="skills",
+                platform=self.platform_id,
+                success=errors == 0,
+                action="removed" if removed_links else "skipped",
+                message=(
+                    f"removed {removed_links} skill symlinks ({errors} errors)"
+                    if removed_links
+                    else "no spellbook skill symlinks found"
+                ),
+            )
+        )
+
+        return results

--- a/installer/platforms/aionui.py
+++ b/installer/platforms/aionui.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING
 
 from ..components.symlinks import create_symlink, remove_symlink
 from .base import (
@@ -63,19 +63,33 @@ class AionUiInstaller(PlatformInstaller):
         """AionUi's user-skills directory."""
         return self.config_dir / "config" / "skills"
 
-    def get_context_files(self) -> List[Path]:
+    def get_context_files(self) -> list[Path]:
         # AionUi has no global instruction file equivalent to CLAUDE.md /
         # AGENTS.md that is read automatically; assistants carry their own
         # rules through the app database.
         return []
 
-    def get_symlinks(self) -> List[Path]:
+    def get_symlinks(self) -> list[Path]:
         skills_dir = self.skills_dir()
         if not skills_dir.is_dir():
             return []
         return [
             item for item in sorted(skills_dir.iterdir()) if item.is_symlink()
         ]
+
+    def _resolves_into_spellbook(self, link: Path) -> bool:
+        """True if ``link`` resolves inside the spellbook source tree.
+
+        Path containment (resolve + parents), NOT a string prefix: a sibling
+        checkout named ``spellbook-something`` shares the prefix but is not
+        spellbook, and uninstall must never remove a user's link to it.
+        """
+        try:
+            resolved = link.resolve()
+        except OSError:
+            return False
+        root = self.spellbook_dir.resolve()
+        return resolved == root or root in resolved.parents
 
     def detect(self) -> PlatformStatus:
         """Detect AionUi status.
@@ -92,11 +106,7 @@ class AionUiInstaller(PlatformInstaller):
             for link in skills_dir.glob("*"):
                 if not link.is_symlink():
                     continue
-                try:
-                    resolved = link.resolve()
-                except OSError:
-                    continue
-                if str(resolved).startswith(str(self.spellbook_dir)):
+                if self._resolves_into_spellbook(link):
                     installed = True
                     installed_version = self.version
                     break
@@ -109,7 +119,7 @@ class AionUiInstaller(PlatformInstaller):
             details={"config_dir": str(self.config_dir)},
         )
 
-    def _ensure_skill_symlinks(self) -> "tuple[int, int]":
+    def _ensure_skill_symlinks(self) -> tuple[int, int]:
         """Create symlinks for spellbook skills in AionUi's skills dir.
 
         Returns (created, errors). create_symlink is idempotent for existing
@@ -153,11 +163,11 @@ class AionUiInstaller(PlatformInstaller):
 
     def install(
         self, force: bool = False, skip_global_steps: bool = False
-    ) -> List["InstallResult"]:
+    ) -> list[InstallResult]:
         """Install spellbook components for AionUi."""
         from ..core import InstallResult
 
-        results: List[InstallResult] = []
+        results: list[InstallResult] = []
 
         if not self.ensure_config_dir():
             return [
@@ -218,22 +228,16 @@ class AionUiInstaller(PlatformInstaller):
 
     def uninstall(
         self, skip_global_steps: bool = False
-    ) -> List["InstallResult"]:
+    ) -> list[InstallResult]:
         """Uninstall spellbook components from AionUi."""
         from ..core import InstallResult
 
-        results: List[InstallResult] = []
+        results: list[InstallResult] = []
 
         removed_links = 0
         errors = 0
         for link in self.get_symlinks():
-            try:
-                resolved = link.resolve()
-            except OSError:
-                resolved = None
-            if resolved is None or not str(resolved).startswith(
-                str(self.spellbook_dir)
-            ):
+            if not self._resolves_into_spellbook(link):
                 continue
             if remove_symlink(link, dry_run=self.dry_run).success:
                 removed_links += 1

--- a/installer/tui.py
+++ b/installer/tui.py
@@ -382,6 +382,8 @@ def render_post_install_notes(
         lines.append("[cyan]Pi[/cyan]: Restart to reload skills and prompts. Verify: /reload")
     if "goose" in platforms:
         lines.append("[cyan]Goose[/cyan]: Restart to load the spellbook MCP server. Skills in ~/.agents/skills/")
+    if "aionui" in platforms:
+        lines.append("[cyan]AionUi[/cyan]: Restart to rescan skills (config/skills). Add the spellbook MCP entry via AionUi settings — MCP and assistant rules are app-database-managed")
 
     if lines:
         body = "\n".join(lines)

--- a/spellbook/cli/commands/install.py
+++ b/spellbook/cli/commands/install.py
@@ -329,6 +329,8 @@ def run(args: argparse.Namespace) -> None:
                     _post_notes.append("ForgeCode: Restart forge to load the spellbook MCP server")
                 elif p == "goose":
                     _post_notes.append("Goose: Skills in ~/.agents/skills/. Restart goose to load the spellbook MCP server")
+                elif p == "aionui":
+                    _post_notes.append("AionUi: Skills symlinked into the app's config/skills directory; restart AionUi to rescan. MCP server and assistant rules are app-database-managed — add the spellbook MCP entry via AionUi settings (type: http, url: http://127.0.0.1:8765/mcp); attach rule modules to assistants in the UI if desired.")
             renderer.render_post_install(_post_notes)
 
         print()

--- a/tests/integration/test_aionui_installer.py
+++ b/tests/integration/test_aionui_installer.py
@@ -1,0 +1,256 @@
+"""Integration tests for AionUi installer."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def spellbook_dir(tmp_path):
+    """Mock spellbook repo with required layout."""
+    spellbook = tmp_path / "spellbook"
+    spellbook.mkdir()
+
+    # Required files for installer
+    (spellbook / ".version").write_text("0.94.0")
+    rules_dir = spellbook / "rules"
+    rules_dir.mkdir()
+    (rules_dir / "00-core.md").write_text(
+        "---\nid: core\n---\n# Test core rule\n"
+    )
+
+    # Skills directory with 2 test skills
+    skills_dir = spellbook / "skills"
+    skills_dir.mkdir()
+    for name in ("test-skill-1", "test-skill-2"):
+        skill_dir = skills_dir / name
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text(
+            f"---\nname: {name}\ndescription: A test skill\n---\n# {name}\n"
+        )
+
+    return spellbook
+
+
+@pytest.fixture
+def aionui_env(tmp_path, monkeypatch):
+    """Isolated config dir so the real AionUi userData is never touched."""
+    config_dir = tmp_path / "AionUi"
+    monkeypatch.setenv("AIONUI_CONFIG_DIR", str(config_dir))
+    return config_dir
+
+
+def _installer(spellbook_dir: Path, aionui_env: Path, dry_run: bool = False):
+    from installer.platforms.aionui import AionUiInstaller
+
+    return AionUiInstaller(
+        spellbook_dir=spellbook_dir,
+        config_dir=aionui_env,
+        version="0.94.0",
+        dry_run=dry_run,
+    )
+
+
+# ---------------------------------------------------------------------
+# Detection
+# ---------------------------------------------------------------------
+
+
+def test_aionui_detect_when_config_dir_missing(spellbook_dir, aionui_env):
+    """detect() returns available=False and does NOT create the config dir."""
+    installer = _installer(spellbook_dir, aionui_env)
+
+    status = installer.detect()
+    assert status.available is False
+    assert status.installed is False
+    assert status.platform == "aionui"
+    # Detect must not have side effects.
+    assert not aionui_env.exists()
+
+
+def test_aionui_detect_when_config_dir_exists(spellbook_dir, aionui_env):
+    """detect() returns available=True when the userData root exists."""
+    aionui_env.mkdir(parents=True, exist_ok=True)
+    status = _installer(spellbook_dir, aionui_env).detect()
+    assert status.available is True
+    assert status.installed is False
+
+
+# ---------------------------------------------------------------------
+# Install
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.posix_only
+def test_aionui_install_creates_skill_symlinks(spellbook_dir, aionui_env):
+    """Skills are symlinked into <userData>/config/skills/.
+
+    POSIX-only: creating a symlink on Windows needs SeCreateSymbolicLink
+    (Administrator, or Developer Mode) — same constraint as goose.
+    """
+    aionui_env.mkdir(parents=True, exist_ok=True)
+
+    results = _installer(spellbook_dir, aionui_env).install()
+
+    skills_dir = aionui_env / "config" / "skills"
+    assert skills_dir.is_dir()
+    for name in ("test-skill-1", "test-skill-2"):
+        link = skills_dir / name
+        assert link.is_symlink()
+        assert link.resolve() == (spellbook_dir / "skills" / name).resolve()
+
+    skills_results = [r for r in results if r.component == "skills"]
+    assert len(skills_results) == 1
+    assert skills_results[0].success
+
+
+def test_aionui_install_never_touches_app_database(spellbook_dir, aionui_env):
+    """MCP is app-database-managed: the installer must not write any db.
+
+    It reports the manual step instead (action=skipped, success=True).
+    """
+    aionui_env.mkdir(parents=True, exist_ok=True)
+    # A stray sqlite file where the app db would live must stay untouched.
+    db = aionui_env / "aionui" / "aionui-backend.db"
+    db.parent.mkdir(parents=True, exist_ok=True)
+    db.write_bytes(b"not a real db")
+
+    results = _installer(spellbook_dir, aionui_env).install()
+
+    assert db.read_bytes() == b"not a real db", "installer touched the app db"
+    mcp = [r for r in results if r.component == "mcp"]
+    assert len(mcp) == 1
+    assert mcp[0].action == "skipped"
+    assert mcp[0].success
+
+
+def test_aionui_install_reports_rules_as_manual(spellbook_dir, aionui_env):
+    """Rules are per-assistant db rows; no rules files are written."""
+    aionui_env.mkdir(parents=True, exist_ok=True)
+    results = _installer(spellbook_dir, aionui_env).install()
+
+    rules = [r for r in results if r.component == "rules"]
+    assert len(rules) == 1
+    assert rules[0].action == "skipped"
+    assert rules[0].success
+    # No rules directory materialized anywhere in the config dir.
+    assert not (aionui_env / "assistant-rules").exists()
+
+
+@pytest.mark.posix_only
+def test_aionui_install_preserves_user_skills(spellbook_dir, aionui_env):
+    """A real skill dir occupying a name is never clobbered."""
+    aionui_env.mkdir(parents=True, exist_ok=True)
+    skills_dir = aionui_env / "config" / "skills"
+    user_skill = skills_dir / "test-skill-1"
+    user_skill.mkdir(parents=True)
+    (user_skill / "SKILL.md").write_text("# User's own skill\n")
+
+    results = _installer(spellbook_dir, aionui_env).install()
+
+    # User skill intact, not replaced by a symlink.
+    assert user_skill.is_dir() and not user_skill.is_symlink()
+    assert (user_skill / "SKILL.md").read_text() == "# User's own skill\n"
+    # The other skill still linked.
+    assert (skills_dir / "test-skill-2").is_symlink()
+
+
+@pytest.mark.posix_only
+def test_aionui_install_is_idempotent(spellbook_dir, aionui_env):
+    """Re-running install leaves correct symlinks in place, still valid."""
+    aionui_env.mkdir(parents=True, exist_ok=True)
+    installer = _installer(spellbook_dir, aionui_env)
+
+    installer.install()
+    first = installer.detect()
+    installer.install()
+    second = installer.detect()
+
+    assert first.installed and second.installed
+    skills_dir = aionui_env / "config" / "skills"
+    for name in ("test-skill-1", "test-skill-2"):
+        link = skills_dir / name
+        assert link.is_symlink()
+        assert link.resolve() == (spellbook_dir / "skills" / name).resolve()
+    assert len(list(skills_dir.iterdir())) == 2, "no duplicates"
+
+
+def test_aionui_install_dry_run_does_not_modify_filesystem(
+    spellbook_dir, aionui_env
+):
+    """dry_run=True reports steps but creates nothing."""
+    aionui_env.mkdir(parents=True, exist_ok=True)
+    _installer(spellbook_dir, aionui_env, dry_run=True).install()
+
+    assert not (aionui_env / "config" / "skills").exists()
+
+
+# ---------------------------------------------------------------------
+# Uninstall
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.posix_only
+def test_aionui_uninstall_removes_spellbook_links_only(
+    spellbook_dir, aionui_env
+):
+    """Uninstall removes spellbook symlinks; user skills stay."""
+    aionui_env.mkdir(parents=True, exist_ok=True)
+    skills_dir = aionui_env / "config" / "skills"
+    user_skill = skills_dir / "user-skill"
+    user_skill.mkdir(parents=True)
+    (user_skill / "SKILL.md").write_text("# User Skill\n")
+
+    installer = _installer(spellbook_dir, aionui_env)
+    installer.install()
+    installer.uninstall()
+
+    for name in ("test-skill-1", "test-skill-2"):
+        assert not (skills_dir / name).exists()
+    assert user_skill.is_dir()
+    assert (user_skill / "SKILL.md").exists()
+
+
+# ---------------------------------------------------------------------
+# Config dir resolution + registration
+# ---------------------------------------------------------------------
+
+
+def test_aionui_config_dir_env_override(tmp_path, monkeypatch):
+    """AIONUI_CONFIG_DIR overrides the OS default for get_platform_config_dir."""
+    from installer.config import get_platform_config_dir
+
+    override = tmp_path / "custom" / "AionUi"
+    monkeypatch.setenv("AIONUI_CONFIG_DIR", str(override))
+    assert get_platform_config_dir("aionui") == override
+    monkeypatch.delenv("AIONUI_CONFIG_DIR")
+    # Default falls back to the OS-aware userData root, never the real
+    # override — just assert it is an absolute path under the user home.
+    default = get_platform_config_dir("aionui")
+    assert default.is_absolute()
+
+
+def test_aionui_registered_in_installer_dispatch():
+    """AionUiInstaller is registered in installer/core.py dispatch dict."""
+    from installer.core import get_platform_installer
+    from installer.platforms.aionui import AionUiInstaller
+
+    installer = get_platform_installer(
+        "aionui",
+        spellbook_dir=Path("/tmp/nonexistent"),
+        version="0.94.0",
+        dry_run=True,
+    )
+    assert isinstance(installer, AionUiInstaller)
+
+
+def test_aionui_in_supported_platforms_and_config():
+    """AionUi is registered in the platform registry (config.py)."""
+    from installer.config import PLATFORM_CONFIG, SUPPORTED_PLATFORMS
+
+    assert "aionui" in SUPPORTED_PLATFORMS
+    entry = PLATFORM_CONFIG["aionui"]
+    assert entry["name"] == "AionUi"
+    assert entry["config_dir_env"] == "AIONUI_CONFIG_DIR"
+    assert entry["mcp_supported"] is False

--- a/tests/integration/test_aionui_installer.py
+++ b/tests/integration/test_aionui_installer.py
@@ -1,6 +1,5 @@
 """Integration tests for AionUi installer."""
 
-import sys
 from pathlib import Path
 
 import pytest
@@ -147,9 +146,8 @@ def test_aionui_install_preserves_user_skills(spellbook_dir, aionui_env):
     user_skill.mkdir(parents=True)
     (user_skill / "SKILL.md").write_text("# User's own skill\n")
 
-    results = _installer(spellbook_dir, aionui_env).install()
-
     # User skill intact, not replaced by a symlink.
+    _installer(spellbook_dir, aionui_env).install()
     assert user_skill.is_dir() and not user_skill.is_symlink()
     assert (user_skill / "SKILL.md").read_text() == "# User's own skill\n"
     # The other skill still linked.
@@ -210,6 +208,54 @@ def test_aionui_uninstall_removes_spellbook_links_only(
         assert not (skills_dir / name).exists()
     assert user_skill.is_dir()
     assert (user_skill / "SKILL.md").exists()
+
+
+# ---------------------------------------------------------------------
+# Sibling-directory prefix safety (startswith regression)
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.posix_only
+def test_aionui_detect_ignores_sibling_prefix_link(
+    spellbook_dir, aionui_env, tmp_path
+):
+    """A symlink into ``spellbook-<suffix>`` (sibling dir) is NOT spellbook.
+
+    The old check used a string prefix test: ``.../spellbook-something``
+    startswith ``.../spellbook``, so detect() falsely reported installed.
+    """
+    aionui_env.mkdir(parents=True, exist_ok=True)
+    sibling = tmp_path / "spellbook-sibling"
+    skill = sibling / "skills" / "fake-skill"
+    skill.mkdir(parents=True)
+    (skill / "SKILL.md").write_text("# Fake\n")
+
+    skills_dir = aionui_env / "config" / "skills"
+    skills_dir.mkdir(parents=True)
+    (skills_dir / "fake-skill").symlink_to(skill)
+
+    status = _installer(spellbook_dir, aionui_env).detect()
+    assert status.installed is False
+
+
+@pytest.mark.posix_only
+def test_aionui_uninstall_keeps_sibling_prefix_link(
+    spellbook_dir, aionui_env, tmp_path
+):
+    """Uninstall must never remove a user's link into a sibling repo."""
+    aionui_env.mkdir(parents=True, exist_ok=True)
+    sibling = tmp_path / "spellbook-sibling"
+    skill = sibling / "skills" / "fake-skill"
+    skill.mkdir(parents=True)
+    (skill / "SKILL.md").write_text("# Fake\n")
+
+    skills_dir = aionui_env / "config" / "skills"
+    skills_dir.mkdir(parents=True)
+    (skills_dir / "fake-skill").symlink_to(skill)
+
+    _installer(spellbook_dir, aionui_env).uninstall()
+    assert (skills_dir / "fake-skill").is_symlink()
+    assert (skills_dir / "fake-skill").resolve() == skill.resolve()
 
 
 # ---------------------------------------------------------------------


### PR DESCRIPTION
## Summary

AionUi (Electron desktop app hosting multiple agent engines) joins spellbook's supported platforms as install target #10.

Skills are symlinked one module per link into `<userData>/config/skills/` — the directory the app watches for user skills, verified against a live install: the `skills` table inventories `source='user'` rows with paths, and the sibling dirs (`config/cron-skills`, `aionui/builtin-skills`) confirm the per-source directory convention.

## Deliberately NOT automated (and why)

Two AionUi surfaces live inside the app's SQLite database. An installer must never write a live app-owned store — the same read-only principle `session-pull` applies to other agents' databases:

| Surface | Where it lives | What the installer does |
|---|---|---|
| MCP servers | `mcp_servers` table (`UNIQUE(user_id,name)`, UI-managed, has `original_json` import column) | Reports manual step: add spellbook entry via AionUi settings (type: http) |
| Assistant rules | `assistant_definitions` rows bound to per-user `custom-*.md` files | Skips — no global rules surface exists; files written without db bindings orphan |

## Details

- Config dir resolves per OS (macOS `~/Library/Application Support/AionUi`, Linux `~/.config/AionUi`, Windows `%APPDATA%/AionUi`), `AIONUI_CONFIG_DIR` override
- Detection is existence-based with **no side effects** (won't create the dir as a byproduct of checking)
- User skills colliding with a spellbook name are preserved, never clobbered
- Idempotent: re-runs leave correct symlinks untouched, no duplicates
- `--dry-run` creates nothing
- Wired into: `SUPPORTED_PLATFORMS`/`PLATFORM_CONFIG`, core installer factory, post-install notes in **both** entry points (root `install.py` + `spellbook/cli/commands/install.py`), TUI post-install summary

## Test plan

- [x] 12 integration tests: detection (no side effects), install/idempotency/dry-run, user-skill preservation, uninstall (removes spellbook links only), db-untouched proof, env override, registry wiring
- [x] Full suite green (2103 passed)
- [x] `install.py --dry-run` lists AionUi as platform 10/10
- [x] Live smoke: 62 skill symlinks created in a scratch config dir; mcp/rules reported as manual steps; detect confirms installed
- [x] CHANGELOG, README platform table, AGENTS.md platform table updated