### PR TITLE
fix(installer): path containment instead of string-prefix match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   deletion, which reads as a broken tree and sends the reader to debug the wrong
   thing.
 
+### Fixed
+
+- Installer path containment: uninstall symlink checks matched targets by
+  string prefix, so a sibling checkout named e.g. `spellbook-something`
+  shared the prefix and `antigravity.py` uninstall would delete a user's
+  skill symlink pointing into that sibling. Matching is now resolved-path
+  containment (`resolve()` + parents) in `installer/platforms/antigravity.py`;
+  the same class of false positive in the source-tree check in `install.py`
+  (skip-update-check) is fixed the same way.
+
 ## [0.94.0] - 2026-09-09
 
 ### Added

--- a/install.py
+++ b/install.py
@@ -657,7 +657,16 @@ def bootstrap(args: argparse.Namespace) -> Path:
 
         # If running install.py from the source repo itself, skip the update check
         script_path = get_script_path()
-        if script_path is not None and str(script_path).startswith(str(spellbook_dir.resolve())):
+        # Path containment, not a string prefix: a sibling checkout named
+        # spellbook-something shares the prefix but is a different tree.
+        try:
+            from_source = (
+                script_path is not None
+                and script_path.resolve().is_relative_to(spellbook_dir.resolve())
+            )
+        except OSError:
+            from_source = False
+        if from_source:
             print_info("Running from source repository, skipping update check.")
         elif (spellbook_dir / ".git").is_dir():
             if not _quiet:

--- a/installer/platforms/antigravity.py
+++ b/installer/platforms/antigravity.py
@@ -385,16 +385,23 @@ class AntigravityInstaller(PlatformInstaller):
 
         # Clean up skill symlinks (both active global root and legacy harness location)
         removed_links = 0
+        spellbook_root = self.spellbook_dir.resolve()
         for target_skills in [self.skills_dir(), self.config_dir / "skills"]:
             if target_skills.exists():
                 for item in target_skills.iterdir():
                     if item.is_symlink():
                         try:
                             resolved = item.resolve()
-                            if (
-                                str(resolved).startswith(str(self.spellbook_dir))
-                                and remove_symlink(item, dry_run=self.dry_run).success
-                            ):
+                            # Containment, not string prefix: a sibling
+                            # checkout named spellbook-something shares the
+                            # prefix but must keep its user symlinks.
+                            inside = (
+                                resolved == spellbook_root
+                                or spellbook_root in resolved.parents
+                            )
+                            if inside and remove_symlink(
+                                item, dry_run=self.dry_run
+                            ).success:
                                 removed_links += 1
                         except OSError:
                             pass

--- a/tests/integration/test_antigravity_installer.py
+++ b/tests/integration/test_antigravity_installer.py
@@ -107,3 +107,37 @@ def test_antigravity_full_install_and_uninstall(tmp_path):
     assert not os.path.lexists(skill_link)
     assert not os.path.lexists(legacy_link)
     assert installer.detect().installed is False
+
+
+def test_antigravity_uninstall_keeps_sibling_prefix_links(tmp_path):
+    """A symlink into a sibling 'spellbook-something' dir is NOT spellbook.
+
+    Uninstall used a string-prefix match: '.../spellbook-something'
+    startswith '.../spellbook', so it would delete a user's symlink into a
+    sibling checkout. Regression: match by resolved-path containment.
+    """
+    spellbook_dir = tmp_path / "spellbook"
+    spellbook_dir.mkdir()
+
+    config_dir = tmp_path / "antigravity"
+    installer = AntigravityInstaller(
+        spellbook_dir=spellbook_dir,
+        config_dir=config_dir,
+        version="0.1.0",
+        dry_run=False,
+    )
+
+    sibling = tmp_path / "spellbook-sibling"
+    sibling_skill = sibling / "skills" / "user-skill"
+    sibling_skill.mkdir(parents=True)
+    (sibling_skill / "SKILL.md").write_text("# User skill\n")
+
+    skills_root = config_dir.parent / "config" / "skills"
+    skills_root.mkdir(parents=True)
+    link = skills_root / "user-skill"
+    link.symlink_to(sibling_skill)
+
+    installer.uninstall()
+
+    assert link.is_symlink()
+    assert link.resolve() == sibling_skill.resolve()


### PR DESCRIPTION
## What

Two sites on main matched filesystem paths by string prefix, which false-positives on sibling directories sharing the prefix (`/x/spellbook-something` startswith `/x/spellbook`):

| Site | Effect of false positive |
|------|--------------------------|
| `installer/platforms/antigravity.py:395` (uninstall) | **destructive** — uninstall() removes any symlink whose target path string starts with the spellbook source path, including a user's link into a sibling checkout |
| `install.py:660` (source-tree check) | benign — skip-update-check triggers when running from a sibling dir |

## Fix

Both now match by resolved-path containment: `(resolved == root) or (root in resolved.parents)`, consistent with the fix already landed on the aionui installer branch (#508).

## Test plan

- New regression test `test_antigravity_uninstall_keeps_sibling_prefix_links` (fails on the old code, passes now)
- Full fast suite green (2091 passed)
- CHANGELOG `### Fixed` entry under Unreleased